### PR TITLE
fix: prevent duplicated env keys when upgrading user to admin

### DIFF
--- a/backend/backend/graphene/mutations/app.py
+++ b/backend/backend/graphene/mutations/app.py
@@ -166,13 +166,17 @@ class AddAppMemberMutation(graphene.Mutation):
         org_member = OrganisationMember.objects.get(id=member_id, deleted_at=None)
 
         app.members.add(org_member)
+
+        # Create new env keys
         for key in env_keys:
-            EnvironmentKey.objects.create(
+            EnvironmentKey.objects.update_or_create(
                 environment_id=key.env_id,
                 user_id=key.user_id,
-                wrapped_seed=key.wrapped_seed,
-                wrapped_salt=key.wrapped_salt,
-                identity_key=key.identity_key,
+                defaults={
+                    "wrapped_seed": key.wrapped_seed,
+                    "wrapped_salt": key.wrapped_salt,
+                    "identity_key": key.identity_key,
+                },
             )
 
         return AddAppMemberMutation(app=app)


### PR DESCRIPTION
## :mag: Overview
Upgrading a user to Admin in certain cases would result in duplicate `EnvironmentKey` instances being created, breaking the App and Environment queries for that User.

## :bulb: Proposed Changes

Update the `AddAppMemberMutation` mutation to use `update_or_create` to update existing EnvironmentKeys where they exist, instead of creating duplicates


## :memo: Release Notes

Fixed a bug with User Environment Keys when updgrading a user to Admin

## :sparkles: How to Test the Changes Locally

* Add a Dev user to an App, and give them access to one or more Environments
* Upgrade the User to Admin from the Organisation Members screen
* Login as the Admin User and make sure all Apps and Envs are accessible

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



