### PR TITLE
feat: use stored device password for webauth

### DIFF
--- a/frontend/app/webauth/[requestCode]/page.tsx
+++ b/frontend/app/webauth/[requestCode]/page.tsx
@@ -21,7 +21,7 @@ import clsx from 'clsx'
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
 import { useContext, useEffect, useState } from 'react'
-import { FaChevronRight, FaExclamationTriangle, FaCheckCircle } from 'react-icons/fa'
+import { FaChevronRight, FaExclamationTriangle, FaCheckCircle, FaShieldAlt } from 'react-icons/fa'
 import { MdContentCopy } from 'react-icons/md'
 import { SiGithub, SiGnometerminal, SiSlack } from 'react-icons/si'
 import { toast } from 'react-toastify'
@@ -209,6 +209,9 @@ export default function WebAuth({ params }: { params: { requestCode: string } })
                   <span className="text-neutral-500">
                     <RoleLabel role={organisation.role!} />
                   </span>
+                  {deviceIsTrusted && (
+                    <FaShieldAlt className="text-emerald-500" title="Trusted device" />
+                  )}
                 </div>
                 <FaChevronRight
                   className={clsx(

--- a/frontend/components/common/Input.tsx
+++ b/frontend/components/common/Input.tsx
@@ -32,7 +32,7 @@ export const Input = (props: InputProps) => {
           className={clsx(
             'custom w-full text-zinc-800 dark:text-white bg-zinc-100 dark:bg-zinc-800 rounded-md',
             secret ? 'ph-no-capture' : '',
-            props.readOnly ? 'opacity-60' : ''
+            props.readOnly || props.disabled ? 'opacity-60' : ''
           )}
         />
         {secret && (


### PR DESCRIPTION
## :mag: Overview

CLI authentication with webauth requires manual entry of the sudo password even when the password is stored locally on the device.

## :bulb: Proposed Changes

Prefill the password field with the stored password when available. 

## :framed_picture: Screenshots or Demo

![image](https://github.com/phasehq/console/assets/6710327/8fc2b428-029d-4270-89d9-dde2467195c1)

![image](https://github.com/phasehq/console/assets/6710327/4ac4552f-1a05-4b1b-8436-3d37ed3116a6)


## :memo: Release Notes

Updated webauth page to use the stored device password when available to prefill the password field.

## :question: Open Questions

If a user only has a single organisation membership and a saved password, should we automatically trigger authentication without a manual click of the "Login" button?


## :sparkles: How to Test the Changes Locally

Test webauth flow for accounts with a locally stored password

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



