### PR TITLE
Fix: Phase CLI install instructions for macos brew, windows and docker

### DIFF
--- a/frontend/components/dashboard/CliInstallCommands.tsx
+++ b/frontend/components/dashboard/CliInstallCommands.tsx
@@ -7,7 +7,7 @@ export const CliInstallCommands = () => {
   const platformScripts = [
     {
       name: 'MacOS',
-      rawScript: 'brew install phase/cli/phase',
+      rawScript: 'brew install phasehq/cli/phase',
       styledScript: (
         <pre>
           <span className="text-emerald-800 dark:text-emerald-300">brew</span> install
@@ -18,7 +18,7 @@ export const CliInstallCommands = () => {
     {
       name: 'Windows',
       rawScript:
-        'scoop bucket add phasehq https://github.com/phasehq/scoop-cli.git; scoop install phase',
+        'scoop bucket add phasehq https://github.com/phasehq/scoop-cli.git && scoop install phase',
       styledScript: (
         <div className="space-y-1">
           <pre>
@@ -87,7 +87,7 @@ export const CliInstallCommands = () => {
       rawScript: 'docker run phasehq/cli',
       styledScript: (
         <pre>
-          <span className="text-emerald-800 dark:text-emerald-300">docker</span> run phase/cli
+          <span className="text-emerald-800 dark:text-emerald-300">docker</span> run phasehq/cli
         </pre>
       ),
     },


### PR DESCRIPTION
# Description 📣

This PR fixes discrepancies between the commands printed in the code boxes and whats copied in the getting started guide in the Phase Console.

As an example - when a user ran the the MacOS install command `brew install phasehq/cli/phase` but due to a big copied  `phase/cli/phase` instead, which results in brew asking the user for their to log into their GitHub thinking its a private repository due to it being a 404.

```zsh
▶ brew install phase/cli/phase
Running `brew update --auto-update`...
==> Auto-updated Homebrew!
Updated 2 taps (homebrew/core and homebrew/cask).
==> New Formulae
asmfmt                               cekit                                helm-docs                            kin                                  magic-wormhole.rs
autobrr                              g-ls                                 ignite                               kubetui                              sui
==> New Casks
cleanclip                      elecom-mouse-util              freeshow                       hancom-docs                    lunarbar                       upscayl

You have 6 outdated formulae installed.

==> Tapping phase/cli
Cloning into '/opt/homebrew/Library/Taps/phase/homebrew-cli'...
Username for 'https://github.com/': ^C
```


