### PR TITLE
fix: incorrect empty state on secrets overview

### DIFF
--- a/frontend/app/[team]/apps/[app]/page.tsx
+++ b/frontend/app/[team]/apps/[app]/page.tsx
@@ -656,7 +656,7 @@ export default function Secrets({ params }: { params: { team: string; app: strin
               </div>
             </div>
 
-            {appSecrets.length > 0 ? (
+            {appSecrets.length > 0 || appFolders.length > 0 ? (
               <table className="table-auto w-full border border-neutral-500/40">
                 <thead id="table-head" className="sticky top-0 bg-zinc-300 dark:bg-zinc-800 z-10">
                   <tr className="divide-x divide-neutral-500/40">


### PR DESCRIPTION
# Description 📣

Fixes an incorrectly displayed empty state on the App secrets overview screen when no secrets were present at the root path.

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation

