### PR TITLE
feat: add organisation info to tokens serializers

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -42,7 +42,7 @@ class CustomUserSerializer(serializers.ModelSerializer):
 class OrganisationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Organisation
-        fields = ["id", "name", "identity_key", "created_at"]
+        fields = ["id", "name"]
 
         def create(self, validated_data):
             return Organisation(**validated_data)
@@ -103,9 +103,17 @@ class UserTokenSerializer(serializers.ModelSerializer):
     # New field 'offline_enabled' with default value False
     offline_enabled = serializers.BooleanField(default=False, read_only=True)
 
+    organisation = OrganisationSerializer(source="user.organisation", read_only=True)
+
     class Meta:
         model = UserToken
-        fields = ["wrapped_key_share", "user_id", "offline_enabled", "apps"]
+        fields = [
+            "wrapped_key_share",
+            "user_id",
+            "offline_enabled",
+            "apps",
+            "organisation",
+        ]
 
     def to_representation(self, instance):
         representation = super().to_representation(instance)
@@ -143,9 +151,11 @@ class UserTokenSerializer(serializers.ModelSerializer):
 class ServiceTokenSerializer(serializers.ModelSerializer):
     apps = EnvironmentKeySerializer(many=True, read_only=True)
 
+    organisation = OrganisationSerializer(source="app.organisation", read_only=True)
+
     class Meta:
         model = ServiceToken
-        fields = ["wrapped_key_share", "apps"]
+        fields = ["wrapped_key_share", "apps", "organisation"]
 
     def to_representation(self, instance):
         representation = super().to_representation(instance)


### PR DESCRIPTION
## :mag: Overview

Organisation context information is missing in the REST api response when authenticating

## :bulb: Proposed Changes

Adds a `organisation` field to the rest api response for the tokens api

## :framed_picture: Screenshots or Demo

The tokens api now returns the following field at the top level of the response:
```
"organisation": {
        "id": "9b4e61a0-9d43-4b30-bc88-fe47aa333031",
        "name": "NASA"
},
```

## :memo: Release Notes

Added organisation context to Tokens REST API


### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



