### PR TITLE
fix: Search UI for light theme

### DIFF
--- a/frontend/app/[team]/apps/[app]/page.tsx
+++ b/frontend/app/[team]/apps/[app]/page.tsx
@@ -399,7 +399,7 @@ export default function Secrets({ params }: { params: { team: string; app: strin
             </div>
 
             <div className="flex items-center w-full justify-between border-b border-zinc-300 dark:border-zinc-700 pb-4">
-              <div className="relative flex items-center bg-white dark:bg-zinc-800 rounded-md px-2">
+              <div className="relative flex items-center bg-zinc-100 dark:bg-zinc-800 rounded-md px-2">
                 <div className="">
                   <FaSearch className="text-neutral-500" />
                 </div>


### PR DESCRIPTION
# Description 📣

Fixes the search UI for the light theme (#74)

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

# Tests 🛠️

- [x] Checked UI on light theme
- [x] Checked UI on dark theme


# Image 📸
- for light theme
<img width="191" alt="image" src="https://github.com/phasehq/console/assets/63700757/5366edb7-3feb-4eaf-9c63-719acacb24f8">

- for dark theme
<img width="198" alt="Screenshot 2023-11-16 165243" src="https://github.com/phasehq/console/assets/63700757/9d6456a5-c578-4b81-98e1-2ae39afbfbaf">
