### PR TITLE
fix: fallback to raw value when reference cannot be resolved

### DIFF
--- a/backend/api/utils/syncing/secrets.py
+++ b/backend/api/utils/syncing/secrets.py
@@ -98,7 +98,7 @@ def get_environment_secrets(environment_sync):
                 f"${{{ref_key}}}",
                 secrets_dict.get(
                     ref_key,
-                    f"Warning: Local reference not found for key.",
+                    value,
                 ),
             )
 


### PR DESCRIPTION
# Description 📣

Fixes an issue when resolving local references, if the referenced env or secret cannot be found. 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation


