### PR TITLE
feat: allow restoring secret values from history

### DIFF
--- a/frontend/components/environments/SecretPropertyDiffs.tsx
+++ b/frontend/components/environments/SecretPropertyDiffs.tsx
@@ -1,13 +1,16 @@
 import { SecretEventType, SecretTagType, SecretType } from '@/apollo/graphql'
 import { areTagsAreSame } from '@/utils/tags'
 import { Tag } from './SecretRow'
+import { FaUndoAlt } from 'react-icons/fa'
+import { Button } from '../common/Button'
 
 export const SecretPropertyDiffs = (props: {
   secret: SecretType
   historyItem: SecretEventType
   index: number
+  handlePropertyChange: Function
 }) => {
-  const { secret, historyItem, index } = props
+  const { secret, historyItem, index, handlePropertyChange } = props
 
   const previousItem = secret.history![index - 1]!
 
@@ -25,6 +28,11 @@ export const SecretPropertyDiffs = (props: {
     return removedTags
   }
 
+  const handleRestoreValue = (value: string) => {
+    console.log('restore', value)
+    handlePropertyChange(secret.id, 'value', value)
+  }
+
   return (
     <>
       {historyItem!.key !== previousItem.key && (
@@ -40,14 +48,25 @@ export const SecretPropertyDiffs = (props: {
       )}
 
       {historyItem!.value !== previousItem.value && (
-        <div className="pl-3 font-mono">
-          <span className="text-neutral-500 mr-2">VALUE:</span>
-          <s className="bg-red-200 dark:bg-red-950 text-red-500 ph-no-capture">
-            {previousItem.value}
-          </s>
-          <span className="bg-emerald-100 dark:bg-emerald-950 text-emerald-500 ph-no-capture">
-            {historyItem!.value}
-          </span>
+        <div className="pl-3 font-mono space-y-1">
+          <div className="flex items-center gap-2">
+            <span className="text-neutral-500 mr-2">VALUE:</span>
+          </div>
+          <div className="flex flex-col">
+            <div className="flex items-center justify-between bg-red-200 dark:bg-red-950">
+              <s className=" text-red-500 ph-no-capture">{previousItem.value}</s>
+              <Button
+                variant="secondary"
+                onClick={() => handleRestoreValue(previousItem.value)}
+                title="Restore this value"
+              >
+                <FaUndoAlt />
+              </Button>
+            </div>
+            <span className="bg-emerald-100 dark:bg-emerald-950 text-emerald-500 ph-no-capture">
+              {historyItem!.value}
+            </span>
+          </div>
         </div>
       )}
 

--- a/frontend/components/environments/SecretRow.tsx
+++ b/frontend/components/environments/SecretRow.tsx
@@ -1,10 +1,4 @@
-import {
-  ApiSecretEventEventTypeChoices,
-  Maybe,
-  SecretEventType,
-  SecretTagType,
-  SecretType,
-} from '@/apollo/graphql'
+import { ApiSecretEventEventTypeChoices, SecretTagType, SecretType } from '@/apollo/graphql'
 import { Fragment, useEffect, useState } from 'react'
 import {
   FaEyeSlash,
@@ -14,15 +8,13 @@ import {
   FaTrashAlt,
   FaHistory,
   FaPlus,
-  FaUser,
   FaTags,
   FaCheckSquare,
   FaSquare,
   FaKey,
-  FaInfo,
 } from 'react-icons/fa'
 import { Button } from '../common/Button'
-import { Dialog, Popover, Transition } from '@headlessui/react'
+import { Dialog, Transition } from '@headlessui/react'
 import { GetSecretTags } from '@/graphql/queries/secrets/getSecretTags.gql'
 import { CreateNewSecretTag } from '@/graphql/mutations/environments/createSecretTag.gql'
 import { LogSecretRead } from '@/graphql/mutations/environments/readSecret.gql'
@@ -234,8 +226,8 @@ const TagsDialog = (props: {
   )
 }
 
-const HistoryDialog = (props: { secret: SecretType }) => {
-  const { secret } = props
+const HistoryDialog = (props: { secret: SecretType; handlePropertyChange: Function }) => {
+  const { secret, handlePropertyChange } = props
 
   const [isOpen, setIsOpen] = useState<boolean>(false)
 
@@ -347,6 +339,7 @@ const HistoryDialog = (props: { secret: SecretType }) => {
                                 secret={secret}
                                 historyItem={historyItem!}
                                 index={index}
+                                handlePropertyChange={handlePropertyChange}
                               />
                             )}
                           </div>
@@ -646,7 +639,7 @@ export default function SecretRow(props: {
           </div>
 
           <div className="opacity-0 group-hover:opacity-100 transition-opacity ease">
-            <HistoryDialog secret={secret} />
+            <HistoryDialog secret={secret} handlePropertyChange={handlePropertyChange} />
           </div>
 
           <div


### PR DESCRIPTION
# Description 📣

Adds a button to secret history events that allow restoring a previous value

![image](https://github.com/phasehq/console/assets/6710327/56e4772f-9d58-4fdd-bf31-248caf8995c3)

The value is only updated locally, and changes must still be deployed to take effect.

## Type ✨

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
