### PR TITLE
feat: use jetbrains mono, update tailwind font config

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,7 +1,7 @@
 import '@/app/globals.css'
 import Providers from './providers'
 
-import { Inter } from '@next/font/google'
+import { Inter, JetBrains_Mono } from 'next/font/google'
 import { ToastContainer } from 'react-toastify'
 import 'react-toastify/dist/ReactToastify.min.css'
 import '@/utils/logoAnimation.css'
@@ -12,6 +12,13 @@ const inter = Inter({
   weight: 'variable',
   subsets: ['latin'],
   display: 'swap',
+  variable: '--font-inter',
+})
+
+const jetbrains_mono = JetBrains_Mono({
+  subsets: ['latin'],
+  display: 'swap',
+  variable: '--font-jetbrains-mono',
 })
 
 // TODO: Set metadata for specific page routes
@@ -35,7 +42,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <Providers>
         <body
-          className={`${inter.className} w-full bg-neutral-200 dark:bg-neutral-900 min-h-screen antialiased`}
+          className={`${inter.variable} ${jetbrains_mono.variable} font-sans w-full bg-neutral-200 dark:bg-neutral-900 min-h-screen antialiased`}
         >
           <NextTopLoader color="#10B981" showSpinner={false} height={1} />
           <ToastContainer

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,6 @@
     "@apollo/client": "^3.8.10",
     "@headlessui/react": "^1.7.18",
     "@heroicons/react": "^2.1.1",
-    "@next/font": "14.1.0",
     "@tailwindcss/typography": "^0.5.10",
     "@types/node": "20.11.7",
     "@types/react": "^18.2.48",

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,6 +1,10 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['./app/**/*.{js,ts,jsx,tsx}', './pages/**/*.{js,ts,jsx,tsx}', './components/**/*.{js,ts,jsx,tsx}'],
+  content: [
+    './app/**/*.{js,ts,jsx,tsx}',
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
+  ],
   darkMode: 'class',
   theme: {
     fontSize: {
@@ -47,6 +51,10 @@ module.exports = {
         2.5: '0.025',
         7.5: '0.075',
         15: '0.15',
+      },
+      fontFamily: {
+        sans: ['var(--font-inter)'],
+        mono: ['var(--font-jetbrains-mono)'],
       },
     },
   },

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1785,11 +1785,6 @@
   dependencies:
     glob "10.3.10"
 
-"@next/font@14.1.0":
-  version "14.1.0"
-  resolved "https://registry.yarnpkg.com/@next/font/-/font-14.1.0.tgz#6f6c4510e36dad505cf64403f92f235d2838d265"
-  integrity sha512-9hJ7bEYDI7UGQ1a++5zRD3F2VUu9NIaK5Hro/uL9bvFFs6b0Cy1OdLtLQHCIQE7sSMt8Rbu4VtcbnlubsseelA==
-
 "@next/swc-darwin-arm64@14.1.0":
   version "14.1.0"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.1.0.tgz#70a57c87ab1ae5aa963a3ba0f4e59e18f4ecea39"


### PR DESCRIPTION
## :bulb: Proposed Changes

* Adds JetBrains Mono for use as the monospace font across the console
* Clean up the next/font and tailwind config
* Removed `@next/font` usage and dependency
* Set `font-sans` as the default font type

## :framed_picture: Screenshots or Demo

![Screenshot from 2024-04-18 18-50-43](https://github.com/phasehq/console/assets/6710327/a96d8dfd-f519-4c62-a8f1-e20bf712f899)

## :memo: Release Notes

Updated the monospace font to JetBrains Mono

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
- [x] Update dependencies and lockfiles (if required)
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



