### PR TITLE
fix: only add set-cookie header to signin response

### DIFF
--- a/frontend/pages/api/auth/[...nextauth].ts
+++ b/frontend/pages/api/auth/[...nextauth].ts
@@ -114,7 +114,8 @@ export const authOptions: NextAuthOptionsCallback = (_req, res) => {
               )
 
               // Add set-cookie header to response
-              res.setHeader('set-cookie', response.headers['set-cookie'])
+              if (response.headers['set-cookie'])
+                res.setHeader('set-cookie', response.headers['set-cookie'])
 
               // Add OAuth profile data to token
               token.user = profile

--- a/frontend/pages/api/auth/[...nextauth].ts
+++ b/frontend/pages/api/auth/[...nextauth].ts
@@ -113,9 +113,10 @@ export const authOptions: NextAuthOptionsCallback = (_req, res) => {
                 }
               )
 
-              Object.entries(response.headers).forEach(([k, v]) => {
-                res.setHeader(k, v)
-              })
+              // Add set-cookie header to response
+              res.setHeader('set-cookie', response.headers['set-cookie'])
+
+              // Add OAuth profile data to token
               token.user = profile
 
               return token


### PR DESCRIPTION
## :mag: Overview

The nextauth `jwt` callback currently add all response headers from the backend authentication POST request to the signIn response from Next.js. This causes several issues during authentication, mainly "Secure connection failed" errors on firefox that require downgrading to HTTP/1.1 in some cases.

## :bulb: Proposed Changes

Selectively add only the required headers to the response, i.e the `set-cookie` header in this case. This should fix the "Secure connection failed" errors on firefox with error codes `NS_ERROR_NET_INTERRUPT` and `NS_ERROR_PARTIAL_TRANSFER`. This will also allow internal api calls between the frontend Node.js server and the backend Django API on `http://backend:8000` for example.

Fixes #232 

## :memo: Release Notes

Fixed an issue with response headers during authentication that caused "Secure connection failed" errors on firefox.

### :dart: Reviewer Focus

Test that logins work correctly on HTTP/2 or HTTP/3 with
* `BACKEND_API_BASE=${HTTP_PROTOCOL}${HOST}/service`
* `BACKEND_API_BASE=http://backend:800`
* Behind an AWS load balancer
* Behind Cloudflare or other reverse proxy


### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



