### PR TITLE
fix: overlapping password icons | Edge Browser

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -40,7 +40,7 @@
   --card-rgb: 180, 185, 188;
   --card-border-rgb: 131, 134, 135;
 
-  --toastify-color-success: rgb(16 185 129)!important;
+  --toastify-color-success: rgb(16 185 129) !important;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -89,6 +89,11 @@ body {
   max-width: 100vw;
   overflow-x: hidden;
 }
+
+::-ms-reveal {
+  display: none;
+}
+
 /*
 body {
   color: rgb(var(--foreground-rgb));
@@ -113,7 +118,7 @@ a {
 
 @layer components {
   input {
-    @apply p-2 focus:outline-none
+    @apply p-2 focus:outline-none;
   }
 
   input:not(.custom) {


### PR DESCRIPTION
# Description 📣

This pull request addresses and resolves the issue of overlapping password icons (#102) specifically observed in the Edge browser. The issue was causing icons appearing on top of each other, leading to a poor user experience.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

- [x] Checked all possible password inputs icons.
- [x]  Ensured that the password reveal control is appropriately hidden/revealed
- [x] Checked password inputs with special attention to the Edge
- [ ] Checked password inputs for other browsers
