### PR TITLE
fix: app queries

### DIFF
--- a/frontend/app/[team]/apps/[app]/page.tsx
+++ b/frontend/app/[team]/apps/[app]/page.tsx
@@ -110,6 +110,7 @@ export default function Secrets({ params }: { params: { team: string; app: strin
     variables: {
       appId: params.app,
     },
+    fetchPolicy: 'cache-and-network',
   })
   const { data: orgAdminsData } = useQuery(GetOrganisationAdminsAndSelf, {
     variables: {

--- a/frontend/app/[team]/apps/page.tsx
+++ b/frontend/app/[team]/apps/page.tsx
@@ -16,8 +16,8 @@ export default function AppsHome({ params }: { params: { team: string } }) {
   const { data, loading } = useQuery(GetApps, {
     variables: {
       organisationId: organisation?.id,
-      skip: !organisation,
     },
+    skip: !organisation,
   })
 
   const apps = data?.apps as AppType[]


### PR DESCRIPTION
## :mag: Overview

Fixes a couple of errors with graphql queries in the apps list and overview pages

## :bulb: Proposed Changes

* Fixed the `skip` argument in the `GetApps` operation that was incorrectly added with query args. This fixes the "variable not provided" error when hard refreshing the Apps page
* Updated the fetch policy for the `GetAppEnvironments` operation. This fixes an issue when creating an app with example secrets showed "0 secrets" in the Environment cards when opened.

## :framed_picture: Screenshots or Demo

Fixed error when refreshing apps page:
[Screencast from 03-27-2024 01:50:26 PM.webm](https://github.com/phasehq/console/assets/6710327/5a659c12-3c95-40b6-9124-3b3961c5f372)

Fixed secret counts when creating app with example secrets:
[Screencast from 03-27-2024 01:53:22 PM.webm](https://github.com/phasehq/console/assets/6710327/3222e478-9951-41ce-b757-b55f48cdaa0c)

## :memo: Release Notes
Fixed miscellaneous issues with queries on the Apps list and detail pages

## :sparkles: How to Test the Changes Locally

* Hard refresh the Apps page
* Create an app with example secrets and open it. Check that the counts of secrets for each Environment card is correct

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



