### PR TITLE
fix: enforce leading slash when cruding secrets over rest

### DIFF
--- a/backend/api/views.py
+++ b/backend/api/views.py
@@ -395,6 +395,8 @@ class SecretsView(APIView):
         try:
             path = request.headers["path"]
             if path:
+                if not path.startswith("/"):
+                    path = "/" + path
                 secrets_filter["path"] = path
         except:
             pass
@@ -453,6 +455,9 @@ class SecretsView(APIView):
 
             try:
                 path = secret["path"]
+                # Ensure path starts with a "/"
+                if not path.startswith("/"):
+                    path = "/" + path
             except:
                 path = "/"
             # path = secret["path"] if secret["path"] is not None else "/"
@@ -533,6 +538,11 @@ class SecretsView(APIView):
             try:
                 folder = None
                 path = secret["path"]
+
+                # Ensure path starts with a "/"
+                if not path.startswith("/"):
+                    path = "/" + path
+
                 if path != "/":
                     folder = create_environment_folder_structure(path, env_id)
 


### PR DESCRIPTION
# Description 📣

Enforces a leading slash on `path` strings when creating or editing secrets over REST. Also enforces a leading slash when querying secrets on a path. 

## Type ✨

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation


