### PR TITLE
fix: move user menu to top right of login screen

### DIFF
--- a/frontend/app/[team]/newdevice/page.tsx
+++ b/frontend/app/[team]/newdevice/page.tsx
@@ -110,6 +110,9 @@ export default function NewDevice({ params }: { params: { team: string } }) {
   return (
     <>
       <div className="flex flex-col justify-between w-full h-screen">
+        <div className="w-full flex justify-end p-4">
+          <UserMenu />
+        </div>
         <div className="flex flex-col mx-auto my-auto w-full max-w-3xl gap-y-8">
           <div className="mx-auto max-w-xl">
             <h1 className="text-4xl text-black dark:text-white text-center font-bold">
@@ -152,9 +155,6 @@ export default function NewDevice({ params }: { params: { team: string } }) {
               </div>
             </div>
           </form>
-        </div>
-        <div className="w-full p-4">
-          <UserMenu />
         </div>
       </div>
     </>


### PR DESCRIPTION
## Description 📣

Moves the User menu on the login screen to the top right. Resolves #36 

## Preview

![image](https://github.com/phasehq/console/assets/6710327/58f69072-af27-4609-9090-fa8c73c2b301)

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation


