### PR TITLE
fix: handle vertical overflow in team layout

### DIFF
--- a/frontend/app/[team]/layout.tsx
+++ b/frontend/app/[team]/layout.tsx
@@ -53,7 +53,7 @@ export default function RootLayout({
       <HeroPattern />
       {showNav && <NavBar team={params.team} />}
       {showNav && <Sidebar />}
-      <div className={clsx(showNav && 'pt-16')}>{children}</div>
+      <div className={clsx('min-h-screen overflow-auto', showNav && 'pt-16')}>{children}</div>
     </div>
   )
 }


### PR DESCRIPTION
# Description 📣

Fix to correctly handle vertical overflow in the team root layout. Resolves issue #71 

[Screencast from 10-12-2023 10:40:54 AM.webm](https://github.com/phasehq/console/assets/6710327/816bf76c-1303-4885-8fe7-3bd054728eb9)


## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation


