### PR TITLE
feat: allow remembering sudo password when onboarding

### DIFF
--- a/frontend/app/[team]/recovery/page.tsx
+++ b/frontend/app/[team]/recovery/page.tsx
@@ -17,12 +17,14 @@ import { organisationContext } from '@/contexts/organisationContext'
 import { KeyringContext } from '@/contexts/keyringContext'
 import { Avatar } from '@/components/common/Avatar'
 import { RoleLabel } from '@/components/users/RoleLabel'
+import { setDevicePassword } from '@/utils/localStorage'
 
 export default function Recovery({ params }: { params: { team: string } }) {
   const { data: session } = useSession()
   const [inputs, setInputs] = useState<Array<string>>([])
   const [pw, setPw] = useState<string>('')
   const [pw2, setPw2] = useState<string>('')
+  const [savePassword, setSavePassword] = useState(true)
 
   const [step, setStep] = useState<number>(0)
 
@@ -86,6 +88,10 @@ export default function Recovery({ params }: { params: { team: string } }) {
             wrappedRecovery: encryptedMnemonic,
           },
         })
+
+        if (savePassword) {
+          setDevicePassword(org?.memberId!, pw)
+        }
 
         resolve({
           publicKey: accountKeyRing.publicKey,
@@ -177,7 +183,16 @@ export default function Recovery({ params }: { params: { team: string } }) {
               />
             )}
 
-            {step === 1 && <AccountPassword pw={pw} setPw={setPw} pw2={pw2} setPw2={setPw2} />}
+            {step === 1 && (
+              <AccountPassword
+                pw={pw}
+                setPw={setPw}
+                pw2={pw2}
+                setPw2={setPw2}
+                savePassword={savePassword}
+                setSavePassword={setSavePassword}
+              />
+            )}
 
             <div className="flex justify-between w-full">
               <div>

--- a/frontend/app/[team]/recovery/page.tsx
+++ b/frontend/app/[team]/recovery/page.tsx
@@ -115,7 +115,7 @@ export default function Recovery({ params }: { params: { team: string } }) {
           pending: 'Recovering your account...',
           success: 'Recovery complete!',
         })
-        .then(() => router.push('/'))
+        .then(() => router.push(`/${org!.name}`))
     }
   }
 

--- a/frontend/app/invite/[invite]/page.tsx
+++ b/frontend/app/invite/[invite]/page.tsx
@@ -19,6 +19,7 @@ import { useSession } from 'next-auth/react'
 import { copyRecoveryKit, generateRecoveryPdf } from '@/utils/recovery'
 import { LogoMark } from '@/components/common/LogoMark'
 import { setDevicePassword } from '@/utils/localStorage'
+import { useRouter } from 'next/navigation'
 
 const bip39 = require('bip39')
 
@@ -44,6 +45,8 @@ export default function Invite({ params }: { params: { invite: string } }) {
   const [acceptInvite] = useMutation(AcceptOrganisationInvite)
 
   const { data: session } = useSession()
+
+  const router = useRouter()
 
   const invite: OrganisationMemberInviteType = data?.validateInvite
 
@@ -166,10 +169,14 @@ export default function Invite({ params }: { params: { invite: string } }) {
     const isFormValid = validateCurrentStep()
     if (step !== steps.length - 1 && isFormValid) setStep(step + 1)
     if (step === steps.length - 1 && isFormValid) {
-      toast.promise(handleAccountInit, {
-        pending: 'Setting up your account',
-        success: 'Account setup complete!',
-      })
+      toast
+        .promise(handleAccountInit, {
+          pending: 'Setting up your account',
+          success: 'Account setup complete!',
+        })
+        .then(() => {
+          router.push(`/${invite.organisation.name}`)
+        })
     }
   }
 

--- a/frontend/app/invite/[invite]/page.tsx
+++ b/frontend/app/invite/[invite]/page.tsx
@@ -18,6 +18,7 @@ import { OrganisationMemberInviteType } from '@/apollo/graphql'
 import { useSession } from 'next-auth/react'
 import { copyRecoveryKit, generateRecoveryPdf } from '@/utils/recovery'
 import { LogoMark } from '@/components/common/LogoMark'
+import { setDevicePassword } from '@/utils/localStorage'
 
 const bip39 = require('bip39')
 
@@ -53,6 +54,7 @@ export default function Invite({ params }: { params: { invite: string } }) {
   const [success, setSuccess] = useState<boolean>(false)
   const [pw, setPw] = useState<string>('')
   const [pw2, setPw2] = useState<string>('')
+  const [savePassword, setSavePassword] = useState(true)
   const [mnemonic, setMnemonic] = useState('')
   const [isloading, setIsLoading] = useState<boolean>(false)
 
@@ -130,9 +132,14 @@ export default function Invite({ params }: { params: { invite: string } }) {
         },
       })
 
+      const memberId = data.createOrganisationMember.orgMember.id
+
       setIsLoading(false)
-      if (data.createOrganisationMember.orgMember.id) {
+      if (memberId) {
         setSuccess(true)
+        if (savePassword) {
+          setDevicePassword(memberId, pw)
+        }
         resolve(true)
       } else {
         reject()
@@ -274,7 +281,16 @@ export default function Invite({ params }: { params: { invite: string } }) {
                   <Stepper steps={steps} activeStep={step} />
                 </div>
 
-                {step === 0 && <AccountPassword pw={pw} setPw={setPw} pw2={pw2} setPw2={setPw2} />}
+                {step === 0 && (
+                  <AccountPassword
+                    pw={pw}
+                    setPw={setPw}
+                    pw2={pw2}
+                    setPw2={setPw2}
+                    savePassword={savePassword}
+                    setSavePassword={setSavePassword}
+                  />
+                )}
 
                 {step === 1 && (
                   <AccountRecovery

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -15,6 +15,7 @@ import { useMutation } from '@apollo/client'
 import { useRouter } from 'next/navigation'
 import { CreateOrg } from '@/graphql/mutations/createOrganisation.gql'
 import { copyRecoveryKit, generateRecoveryPdf } from '@/utils/recovery'
+import { setDevicePassword } from '@/utils/localStorage'
 
 const bip39 = require('bip39')
 
@@ -23,6 +24,7 @@ const Onboard = () => {
   const [teamName, setTeamName] = useState<string>('')
   const [pw, setPw] = useState<string>('')
   const [pw2, setPw2] = useState<string>('')
+  const [savePassword, setSavePassword] = useState(true)
   const [mnemonic, setMnemonic] = useState('')
   const [orgId, setOrgId] = useState('')
   const [inputs, setInputs] = useState<Array<string>>([])
@@ -157,6 +159,9 @@ const Onboard = () => {
         })
         const { data } = result
         const newOrg = data.createOrganisation.organisation
+        if (savePassword) {
+          setDevicePassword(newOrg.memberId, pw)
+        }
       } catch (e) {
         setIsLoading(false)
         reject()
@@ -240,7 +245,16 @@ const Onboard = () => {
             </div>
 
             {step === 0 && <TeamName name={teamName} setName={setTeamName} />}
-            {step === 1 && <AccountPassword pw={pw} setPw={setPw} pw2={pw2} setPw2={setPw2} />}
+            {step === 1 && (
+              <AccountPassword
+                pw={pw}
+                setPw={setPw}
+                pw2={pw2}
+                setPw2={setPw2}
+                savePassword={savePassword}
+                setSavePassword={setSavePassword}
+              />
+            )}
             {step === 2 && (
               <AccountRecovery
                 mnemonic={mnemonic}

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -178,10 +178,14 @@ const Onboard = () => {
     const isFormValid = validateCurrentStep()
     if (step !== steps.length - 1 && isFormValid) setStep(step + 1)
     if (step === steps.length - 1 && isFormValid) {
-      toast.promise(handleAccountInit, {
-        pending: 'Setting up your account',
-        success: 'Account setup complete!',
-      })
+      toast
+        .promise(handleAccountInit, {
+          pending: 'Setting up your account',
+          success: 'Account setup complete!',
+        })
+        .then(() => {
+          router.push(`/${teamName}`)
+        })
     }
   }
 

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -34,7 +34,7 @@ const SidebarLink = (props: SidebarLinkT) => {
     <Link href={href} title={name}>
       <div
         className={clsx(
-          'flex items-center gap-2 hover:text-emerald-500 text-sm font-medium rounded-md p-2 w-56',
+          'flex items-center gap-2 hover:text-emerald-500 text-sm font-medium rounded-md p-2 w-full',
           active && 'bg-neutral-300 dark:bg-neutral-800'
         )}
       >
@@ -64,11 +64,9 @@ const Sidebar = () => {
           <>
             <Menu.Button
               as="div"
-              className="p-2 text-neutral-500 font-semibold uppercase tracking-wider cursor-pointer flex items-center justify-between  w-full "
+              className="p-2 text-neutral-500 font-semibold uppercase tracking-wider cursor-pointer flex items-center justify-between w-full"
             >
-              <span className="truncate">
-              {activeOrganisation?.name}
-              </span>
+              <span className="truncate">{activeOrganisation?.name}</span>
               <FaChevronDown
                 className={clsx('transition ease', open ? 'rotate-180' : 'rotate-0')}
               />
@@ -94,11 +92,9 @@ const Sidebar = () => {
                               active
                                 ? 'hover:text-emerald-500 dark:text-white dark:hover:text-emerald-500'
                                 : 'text-gray-900 dark:text-white dark:hover:text-emerald-500'
-                            } group flex  gap-2 items-center justify-between rounded-md px-2 py-2 text-base font-medium w-[95%]`}
+                            } group flex w-full  gap-2 items-center justify-between rounded-md px-2 py-2 text-base font-medium`}
                           >
-                            <span className="truncate w-[80%] text-left">
-                            {org.name}
-                            </span>
+                            <span className="truncate w-[80%] text-left">{org.name}</span>
                             <FaExchangeAlt />
                           </button>
                         )}
@@ -161,9 +157,9 @@ const Sidebar = () => {
   ]
 
   return (
-    <div className="h-screen flex flex-col pt-[64px] w-[300px]">
+    <div className="h-screen flex flex-col pt-[64px] w-72">
       <nav className="flex flex-col divide-y divide-neutral-300 dark:divide-neutral-800 items-start justify-between h-full bg-neutral-100/30 dark:bg-neutral-900/30 text-black dark:text-white">
-        <div className="gap-4 p-4 grid grid-cols-1">
+        <div className="gap-4 p-4 grid grid-cols-1 w-full">
           <OrgsMenu />
 
           {links.slice(0, 5).map((link) => (

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -88,6 +88,7 @@ const Sidebar = () => {
                         {({ active }) => (
                           <button
                             onClick={() => switchOrg(org)}
+                            title={`Switch to ${org.name}`}
                             className={`${
                               active
                                 ? 'hover:text-emerald-500 dark:text-white dark:hover:text-emerald-500'

--- a/frontend/components/onboarding/AccountPassword.tsx
+++ b/frontend/components/onboarding/AccountPassword.tsx
@@ -1,17 +1,20 @@
-import { useEffect, useState } from 'react'
+import { Dispatch, SetStateAction, useEffect, useState } from 'react'
 import { ZXCVBNResult } from 'zxcvbn'
-import { FaCheck, FaEye, FaEyeSlash, FaInfo } from 'react-icons/fa'
+import { FaCheck, FaEye, FaEyeSlash, FaInfo, FaShieldAlt } from 'react-icons/fa'
 import clsx from 'clsx'
+import { ToggleSwitch } from '../common/ToggleSwitch'
 
 interface AccountPasswordProps {
   pw: string
   pw2: string
+  savePassword: boolean
   setPw: Function
   setPw2: Function
+  setSavePassword: Function
 }
 
 export const AccountPassword = (props: AccountPasswordProps) => {
-  const { pw, setPw, pw2, setPw2 } = props
+  const { pw, setPw, pw2, setPw2, savePassword, setSavePassword } = props
   const [showPw, setShowPw] = useState<boolean>(false)
   const [showPw2, setShowPw2] = useState<boolean>(false)
   const [pwStrength, setPwStrength] = useState<ZXCVBNResult>({} as ZXCVBNResult)
@@ -60,7 +63,7 @@ export const AccountPassword = (props: AccountPasswordProps) => {
   const passwordIsStrong = pwStrength?.feedback?.suggestions?.length == 0 || false
 
   return (
-    <div className="flex flex-col gap-4 max-w-md mx-auto">
+    <div className="space-y-4 max-w-md mx-auto">
       <div className="space-y-1">
         <label className="block text-gray-700 text-sm font-bold" htmlFor="password">
           Password
@@ -111,19 +114,29 @@ export const AccountPassword = (props: AccountPasswordProps) => {
         </div>
       </div>
 
-      <div className={clsx('my-6 h-1 w-full bg-neutral-300 dark:bg-neutral-600 text-sm')}>
-        <div
-          className={clsx('h-1 w-full ml-0 transition-all ease float-left', pwStrengthColor())}
-          style={{
-            transform: `scaleX(${pwStrengthPercent()})`,
-            transformOrigin: '0%',
-          }}
-        ></div>
-
+      <div>
+        <div className={clsx('h-1 w-full bg-neutral-300 dark:bg-neutral-600 text-sm')}>
+          <div
+            className={clsx('h-1 w-full ml-0 transition-all ease float-left', pwStrengthColor())}
+            style={{
+              transform: `scaleX(${pwStrengthPercent()})`,
+              transformOrigin: '0%',
+            }}
+          ></div>
+        </div>
         <div className="flex w-full items-center gap-4 p-3 bg-zinc-200 dark:bg-zinc-800 dark:bg-opacity-60 rounded-b-md text-black/50 dark:text-white/50">
           {passwordIsStrong ? <FaCheck /> : <FaInfo />}
           {passwordIsStrong ? 'Strong password' : pwStrength?.feedback?.suggestions}
         </div>
+      </div>
+
+      <div className="flex items-center justify-between gap-2 py-2">
+        <div className="flex items-center gap-2">
+          {' '}
+          <FaShieldAlt className="text-emerald-500" />
+          <span className="text-neutral-500 text-sm">Remember password on this device </span>
+        </div>
+        <ToggleSwitch value={savePassword} onToggle={() => setSavePassword(!savePassword)} />
       </div>
     </div>
   )

--- a/frontend/components/onboarding/Stepper.tsx
+++ b/frontend/components/onboarding/Stepper.tsx
@@ -78,9 +78,9 @@ export const Stepper = (props: StepperProps) => {
         <div className="text-3xl text-black dark:text-white font-bold text-center">
           {props.steps[props.activeStep].title}
         </div>
-        <p className="text-black/30 dark:text-white/40 text-center text-lg">
+        <div className="text-black/30 dark:text-white/40 text-center text-lg">
           {props.steps[props.activeStep].description}
-        </p>
+        </div>
       </div>
     </div>
   )

--- a/frontend/graphql/mutations/createOrganisation.gql
+++ b/frontend/graphql/mutations/createOrganisation.gql
@@ -3,7 +3,7 @@ mutation CreateOrg($id: ID!, $name: String!, $identityKey: String!, $wrappedKeyr
     organisation {
       id
       name
-      createdAt
+      memberId
     }
   }
 }


### PR DESCRIPTION
## :mag: Overview

Release [v2.12.0](https://github.com/phasehq/console/releases/tag/v2.12.0) added support for storing sudo passwords in browser storage for more seasmless management of user keyrings. However, storing a password locally can only done via the unlock keyring dialog, but not when onboarding.

## :bulb: Proposed Changes

Add an option to save the sudo password locally on the device that a user onboards from. This can further improve the UX for managing user keyrings by removing the need to manual password entry immediately after onboarding.

## :framed_picture: Screenshots or Demo

![image](https://github.com/phasehq/console/assets/6710327/78d69558-a531-46ab-bff7-b5e1a8ae841b)

[Screencast from 03-29-2024 04:14:21 PM.webm](https://github.com/phasehq/console/assets/6710327/c1bb224f-8457-4e9d-9e35-93f63c6fd2c8)

## :memo: Release Notes

* Added an option to remember the user sudo password when signing up or joining on organisation.
* Misc UI cleanup to sidebar
* Automatically redirect to org home after onboard / recovery

### :dart: Reviewer Focus

* Sign up with a new organisation with / without the "Remember password" option. Check that the password is or is not saved locally, as per chosen setting. 
* Join an organisation via an invite with and withou the "Remember password" option. Check that the password is or is not saved locally, as per chosen setting. 

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



