### PR TITLE
fix: help button type in provider creds dialog

### DIFF
--- a/frontend/components/syncing/CreateProviderCredentialsDialog.tsx
+++ b/frontend/components/syncing/CreateProviderCredentialsDialog.tsx
@@ -212,7 +212,7 @@ export const CreateProviderCredentialsDialog = (props: {
                             </span>
                           </div>
                           <Link href={docsLink(provider)} target="_blank">
-                            <Button variant="secondary">
+                            <Button type="button" variant="secondary">
                               <FaQuestionCircle className="my-1 shrink-0" />
                               Help
                             </Button>


### PR DESCRIPTION
# Description 📣

Fixes the button type for the "Help" button in `CreateProviderCredentialsDialog`

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation


