### PR TITLE
fix: default reveal regression in secret row

### DIFF
--- a/frontend/components/environments/secrets/SecretRow.tsx
+++ b/frontend/components/environments/secrets/SecretRow.tsx
@@ -71,7 +71,7 @@ export default function SecretRow(props: {
 
   // Handle global reveal
   useEffect(() => {
-    if (!isBoolean || globallyRevealed) setIsRevealed(globallyRevealed)
+    if ((!isBoolean || globallyRevealed) && cannonicalSecret) setIsRevealed(globallyRevealed)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [globallyRevealed, isBoolean])
 


### PR DESCRIPTION
## :mag: Overview

Fixes a regression that caused newly created secrets to not be revealed by default. This was introduced in the "global reveal" feature

## :framed_picture: Screenshots or Demo
[Screencast from 05-23-2024 07:02:36 PM.webm](https://github.com/phasehq/console/assets/6710327/5102066e-188e-4068-bd50-38361caf1170)

## :memo: Release Notes

Fixed a bug that cause newly created secrets to not be revealed by default

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



