### PR TITLE
feat: display token environments in SecretTokens

### DIFF
--- a/frontend/components/apps/tokens/SecretTokens.tsx
+++ b/frontend/components/apps/tokens/SecretTokens.tsx
@@ -566,6 +566,18 @@ export const SecretTokens = (props: { organisationId: string; appId: string }) =
 
     const allowDelete = activeUserIsAdmin || token.createdBy!.self
 
+    const identityKeys = token.keys.map((key) => key.identityKey)
+
+    const { data } = useQuery(GetAppEnvironments, {
+      variables: {
+        appId,
+      },
+    })
+
+    const tokenEnvironments = data.appEnvironments.filter((env: EnvironmentType) =>
+      identityKeys.includes(env.identityKey)
+    )
+
     return (
       <div className="flex items-center w-full justify-between p-2 group">
         <div className="flex items-center gap-4">
@@ -590,6 +602,10 @@ export const SecretTokens = (props: { organisationId: string; appId: string }) =
                 {isExpired ? 'Expired' : 'Expires'}{' '}
                 {token.expiresAt ? relativeTimeFromDates(new Date(token.expiresAt)) : 'never'}
               </div>
+
+              {tokenEnvironments.map(({ idx, name }: { idx: number; name: string }) => (
+                <div key={idx}>{name}</div>
+              ))}
             </div>
           </div>
         </div>

--- a/frontend/graphql/queries/secrets/getServiceTokens.gql
+++ b/frontend/graphql/queries/secrets/getServiceTokens.gql
@@ -11,7 +11,7 @@ query GetServiceTokens($appId: ID!) {
     expiresAt
     keys {
       id
-      
+      identityKey
     }
   }
 }


### PR DESCRIPTION
# Description 📣

feat: add token environments to SecretTokens component

This commit enhances the SecretTokens component to fetch and display the associated environments for each token. It introduces the use of the `useQuery` hook to retrieve the app environments based on the token's identity keys.

BREAKING CHANGE: The GraphQL schema for `Key` in the `GetServiceTokens` query now includes the `identityKey` field. Existing implementations relying on this query may need to update their handling of the `Key` type.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

Instructions for testing:
1. Run the following Docker Compose command to set up the development environment.
`docker compose -f dev-docker-compose.yml --env-file .env.dev up
`
2. Sign in.
3. Navigate to 'Apps' -> 'Service Tokens'.
4. Click '+Create Service Token'.
5. Fill in the required information.
6. Click 'Create'.

Note: Ensure all dependencies and configurations are set up.
