### PR TITLE
fix: lockbox meta description apostrophe

### DIFF
--- a/frontend/app/lockbox/[boxId]/layout.tsx
+++ b/frontend/app/lockbox/[boxId]/layout.tsx
@@ -5,7 +5,7 @@ import OnboardingNavbar from '@/components/layout/OnboardingNavbar'
 export const metadata: Metadata = {
   title: 'Phase Lockbox',
   description:
-    'You&apos;ve recieved a secret via Phase Lockbox, secured with zero-trust encryption.',
+    "You've recieved a secret via Phase Lockbox, secured with zero-trust encryption.",
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## :mag: Overview

Fixes a typo in the lockbox meta description
