### PR TITLE
feat: bump session cookie ttl to 1 week

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -53,7 +53,7 @@ SESSION_COOKIE_SECURE = True
 
 SESSION_COOKIE_DOMAIN = os.getenv('SESSION_COOKIE_DOMAIN')
 
-SESSION_COOKIE_AGE = 86400  # 24 hours
+SESSION_COOKIE_AGE = 604800  # 1 week, in seconds
 
 # Application definition
 


### PR DESCRIPTION
# Description 📣

Bumps the session cookie TTL to 1 week.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
