### PR TITLE
refactor: replace unncessary use of useLazyQuery

### DIFF
--- a/frontend/app/[team]/apps/[app]/layout.tsx
+++ b/frontend/app/[team]/apps/[app]/layout.tsx
@@ -23,7 +23,7 @@ export default function AppLayout({
 
   const { data, loading } = useQuery(GetAppDetail, {
     variables: {
-      organisationId: organisation!.id,
+      organisationId: organisation!?.id,
       appId: params.app,
     },
     skip: !organisation,

--- a/frontend/app/[team]/apps/[app]/layout.tsx
+++ b/frontend/app/[team]/apps/[app]/layout.tsx
@@ -4,7 +4,7 @@ import { Fragment, useContext, useEffect, useState } from 'react'
 import { Tab } from '@headlessui/react'
 import clsx from 'clsx'
 import Link from 'next/link'
-import { useLazyQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client'
 import { AppType } from '@/apollo/graphql'
 import { GetAppDetail } from '@/graphql/queries/getAppDetail.gql'
 import { usePathname } from 'next/navigation'
@@ -20,7 +20,14 @@ export default function AppLayout({
   const { activeOrganisation: organisation } = useContext(organisationContext)
   const path = usePathname()
   const [tabIndex, setTabIndex] = useState(0)
-  const [getApp, { data, loading }] = useLazyQuery(GetAppDetail)
+
+  const { data, loading } = useQuery(GetAppDetail, {
+    variables: {
+      organisationId: organisation!.id,
+      appId: params.app,
+    },
+    skip: !organisation,
+  })
   const app = data?.apps[0] as AppType
 
   const [tabs, setTabs] = useState([
@@ -48,13 +55,6 @@ export default function AppLayout({
 
   useEffect(() => {
     if (organisation) {
-      getApp({
-        variables: {
-          organisationId: organisation.id,
-          appId: params.app,
-        },
-      })
-
       if (organisation.role!.toLowerCase() !== 'dev') {
         setTabs((prevTabs) =>
           prevTabs.some((tab) => tab.name === 'Settings')

--- a/frontend/app/[team]/apps/[app]/members/page.tsx
+++ b/frontend/app/[team]/apps/[app]/members/page.tsx
@@ -49,18 +49,13 @@ export default function Members({ params }: { params: { team: string; app: strin
   const { data: session } = useSession()
 
   const AddMemberDialog = () => {
-    const [getMembers, { data: orgMembersData }] = useLazyQuery(GetOrganisationMembers)
-
-    useEffect(() => {
-      if (organisation) {
-        getMembers({
-          variables: {
-            organisationId: organisation.id,
-            role: null,
-          },
-        })
-      }
-    }, [getMembers])
+    const { data: orgMembersData } = useQuery(GetOrganisationMembers, {
+      variables: {
+        organisationId: organisation?.id,
+        role: null,
+        skip: !organisation,
+      },
+    })
 
     const memberOptions =
       orgMembersData?.organisationMembers.filter(

--- a/frontend/app/[team]/apps/[app]/page.tsx
+++ b/frontend/app/[team]/apps/[app]/page.tsx
@@ -104,16 +104,23 @@ const Environments = (props: { environments: EnvironmentType[] }) => {
 }
 
 export default function Secrets({ params }: { params: { team: string; app: string } }) {
+  const { activeOrganisation: organisation } = useContext(organisationContext)
+
   const { data } = useQuery(GetAppEnvironments, {
     variables: {
       appId: params.app,
     },
   })
-
+  const { data: orgAdminsData } = useQuery(GetOrganisationAdminsAndSelf, {
+    variables: {
+      organisationId: organisation!.id,
+    },
+    skip: !organisation,
+  })
   const pathname = usePathname()
 
   const [getEnvSecrets] = useLazyQuery(GetEnvSecretsKV)
-  const [getOrgAdmins, { data: orgAdminsData }] = useLazyQuery(GetOrganisationAdminsAndSelf)
+
   const [appSecrets, setAppSecrets] = useState<AppSecret[]>([])
   const [appFolders, setAppFolders] = useState<AppFolder[]>([])
   const [searchQuery, setSearchQuery] = useState<string>('')
@@ -122,7 +129,6 @@ export default function Secrets({ params }: { params: { team: string; app: strin
   const [loading, setLoading] = useState(true)
 
   const { keyring } = useContext(KeyringContext)
-  const { activeOrganisation: organisation } = useContext(organisationContext)
 
   const activeUserIsAdmin = organisation ? userIsAdmin(organisation.role!) : false
 
@@ -141,16 +147,6 @@ export default function Secrets({ params }: { params: { team: string; app: strin
           const searchRegex = new RegExp(searchQuery, 'i')
           return searchRegex.test(folder.name)
         })
-
-  useEffect(() => {
-    if (organisation) {
-      getOrgAdmins({
-        variables: {
-          organisationId: organisation.id,
-        },
-      })
-    }
-  }, [getOrgAdmins, organisation, params.app])
 
   useEffect(() => {
     const fetchAndDecryptAppEnvs = async (appEnvironments: EnvironmentType[]) => {

--- a/frontend/app/[team]/apps/[app]/page.tsx
+++ b/frontend/app/[team]/apps/[app]/page.tsx
@@ -113,7 +113,7 @@ export default function Secrets({ params }: { params: { team: string; app: strin
   })
   const { data: orgAdminsData } = useQuery(GetOrganisationAdminsAndSelf, {
     variables: {
-      organisationId: organisation!.id,
+      organisationId: organisation?.id,
     },
     skip: !organisation,
   })

--- a/frontend/app/[team]/apps/[app]/settings/page.tsx
+++ b/frontend/app/[team]/apps/[app]/settings/page.tsx
@@ -13,7 +13,7 @@ export default function AppSettings({ params }: { params: { team: string; app: s
 
   const { data } = useQuery(GetAppDetail, {
     variables: {
-      organisationId: organisation!.id,
+      organisationId: organisation?.id,
       appId: params.app,
     },
     skip: !organisation,

--- a/frontend/app/[team]/apps/[app]/settings/page.tsx
+++ b/frontend/app/[team]/apps/[app]/settings/page.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import { GetOrganisations } from '@/graphql/queries/getOrganisations.gql'
 import { GetAppDetail } from '@/graphql/queries/getAppDetail.gql'
-import { useLazyQuery, useQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client'
 import { AppType } from '@/apollo/graphql'
-import { useContext, useEffect } from 'react'
+import { useContext } from 'react'
 import DeleteAppDialog from '@/components/apps/DeleteAppDialog'
 import { organisationContext } from '@/contexts/organisationContext'
 import { FaCube } from 'react-icons/fa'
@@ -12,18 +11,13 @@ import { FaCube } from 'react-icons/fa'
 export default function AppSettings({ params }: { params: { team: string; app: string } }) {
   const { activeOrganisation: organisation } = useContext(organisationContext)
 
-  const [getApp, { data, loading }] = useLazyQuery(GetAppDetail)
-
-  useEffect(() => {
-    if (organisation) {
-      getApp({
-        variables: {
-          organisationId: organisation.id,
-          appId: params.app,
-        },
-      })
-    }
-  }, [getApp, organisation, params.app])
+  const { data } = useQuery(GetAppDetail, {
+    variables: {
+      organisationId: organisation!.id,
+      appId: params.app,
+    },
+    skip: !organisation,
+  })
 
   const app = data?.apps[0] as AppType
 

--- a/frontend/app/[team]/apps/[app]/tokens/page.tsx
+++ b/frontend/app/[team]/apps/[app]/tokens/page.tsx
@@ -25,7 +25,7 @@ export default function Tokens({ params }: { params: { team: string; app: string
 
   const { data } = useQuery(GetAppDetail, {
     variables: {
-      organisationId: organisation!.id,
+      organisationId: organisation?.id,
       appId: params.app,
     },
     skip: !organisation,

--- a/frontend/app/[team]/apps/[app]/tokens/page.tsx
+++ b/frontend/app/[team]/apps/[app]/tokens/page.tsx
@@ -2,7 +2,7 @@
 
 import { GetAppDetail } from '@/graphql/queries/getAppDetail.gql'
 import { RotateAppKey } from '@/graphql/mutations/rotateAppKeys.gql'
-import { useLazyQuery, useMutation } from '@apollo/client'
+import { useLazyQuery, useMutation, useQuery } from '@apollo/client'
 import { AppType } from '@/apollo/graphql'
 import { Fragment, useContext, useEffect, useState } from 'react'
 import { Button } from '@/components/common/Button'
@@ -21,26 +21,21 @@ import { SecretTokens } from '@/components/apps/tokens/SecretTokens'
 import { organisationContext } from '@/contexts/organisationContext'
 
 export default function Tokens({ params }: { params: { team: string; app: string } }) {
-  const [getApp, { data }] = useLazyQuery(GetAppDetail)
+  const { activeOrganisation: organisation } = useContext(organisationContext)
+
+  const { data } = useQuery(GetAppDetail, {
+    variables: {
+      organisationId: organisation!.id,
+      appId: params.app,
+    },
+    skip: !organisation,
+  })
 
   const app = data?.apps[0] as AppType
 
   const [activePanel, setActivePanel] = useState<'secrets' | 'kms'>('secrets')
 
-  const { activeOrganisation: organisation } = useContext(organisationContext)
-
   const { keyring } = useContext(KeyringContext)
-
-  useEffect(() => {
-    if (organisation) {
-      getApp({
-        variables: {
-          organisationId: organisation.id,
-          appId: params.app,
-        },
-      })
-    }
-  }, [getApp, organisation, params.app])
 
   const handleCopy = (val: string) => {
     copyToClipBoard(val)

--- a/frontend/app/[team]/apps/page.tsx
+++ b/frontend/app/[team]/apps/page.tsx
@@ -1,11 +1,10 @@
 'use client'
 
-import { useLazyQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client'
 import { GetApps } from '@/graphql/queries/getApps.gql'
 import { AppType } from '@/apollo/graphql'
 import NewAppDialog from '@/components/apps/NewAppDialog'
-import { FaPlus } from 'react-icons/fa'
-import { useContext, useEffect } from 'react'
+import { useContext } from 'react'
 import Link from 'next/link'
 import Spinner from '@/components/common/Spinner'
 import { AppCard } from '@/components/apps/AppCard'
@@ -14,22 +13,12 @@ import { organisationContext } from '@/contexts/organisationContext'
 export default function AppsHome({ params }: { params: { team: string } }) {
   const { activeOrganisation: organisation } = useContext(organisationContext)
 
-  const [getApps, { data, loading }] = useLazyQuery(GetApps)
-
-  useEffect(() => {
-    if (organisation) {
-      const fetchData = async () => {
-        getApps({
-          variables: {
-            organisationId: organisation.id,
-          },
-        })
-      }
-
-      fetchData()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [organisation])
+  const { data, loading } = useQuery(GetApps, {
+    variables: {
+      organisationId: organisation!.id,
+      skip: !organisation,
+    },
+  })
 
   const apps = data?.apps as AppType[]
 

--- a/frontend/app/[team]/apps/page.tsx
+++ b/frontend/app/[team]/apps/page.tsx
@@ -15,7 +15,7 @@ export default function AppsHome({ params }: { params: { team: string } }) {
 
   const { data, loading } = useQuery(GetApps, {
     variables: {
-      organisationId: organisation!.id,
+      organisationId: organisation?.id,
       skip: !organisation,
     },
   })

--- a/frontend/app/[team]/integrations/page.tsx
+++ b/frontend/app/[team]/integrations/page.tsx
@@ -39,7 +39,7 @@ export default function Integrations({ params }: { params: { team: string } }) {
   const [provider, setProvider] = useState<ProviderType | null>(null)
 
   const { data } = useQuery(GetOrganisationSyncs, {
-    variables: { orgId: organisation!.id },
+    variables: { orgId: organisation?.id },
     pollInterval: 10000,
     skip: !organisation,
   })

--- a/frontend/app/[team]/members/page.tsx
+++ b/frontend/app/[team]/members/page.tsx
@@ -11,7 +11,7 @@ import RemoveMember from '@/graphql/mutations/organisation/deleteOrgMember.gql'
 import UpdateMemberRole from '@/graphql/mutations/organisation/updateOrgMemberRole.gql'
 import AddMemberToApp from '@/graphql/mutations/apps/addAppMember.gql'
 import { useLazyQuery, useMutation, useQuery } from '@apollo/client'
-import { Fragment, useContext, useEffect, useState } from 'react'
+import { Fragment, useContext, useState } from 'react'
 import {
   OrganisationMemberInviteType,
   OrganisationMemberType,
@@ -37,13 +37,11 @@ import clsx from 'clsx'
 import { cryptoUtils } from '@/utils/auth'
 import { copyToClipBoard } from '@/utils/clipboard'
 import { toast } from 'react-toastify'
-import { useSession } from 'next-auth/react'
 import { Avatar } from '@/components/common/Avatar'
 import { userIsAdmin } from '@/utils/permissions'
 import { RoleLabel } from '@/components/users/RoleLabel'
 import { KeyringContext } from '@/contexts/keyringContext'
 import { unwrapEnvSecretsForUser, wrapEnvSecretsForUser } from '@/utils/environments'
-import UnlockKeyringDialog from '@/components/auth/UnlockKeyringDialog'
 import { Alert } from '@/components/common/Alert'
 
 const handleCopy = (val: string) => {
@@ -457,7 +455,7 @@ export default function Members({ params }: { params: { team: string } }) {
 
   const { data: membersData } = useQuery(GetOrganisationMembers, {
     variables: {
-      organisationId: organisation!.id,
+      organisationId: organisation?.id,
       role: null,
     },
     pollInterval: 5000,
@@ -466,7 +464,7 @@ export default function Members({ params }: { params: { team: string } }) {
 
   const { data: invitesData } = useQuery(GetInvites, {
     variables: {
-      orgId: organisation!.id,
+      orgId: organisation?.id,
     },
     pollInterval: 5000,
     skip: !organisation,
@@ -506,7 +504,7 @@ export default function Members({ params }: { params: { team: string } }) {
           {
             query: GetInvites,
             variables: {
-              orgId: organisation!.id,
+              orgId: organisation?.id,
             },
           },
         ],

--- a/frontend/app/[team]/members/page.tsx
+++ b/frontend/app/[team]/members/page.tsx
@@ -453,8 +453,25 @@ const InviteDialog = (props: { organisationId: string }) => {
 }
 
 export default function Members({ params }: { params: { team: string } }) {
-  const [getMembers, { data: membersData }] = useLazyQuery(GetOrganisationMembers)
-  const [getInvites, { data: invitesData }] = useLazyQuery(GetInvites)
+  const { activeOrganisation: organisation } = useContext(organisationContext)
+
+  const { data: membersData } = useQuery(GetOrganisationMembers, {
+    variables: {
+      organisationId: organisation!.id,
+      role: null,
+    },
+    pollInterval: 5000,
+    skip: !organisation,
+  })
+
+  const { data: invitesData } = useQuery(GetInvites, {
+    variables: {
+      orgId: organisation!.id,
+    },
+    pollInterval: 5000,
+    skip: !organisation,
+  })
+
   const [deleteInvite] = useMutation(DeleteOrgInvite)
 
   const sortedInvites: OrganisationMemberInviteType[] =
@@ -465,29 +482,7 @@ export default function Members({ params }: { params: { team: string } }) {
         return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
       }) || []
 
-  const { activeOrganisation: organisation } = useContext(organisationContext)
-
   const activeUserIsAdmin = organisation ? userIsAdmin(organisation.role!) : false
-
-  const { data: session } = useSession()
-
-  useEffect(() => {
-    if (organisation) {
-      getMembers({
-        variables: {
-          organisationId: organisation.id,
-          role: null,
-        },
-        pollInterval: 5000,
-      })
-      getInvites({
-        variables: {
-          orgId: organisation.id,
-        },
-        pollInterval: 5000,
-      })
-    }
-  }, [getInvites, getMembers, organisation])
 
   const DeleteInviteConfirmDialog = (props: { inviteId: string }) => {
     const { inviteId } = props

--- a/frontend/app/[team]/page.tsx
+++ b/frontend/app/[team]/page.tsx
@@ -2,15 +2,11 @@
 
 import AppsHomeCard from '@/components/apps/AppsHomeCard'
 import Link from 'next/link'
-import { useContext, useState } from 'react'
+import { useContext } from 'react'
 import { organisationContext } from '@/contexts/organisationContext'
 import MembersHomeCard from '@/components/users/MembersHomeCard'
 import IntegrationsHomeCard from '@/components/syncing/IntegrationsHomeCard'
 import { GetStarted } from '@/components/dashboard/GetStarted'
-import clsx from 'clsx'
-import { FaChevronRight } from 'react-icons/fa'
-import { Button } from '@/components/common/Button'
-import UnlockKeyringDialog from '@/components/auth/UnlockKeyringDialog'
 
 export default function AppsHome({ params }: { params: { team: string } }) {
   const { activeOrganisation: organisation } = useContext(organisationContext)

--- a/frontend/components/apps/NewAppDialog.tsx
+++ b/frontend/components/apps/NewAppDialog.tsx
@@ -56,7 +56,7 @@ export default function NewAppDialog(props: { appCount: number; organisation: Or
 
   const { data: orgAdminsData } = useQuery(GetOrganisationAdminsAndSelf, {
     variables: {
-      organisationId: organisation!.id,
+      organisationId: organisation?.id,
     },
     skip: !organisation,
   })

--- a/frontend/components/apps/NewAppDialog.tsx
+++ b/frontend/components/apps/NewAppDialog.tsx
@@ -10,7 +10,7 @@ import { CreateNewSecret } from '@/graphql/mutations/environments/createSecret.g
 import { GetOrganisationAdminsAndSelf } from '@/graphql/queries/organisation/getOrganisationAdminsAndSelf.gql'
 import { InitAppEnvironments } from '@/graphql/mutations/environments/initAppEnvironments.gql'
 import { GetAppEnvironments } from '@/graphql/queries/secrets/getAppEnvironments.gql'
-import { useLazyQuery, useMutation } from '@apollo/client'
+import { useLazyQuery, useMutation, useQuery } from '@apollo/client'
 import {
   ApiEnvironmentEnvTypeChoices,
   ApiOrganisationPlanChoices,
@@ -53,21 +53,17 @@ export default function NewAppDialog(props: { appCount: number; organisation: Or
 
   const [getApps] = useLazyQuery(GetApps)
   const [getAppEnvs] = useLazyQuery(GetAppEnvironments)
-  const [getOrgAdmins, { data: orgAdminsData }] = useLazyQuery(GetOrganisationAdminsAndSelf)
+
+  const { data: orgAdminsData } = useQuery(GetOrganisationAdminsAndSelf, {
+    variables: {
+      organisationId: organisation!.id,
+    },
+    skip: !organisation,
+  })
 
   const [createSuccess, setCreateSuccess] = useState(false)
 
   const { keyring } = useContext(KeyringContext)
-
-  useEffect(() => {
-    if (organisation) {
-      getOrgAdmins({
-        variables: {
-          organisationId: organisation.id,
-        },
-      })
-    }
-  }, [getOrgAdmins, organisation])
 
   const reset = () => {
     setName('')

--- a/frontend/components/layout/Navbar.tsx
+++ b/frontend/components/layout/Navbar.tsx
@@ -17,7 +17,7 @@ export const NavBar = (props: { team: string }) => {
 
   const { data: appsData } = useQuery(GetApps, {
     variables: {
-      organisationId: organisation!.id,
+      organisationId: organisation?.id,
     },
     skip: !organisation,
   })

--- a/frontend/components/layout/Navbar.tsx
+++ b/frontend/components/layout/Navbar.tsx
@@ -1,5 +1,5 @@
 import UserMenu from '../UserMenu'
-import { useLazyQuery } from '@apollo/client'
+import { useLazyQuery, useQuery } from '@apollo/client'
 import { GetApps } from '@/graphql/queries/getApps.gql'
 import { GetAppEnvironments } from '@/graphql/queries/secrets/getAppEnvironments.gql'
 import { usePathname } from 'next/navigation'
@@ -15,22 +15,13 @@ import { LogoMark } from '../common/LogoMark'
 export const NavBar = (props: { team: string }) => {
   const { activeOrganisation: organisation } = useContext(organisationContext)
 
-  const [getApps, { data: appsData }] = useLazyQuery(GetApps)
+  const { data: appsData } = useQuery(GetApps, {
+    variables: {
+      organisationId: organisation!.id,
+    },
+    skip: !organisation,
+  })
   const [getAppEnvs, { data: appEnvsData }] = useLazyQuery(GetAppEnvironments)
-
-  useEffect(() => {
-    if (organisation) {
-      const fetchData = async () => {
-        getApps({
-          variables: {
-            organisationId: organisation.id,
-          },
-        })
-      }
-
-      fetchData()
-    }
-  }, [getApps, organisation])
 
   const apps = appsData?.apps as AppType[]
 

--- a/frontend/graphql/queries/syncing/GetOrgSyncs.gql
+++ b/frontend/graphql/queries/syncing/GetOrgSyncs.gql
@@ -36,4 +36,24 @@ query GetOrganisationSyncs($orgId: ID!) {
       meta
     }
   }
+  savedCredentials(orgId: $orgId) {
+    id
+    name
+    credentials
+    createdAt
+    provider {
+      id
+      name
+      expectedCredentials
+      optionalCredentials
+    }
+    syncCount
+  }
+  apps(organisationId: $orgId, appId: null) {
+    id
+    name
+    identityKey
+    createdAt
+    syncEnabled
+  }
 }


### PR DESCRIPTION
## :mag: Overview

Several page components rely on `organisation.id` from the `OrganisationContext` to be available before performing their initial queries. This is being achieved by a combination of `useEffect` that depends on the context value to the truthy, and the query being executed with `useLazyQuery`

## :bulb: Proposed Changes
Replace the combination of `useEffect` and `useLazyQuery` with just a standard `useQuery`. Use the `skip` argument to prevent querying data till the context value is present.

This will simplify the code and should make data fetching on most pages slightly faster.

## :memo: Release Notes

Improved client-side query performance on several page routes


### :dart: Reviewer Focus

Verify that initial queries are correctly executed and data is fetched on the following page routes / components:
* Apps
* Integrations
* Members
* App Home
* App Members
* App Settings
* App Tokens
* NewAppDialog

### :heavy_plus_sign: Additional Context

https://www.apollographql.com/docs/react/data/queries#queryhookoptions-interface-skip

## :sparkles: How to Test the Changes Locally

Build and test the page routes mentioned above. 

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



