### PR TITLE
fix: set active org to null when returning to app root

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -15,8 +15,7 @@ import OnboardingNavbar from '@/components/layout/OnboardingNavbar'
 export default function Home() {
   const router = useRouter()
 
-  const { organisations, activeOrganisation, setActiveOrganisation, loading } =
-    useContext(organisationContext)
+  const { organisations, setActiveOrganisation, loading } = useContext(organisationContext)
 
   const [showOrgCards, setShowOrgCards] = useState<boolean>(false)
 
@@ -26,13 +25,18 @@ export default function Home() {
 
   useEffect(() => {
     if (!loading && organisations !== null) {
-      // if there is no org setup on the server, send to onboarding page
+      // if there is no org membership, send to onboarding
       if (organisations.length === 0) router.push('/signup')
+      // if there is a single org membership, send to org home
       else if (organisations.length === 1) {
         const organisation = organisations[0]
         setActiveOrganisation(organisation)
         router.push(`/${organisation!.name}`)
-      } else {
+      }
+
+      // if there are multiple memberships, show orgs
+      else {
+        setActiveOrganisation(null)
         setShowOrgCards(true)
       }
     }

--- a/frontend/contexts/organisationContext.tsx
+++ b/frontend/contexts/organisationContext.tsx
@@ -10,7 +10,7 @@ import posthog from 'posthog-js'
 interface OrganisationContextValue {
   activeOrganisation: OrganisationType | null
   organisations: OrganisationType[] | null
-  setActiveOrganisation: (organisation: OrganisationType) => void
+  setActiveOrganisation: (organisation: OrganisationType | null) => void
   loading: boolean
 }
 


### PR DESCRIPTION
## :mag: Overview

When navigating back to the app root via the browser back button and switching to a different organisation, router loop was triggered, switching between the previously and currently select orgs

## :bulb: Proposed Changes

Fixed the regression by correctly resetting the `activeOrganisation` state when return to the app root

## :memo: Release Notes

Fixed a bug with navigation when returning to the app root and picking a different Organisation workspace

## :sparkles: How to Test the Changes Locally

* Sign in to an account with multiple Org memberships
* Pick a Org workspace from the workspace selection screen 
* Click 'Back' in the browser
* Choose a different Org workspace

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
- [ ] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



