### PR TITLE
chore: bump posthog sdk version

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
     "next": "13.1.6",
     "next-auth": "^4.20.1",
     "npm": "^9.9.0",
-    "posthog-js": "^1.87.5",
+    "posthog-js": "^1.91.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-icons": "^4.8.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5919,7 +5919,7 @@ postcss@^8.0.9, postcss@^8.4.31:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-posthog-js@^1.87.5:
+posthog-js@^1.91.1:
   version "1.91.1"
   resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.91.1.tgz#8e03f55960aa2ff7add52fb4f820474f72cb3923"
   integrity sha512-Pj4mqCT8p4JdEXOwdZ1lNFU4W8a+Uv7zZs3FIBvvFnnXcMak8Fr8ns6RTTdWo3UQqZGD7iuarYcwTYI8E5UHdA==

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5920,9 +5920,9 @@ postcss@^8.0.9, postcss@^8.4.31:
     source-map-js "^1.0.2"
 
 posthog-js@^1.87.5:
-  version "1.87.5"
-  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.87.5.tgz#a279fc2016984008f2378a451bbbe33d9c89b857"
-  integrity sha512-GvSOX9oA1iPPaZSwFkuA333PDDo9yCKj4yqFYjxf/dU2mBIOuIMjdPLTiCvoVmsf2UL/2/9c7AwlnFAG4iRZuQ==
+  version "1.91.1"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.91.1.tgz#8e03f55960aa2ff7add52fb4f820474f72cb3923"
+  integrity sha512-Pj4mqCT8p4JdEXOwdZ1lNFU4W8a+Uv7zZs3FIBvvFnnXcMak8Fr8ns6RTTdWo3UQqZGD7iuarYcwTYI8E5UHdA==
   dependencies:
     fflate "^0.4.1"
 


### PR DESCRIPTION
## Description 📣

Bumps the posthog SDK version to `1.91.1`
