### PR TITLE
fix: set correct sse context in personal secret serializer

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -112,7 +112,7 @@ class SecretSerializer(serializers.ModelSerializer):
                     secret=obj, user=org_member
                 )
                 return PersonalSecretSerializer(
-                    personal_secret, context={"sse": True}
+                    personal_secret, context={"sse": self.context.get("sse")}
                 ).data
             except PersonalSecret.DoesNotExist:
                 return None


### PR DESCRIPTION
## :mag: Overview

Fixes a bug with the `PersonalSecretSerializer`

## :bulb: Proposed Changes

Set the correct `sse` context to the PersonalSecretSerializer when resolving secret overrides.

## :memo: Release Notes

Fixes a bug with personal secrets that affected the CLI and API

## :sparkles: How to Test the Changes Locally

Ensure that overrides are correctly resolved / returned in both the CLI and API when using a PAT

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
- [x] Update dependencies and lockfiles (if required)
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



