### PR TITLE
fix: refetch organisation list on signup

### DIFF
--- a/frontend/app/invite/[invite]/page.tsx
+++ b/frontend/app/invite/[invite]/page.tsx
@@ -3,6 +3,7 @@
 import { cryptoUtils } from '@/utils/auth'
 import VerifyInvite from '@/graphql/queries/organisation/validateOrganisationInvite.gql'
 import AcceptOrganisationInvite from '@/graphql/mutations/organisation/acceptInvite.gql'
+import GetOrganisations from '@/graphql/queries/getOrganisations.gql'
 import { useLazyQuery, useMutation } from '@apollo/client'
 import { HeroPattern } from '@/components/common/HeroPattern'
 import { Button } from '@/components/common/Button'
@@ -133,6 +134,7 @@ export default function Invite({ params }: { params: { invite: string } }) {
           wrappedRecovery: encryptedMnemonic,
           inviteId: invite.id,
         },
+        refetchQueries: [{ query: GetOrganisations }],
       })
 
       const memberId = data.createOrganisationMember.orgMember.id

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -14,6 +14,7 @@ import { toast } from 'react-toastify'
 import { useMutation } from '@apollo/client'
 import { useRouter } from 'next/navigation'
 import { CreateOrg } from '@/graphql/mutations/createOrganisation.gql'
+import GetOrganisations from '@/graphql/queries/getOrganisations.gql'
 import { copyRecoveryKit, generateRecoveryPdf } from '@/utils/recovery'
 import { setDevicePassword } from '@/utils/localStorage'
 
@@ -156,6 +157,7 @@ const Onboard = () => {
             wrappedKeyring: encryptedKeyring,
             wrappedRecovery: encryptedMnemonic,
           },
+          refetchQueries: [{ query: GetOrganisations }],
         })
         const { data } = result
         const newOrg = data.createOrganisation.organisation


### PR DESCRIPTION
## :mag: Overview

Release v2.17.0 added automatic redirection to the organisation home once onboarding was complete, however new users with no active memberships were getting redirected back to the signup page

## :bulb: Proposed Changes

Refetch the organisation memberships query once onboarding is complete is allow redirection to org home.

## :memo: Release Notes

Fixed a bug when signing up that caused redirection back to signup instead of org home for new users. 


## :sparkles: How to Test the Changes Locally

* Signup with an account that has no existing phase org memberships. Check that you are correctly redirected to org home.
* Accept an invite with no prior phase org memberships. Check that you are correctly redirected to org home.

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



