### PR TITLE
fix: add mising example secret

### DIFF
--- a/frontend/components/apps/NewAppDialog.tsx
+++ b/frontend/components/apps/NewAppDialog.tsx
@@ -206,6 +206,11 @@ export default function NewAppDialog(props: {
         comment: 'This is an example secret.',
       },
       {
+        key: 'DB_USER',
+        value: 'postgres',
+        comment: 'This is an example secret.',
+      },
+      {
         key: 'DB_HOST',
         value: 'mc-laren-prod-db.c9ufzjtplsaq.us-west-1.rds.amazonaws.com',
         comment: 'This is an example secret.',


### PR DESCRIPTION
# Description 📣

Adds the missing `DB_USER` secret to the example secrets. Fixes #73 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

