### PR TITLE
fix: only fetch create and update events in secret history query

### DIFF
--- a/backend/backend/graphene/types.py
+++ b/backend/backend/graphene/types.py
@@ -176,7 +176,7 @@ class SecretType(DjangoObjectType):
         # interfaces = (relay.Node, )
 
     def resolve_history(self, info):
-        return SecretEvent.objects.filter(secret_id=self.id).order_by('timestamp')
+        return SecretEvent.objects.filter(secret_id=self.id, event_type__in=[SecretEvent.CREATE, SecretEvent.UPDATE]).order_by('timestamp')
 
 
 class KMSLogType(ObjectType):

--- a/frontend/components/environments/SecretRow.tsx
+++ b/frontend/components/environments/SecretRow.tsx
@@ -261,9 +261,7 @@ const HistoryDialog = (props: { secret: SecretType }) => {
     if (eventType === ApiSecretEventEventTypeChoices.D) return 'Deleted'
   }
 
-  const secretHistory = secret.history?.filter(
-    (event: Maybe<SecretEventType>) => event?.eventType! !== ApiSecretEventEventTypeChoices.R
-  )
+  const secretHistory = secret.history
 
   return (
     <>


### PR DESCRIPTION
## Description 📣
Updates the secret history resolver to only fetch 'Create' and 'Update' events, and removed the client side filter based on event type. This should speed up client-side performance for secrets with a large number of read events.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

