### PR TITLE
feat: set nextauth debug mode based on env var

### DIFF
--- a/frontend/pages/api/auth/[...nextauth].ts
+++ b/frontend/pages/api/auth/[...nextauth].ts
@@ -105,7 +105,7 @@ export const authOptions: NextAuthOptionsCallback = (_req, res) => {
       newUser: '/onboard',
       signIn: '/login',
     },
-    debug: false,
+    debug: process.env.DEBUG ? process.env.DEBUG === 'True' : false,
   }
 }
 


### PR DESCRIPTION
# Description 📣

Curently the debug mode in next-auth config is hardcoded as `false`. This change updates the next-auth config to parse the `DEBUG` env var and set the debug mode accordingly.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
