### PR TITLE
feat: specified postgresql version in the docker-compose configs

### DIFF
--- a/dev-docker-compose.yml
+++ b/dev-docker-compose.yml
@@ -49,7 +49,7 @@ services:
 
   postgres:
     container_name: phase-postgres
-    image: postgres
+    image: postgres:15.4-alpine3.17
     restart: always
     env_file:
       - .env.dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
 
   postgres:
     container_name: phase-postgres
-    image: postgres
+    image: postgres:15.4-alpine3.17
     restart: always
     env_file:
       - .env

--- a/staging-docker-compose.yml
+++ b/staging-docker-compose.yml
@@ -54,7 +54,7 @@ services:
 
   postgres:
     container_name: phase-postgres
-    image: postgres
+    image: postgres:15.4-alpine3.17
     restart: always
     env_file:
       - .env


### PR DESCRIPTION
# Description 📣

Use postgresql version 15.4 on alpine 3.17, instead of using postgresql:latest. Specifying a database version is always best practice and should avoid issues in development, staging and self hosted production instances.


## Type ✨

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. You may want to add screenshots when relevant and possible -->

```sh
# Here's some code block to paste some code snippets
```
