### PR TITLE
fix: ensure keyring is unlocked when creating example secrets

### DIFF
--- a/frontend/components/apps/NewAppDialog.tsx
+++ b/frontend/components/apps/NewAppDialog.tsx
@@ -128,9 +128,11 @@ export default function NewAppDialog(props: {
   ) {
     const { data: appEnvsData } = await getAppEnvs({ variables: { appId } })
 
+    const keyring = await validateKeyring(pw)
+
     const userKxKeys = {
-      publicKey: await getUserKxPublicKey(keyring!.publicKey),
-      privateKey: await getUserKxPrivateKey(keyring!.privateKey),
+      publicKey: await getUserKxPublicKey(keyring.publicKey),
+      privateKey: await getUserKxPrivateKey(keyring.privateKey),
     }
 
     const env = appEnvsData.appEnvironments.find((env: EnvironmentType) => env.envType === envType)


### PR DESCRIPTION
# Description 📣

Fixes an issue when creating a new app with example secrets, and the user keyring isn't unlocked.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation


