### PR TITLE
feat: reveal newly created secrets

### DIFF
--- a/frontend/components/environments/secrets/SecretRow.tsx
+++ b/frontend/components/environments/secrets/SecretRow.tsx
@@ -1,5 +1,5 @@
 import { EnvironmentType, SecretType } from '@/apollo/graphql'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { FaEyeSlash, FaEye } from 'react-icons/fa'
 import { Button } from '../../common/Button'
 
@@ -27,11 +27,18 @@ export default function SecretRow(props: {
 
   const [isRevealed, setIsRevealed] = useState<boolean>(false)
 
+  const keyInputRef = useRef<HTMLInputElement>(null)
+
   const [readSecret] = useMutation(LogSecretRead)
 
   // Reveal newly created secrets by default
   useEffect(() => {
-    if (cannonicalSecret === undefined) setIsRevealed(true)
+    if (cannonicalSecret === undefined) {
+      setIsRevealed(true)
+      if (keyInputRef.current) {
+        keyInputRef.current.focus()
+      }
+    }
   }, [cannonicalSecret])
 
   const handleRevealSecret = async () => {
@@ -67,6 +74,7 @@ export default function SecretRow(props: {
     <div className="flex flex-row w-full gap-2 group relative z-0">
       <div className="w-1/3 relative">
         <input
+          ref={keyInputRef}
           className={clsx(
             INPUT_BASE_STYLE,
             'rounded-sm',

--- a/frontend/components/environments/secrets/SecretRow.tsx
+++ b/frontend/components/environments/secrets/SecretRow.tsx
@@ -1,5 +1,5 @@
 import { EnvironmentType, SecretType } from '@/apollo/graphql'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { FaEyeSlash, FaEye } from 'react-icons/fa'
 import { Button } from '../../common/Button'
 
@@ -28,6 +28,11 @@ export default function SecretRow(props: {
   const [isRevealed, setIsRevealed] = useState<boolean>(false)
 
   const [readSecret] = useMutation(LogSecretRead)
+
+  // Reveal newly created secrets by default
+  useEffect(() => {
+    if (cannonicalSecret === undefined) setIsRevealed(true)
+  }, [cannonicalSecret])
 
   const handleRevealSecret = async () => {
     setIsRevealed(true)


### PR DESCRIPTION
## :mag: Overview

Creating a new secret in the console often requires manually revealing the value to see what is typed / pasted. This gets particularly annoying when creating multiple secrets.

## :bulb: Proposed Changes

Reveal the value when creating a new secret. Mask it once changes are saved. 

Fixes #193 

## :framed_picture: Screenshots or Demo

[Screencast from 02-27-2024 11:52:38 AM.webm](https://github.com/phasehq/console/assets/6710327/940eb4cc-e8a0-4544-8851-d13240913c64)

## :memo: Release Notes

Automatically reveal secret value when creating a new secret

## :question: Open Questions

Should this be a workspace / Organisation level setting in the future? Some users may prefer the original behavior, particularly if working in public, screen sharing etc.

## :sparkles: How to Test the Changes Locally

* Create a secret
* Observe that the value is automatically revealed
* Observe that the value is automatically masked once the secret is saved on the server

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



