### PR TITLE
Removed placeholder comments from sample secrets

### DIFF
--- a/backend/api/templates/backend/api/email_templates/user_joined_org.html
+++ b/backend/api/templates/backend/api/email_templates/user_joined_org.html
@@ -293,6 +293,28 @@
                           </div>
                         </td>
                       </tr>
+                      <tr>
+                        <td
+                          align="left"
+                          style="
+                            font-size: 0px;
+                            padding: 10px 25px;
+                            word-break: break-word;
+                          "
+                        >
+                          <div
+                            style="
+                              font-family: Arial, sans-serif;
+                              font-size: 16px;
+                              line-height: 1.25;
+                              text-align: left;
+                              color: #bbbbbb;
+                            "
+                          >
+                          You will need to add them to the specific Apps and Environments you would like them to access. You can do so from the App Members tab. Explore the docs for more information on managing user access.
+                          </div>
+                        </td>
+                      </tr>
                     </tbody>
                   </table>
                 </div>

--- a/frontend/app/[team]/members/page.tsx
+++ b/frontend/app/[team]/members/page.tsx
@@ -23,16 +23,7 @@ import { Button } from '@/components/common/Button'
 import { organisationContext } from '@/contexts/organisationContext'
 import { relativeTimeFromDates } from '@/utils/time'
 import { Dialog, Listbox, Transition } from '@headlessui/react'
-import {
-  FaCheckSquare,
-  FaChevronDown,
-  FaCopy,
-  FaPlus,
-  FaSquare,
-  FaTimes,
-  FaTrashAlt,
-  FaUserAlt,
-} from 'react-icons/fa'
+import { FaChevronDown, FaCopy, FaPlus, FaTimes, FaTrashAlt, FaUserAlt } from 'react-icons/fa'
 import clsx from 'clsx'
 import { cryptoUtils } from '@/utils/auth'
 import { copyToClipBoard } from '@/utils/clipboard'

--- a/frontend/app/[team]/members/page.tsx
+++ b/frontend/app/[team]/members/page.tsx
@@ -320,7 +320,7 @@ const InviteDialog = (props: { organisationId: string }) => {
 
                   <div className="space-y-4 divide-y divide-neutral-500/40">
                     <p className="text-neutral-500">
-                      Invite a user to join your Organisation on Phase.
+                      Invite a user to your Organisation.
                     </p>
                     <div>
                       {!inviteLink && (
@@ -332,10 +332,14 @@ const InviteDialog = (props: { organisationId: string }) => {
                           )}
 
                           <p className="text-neutral-500">
-                            Enter the email address of the user you want to invite below. An invite
-                            link will be sent by email to this user. They will be able to join your
-                            organisation by clicking the link in their email.
+                            Enter the email address of the user you want to invite below. An invitation link will be sent to this email address.
                           </p>
+
+                          <Alert variant="info" icon={true}>
+                            <p>
+                              You will need to manually provision access to <strong>  applications </strong> and  <strong> environments </strong> after the member has joined the organization.
+                            </p>
+                          </Alert>
                           <div className="w-full">
                             <Input
                               value={email}

--- a/frontend/components/apps/NewAppDialog.tsx
+++ b/frontend/components/apps/NewAppDialog.tsx
@@ -99,21 +99,21 @@ export default function NewAppDialog(props: { appCount: number; organisation: Or
       publicKey: await getUserKxPublicKey(keyring!.publicKey),
       privateKey: await getUserKxPrivateKey(keyring!.privateKey),
     }
-
+  
     const envSalt = await decryptAsymmetric(
       env.wrappedSalt,
       userKxKeys.privateKey,
       userKxKeys.publicKey
     )
-
+  
     const promises = secrets.map(async (secret) => {
       const { key, value, comment } = secret
-
+  
       const encryptedKey = await encryptAsymmetric(key!, env.identityKey)
       const encryptedValue = await encryptAsymmetric(value!, env.identityKey)
       const keyDigest = await digest(key!, envSalt)
       const encryptedComment = await encryptAsymmetric(comment!, env.identityKey)
-
+  
       await createSecret({
         variables: {
           newSecret: {
@@ -128,10 +128,10 @@ export default function NewAppDialog(props: { appCount: number; organisation: Or
         },
       })
     })
-
+  
     return Promise.all(promises)
   }
-
+  
   /**
    * Handles the creation of example secrets for a given app. Defines the set of example secrets, fetches all envs for this app and handles creation of each set of secrets with the respective envs
    *
@@ -143,63 +143,63 @@ export default function NewAppDialog(props: { appCount: number; organisation: Or
       {
         key: 'AWS_ACCESS_KEY_ID',
         value: 'AKIAIX4ONRSG6ODEFVJA',
-        comment: 'This is an example secret.',
+        comment: '',
       },
       {
         key: 'AWS_SECRET_ACCESS_KEY',
         value: 'aCRAMarEbFC3Q5c24pi7AVMIt6TaCfHeFZ4KCf/a',
-        comment: 'This is an example secret.',
+        comment: '',
       },
       {
         key: 'JWT_SECRET',
         value:
           'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlIjoic2VydmljZV9yb2xlIiwiaWF0IjoxNjMzNjIwMTcxLCJleHAiOjIyMDg5ODUyMDB9.pHnckabbMbwTHAJOkb5Z7G7B4chY6GllJf6K2m96z3A',
-        comment: 'This is an example secret.',
+          comment: '',
       },
       {
         key: 'STRIPE_SECRET_KEY',
         value: 'sk_test_EeHnL644i6zo4Iyq4v1KdV9H',
-        comment: 'This is an example secret.',
+        comment: '',
       },
       {
         key: 'DJANGO_SECRET_KEY',
         value: 'wwf*2#86t64!fgh6yav$aoeuo@u2o@fy&*gg76q!&%6x_wbduad',
-        comment: 'This is an example secret.',
+        comment: '',
       },
       {
         key: 'DJANGO_DEBUG',
         value: 'True',
-        comment: 'This is an example secret.',
+        comment: '',
       },
       {
         key: 'POSTGRES_CONNECTION_STRING',
         value: 'postgresql://${DB_USER}:${DB_PASSWORD}@${DB_HOST}:${DB_PORT}/${DB_NAME}',
-        comment: 'This is an example secret.',
+        comment: 'AWS RDS pgsql - us-west-1',
       },
       {
         key: 'DB_USER',
         value: 'postgres',
-        comment: 'This is an example secret.',
+        comment: '',
       },
       {
         key: 'DB_HOST',
         value: 'mc-laren-prod-db.c9ufzjtplsaq.us-west-1.rds.amazonaws.com',
-        comment: 'This is an example secret.',
+        comment: '',
       },
       {
         key: 'DB_NAME',
         value: 'XP1_LM',
-        comment: 'This is an example secret.',
+        comment: '',
       },
       {
         key: 'DB_PASSWORD',
         value: '6c37810ec6e74ec3228416d2844564fceb99ebd94b29f4334c244db011630b0e',
-        comment: 'This is an example secret.',
+        comment: '',
       },
       {
         key: 'DB_PORT',
         value: '5432',
-        comment: 'This is an example secret.',
+        comment: '',
       },
     ]
 
@@ -207,7 +207,7 @@ export default function NewAppDialog(props: { appCount: number; organisation: Or
       {
         key: 'DJANGO_DEBUG',
         value: 'False',
-        comment: 'This is an example secret.',
+        comment: '',
       },
     ]
 
@@ -215,12 +215,12 @@ export default function NewAppDialog(props: { appCount: number; organisation: Or
       {
         key: 'STRIPE_SECRET_KEY',
         value: 'sk_live_epISNGSkdeXov2frTey7RHAi',
-        comment: 'This is an example secret.',
+        comment: 'Stripe prod key - Stripe Atlas',
       },
       {
         key: 'DJANGO_DEBUG',
         value: 'False',
-        comment: 'This is an example secret.',
+        comment: '',
       },
     ]
 

--- a/frontend/components/common/Input.tsx
+++ b/frontend/components/common/Input.tsx
@@ -26,7 +26,7 @@ export const Input = (props: InputProps) => {
       <div className="flex justify-between w-full bg-zinc-100 dark:bg-zinc-800 ring-1 ring-inset ring-neutral-500/40  focus-within:ring-1 focus-within:ring-inset focus-within:ring-emerald-500 rounded-md p-px">
         <input
           {...props}
-          type={showValue || !secret ? 'text' : 'password'}
+          type={showValue || !secret ? props.type || 'text' : 'password'}
           value={value}
           onChange={(e) => setValue(e.target.value)}
           className={clsx(


### PR DESCRIPTION
## :mag: Overview

Removed secret placeholder example comments from most of the secrets in development, staging and production. To make the sample secret environment more cleaner.

## :framed_picture: Screenshots or Demo

Here's what a fresh development with sample secrets looks like:

![image](https://github.com/phasehq/console/assets/85357445/117e93cc-f215-49e7-9b9e-10da2fbce3aa)


### :green_heart: Did You...

- [ ] Ensure linting passes (code style checks)?
- [ ] Update dependencies and lockfiles (if required)
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



