### PR TITLE
fix: disallow spaces in secret names

### DIFF
--- a/frontend/components/environments/SecretRow.tsx
+++ b/frontend/components/environments/SecretRow.tsx
@@ -849,7 +849,7 @@ export default function SecretRow(props: {
           )}
           value={secret.key}
           onChange={(e) =>
-            handlePropertyChange(secret.id, 'key', e.target.value.replace(/ /g, '').toUpperCase())
+            handlePropertyChange(secret.id, 'key', e.target.value.replace(/ /g, '_').toUpperCase())
           }
         />
         <div className="absolute inset-y-0 right-2 flex gap-1 items-center">

--- a/frontend/components/environments/SecretRow.tsx
+++ b/frontend/components/environments/SecretRow.tsx
@@ -848,7 +848,9 @@ export default function SecretRow(props: {
             secretHasBeenModified() && '!text-amber-500'
           )}
           value={secret.key}
-          onChange={(e) => handlePropertyChange(secret.id, 'key', e.target.value.toUpperCase())}
+          onChange={(e) =>
+            handlePropertyChange(secret.id, 'key', e.target.value.replace(/ /g, '').toUpperCase())
+          }
         />
         <div className="absolute inset-y-0 right-2 flex gap-1 items-center">
           <div


### PR DESCRIPTION
# Description 📣

Prevents spaces from being used in secret keys

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
