### PR TITLE
fix: integration links leading slash on docs path

### DIFF
--- a/frontend/components/syncing/FrameworkIntegrations.tsx
+++ b/frontend/components/syncing/FrameworkIntegrations.tsx
@@ -125,7 +125,7 @@ export const FrameworkIntegrations = () => {
       {frameworks.map((framework) => (
         <Card key={framework.name}>
           <Link
-            href={`https://docs.phase.dev/${framework.href}`}
+            href={`https://docs.phase.dev${framework.href}`}
             target="_blank"
             className="flex flex-row-reverse gap-6"
           >


### PR DESCRIPTION
# Description 📣

This PR fixes the double slashes for the Phase Docs links in the framework integration section of the integration page.

Example: https://docs.phase.dev//integrations/frameworks/fiber

Which causes unexpected 404 like: https://docs.phase.dev/frameworks/fiber#initialize-phase-for-your-fiber-app
