### PR TITLE
fix: validate host and key before intializing posthog

### DIFF
--- a/frontend/utils/posthog.ts
+++ b/frontend/utils/posthog.ts
@@ -1,7 +1,11 @@
 import posthog from 'posthog-js'
 
 export function initializePostHog() {
-  if (typeof window !== 'undefined' && process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+  if (
+    typeof window !== 'undefined' &&
+    process.env.NEXT_PUBLIC_POSTHOG_KEY &&
+    process.env.NEXT_PUBLIC_POSTHOG_HOST !== 'BAKED_NEXT_PUBLIC_POSTHOG_HOST'
+  ) {
     posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
       api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || 'https://app.posthog.com',
       capture_pageview: true,


### PR DESCRIPTION
## :mag: Overview

Adds better validation for posthog host and key env vars before initializing posthog. Currently, baked values were passing a basic 'truthy' check and posthog was attempting to initialize with the placeholder values, leading to console and browser errors.

## :bulb: Proposed Changes

Adds extra validation to ensure `NEXT_PUBLIC_POSTHOG_HOST` is not a placeholder string before initializing posthog

## :memo: Release Notes

Fixed posthog attempting to initialize with invalid creds

## :sparkles: How to Test the Changes Locally

Make sure posthog correctly initializes with valid creds, and skips initializing when `NEXT_PUBLIC_POSTHOG_HOST` and `NEXT_PUBLIC_POSTHOG_KEY` are not supplied when starting the container.

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



