### PR TITLE
fix: api token code snippets

### DIFF
--- a/frontend/components/apps/tokens/CreateServiceTokenDialog.tsx
+++ b/frontend/components/apps/tokens/CreateServiceTokenDialog.tsx
@@ -27,6 +27,7 @@ import { CreateNewServiceToken } from '@/graphql/mutations/environments/createSe
 import Link from 'next/link'
 import { ExpiryOptionT, humanReadableExpiry, tokenExpiryOptions } from '@/utils/tokens'
 import { getApiHost } from '@/utils/appConfig'
+import { EnableSSEDialog } from '../EnableSSEDialog'
 
 const compareExpiryOptions = (a: ExpiryOptionT, b: ExpiryOptionT) => {
   return a.getExpiry() === b.getExpiry()
@@ -287,62 +288,80 @@ export const CreateServiceTokenDialog = (props: { organisationId: string; appId:
                             </div>
                           </Tab.Panel>
                           <Tab.Panel>
-                            <div className="space-y-6">
-                              <div className="bg-zinc-300/50 dark:bg-zinc-800/50 shadow-inner p-3 rounded-lg group relative">
-                                <div className="w-full flex items-center justify-between pb-4">
-                                  <span className="uppercase text-xs tracking-widest text-gray-500">
-                                    API token
-                                  </span>
-                                  <div className="flex gap-4 items-center">
-                                    {apiServiceToken && (
-                                      <div className="">
-                                        <CopyButton value={apiServiceToken} />
-                                      </div>
-                                    )}
+                            {data.sseEnabled ? (
+                              <div className="space-y-6">
+                                <div className="bg-zinc-300/50 dark:bg-zinc-800/50 shadow-inner p-3 rounded-lg group relative">
+                                  <div className="w-full flex items-center justify-between pb-4">
+                                    <span className="uppercase text-xs tracking-widest text-gray-500">
+                                      API token
+                                    </span>
+                                    <div className="flex gap-4 items-center">
+                                      {apiServiceToken && (
+                                        <div className="">
+                                          <CopyButton value={apiServiceToken} />
+                                        </div>
+                                      )}
+                                    </div>
                                   </div>
+                                  <code className="text-xs break-all text-emerald-500 ph-no-capture">
+                                    {apiServiceToken}
+                                  </code>
                                 </div>
-                                <code className="text-xs break-all text-emerald-500 ph-no-capture">
-                                  {apiServiceToken}
-                                </code>
-                              </div>
 
-                              <div className="bg-zinc-300/50 dark:bg-zinc-800/50 shadow-inner p-3 rounded-lg group relative">
-                                <div className="w-full flex items-center justify-between pb-4">
-                                  <span className="uppercase text-xs tracking-widest text-gray-500">
-                                    app id
-                                  </span>
-                                  <div className="flex gap-4 items-center">
-                                    {apiServiceToken && (
-                                      <div className="">
-                                        <CopyButton value={appId} />
-                                      </div>
-                                    )}
+                                <div className="bg-zinc-300/50 dark:bg-zinc-800/50 shadow-inner p-3 rounded-lg group relative">
+                                  <div className="w-full flex items-center justify-between pb-4">
+                                    <span className="uppercase text-xs tracking-widest text-gray-500">
+                                      app id
+                                    </span>
+                                    <div className="flex gap-4 items-center">
+                                      {apiServiceToken && (
+                                        <div className="">
+                                          <CopyButton value={appId} />
+                                        </div>
+                                      )}
+                                    </div>
                                   </div>
+                                  <code className="text-xs break-all text-neutral-500 ph-no-capture">
+                                    {appId}
+                                  </code>
                                 </div>
-                                <code className="text-xs break-all text-neutral-500 ph-no-capture">
-                                  {appId}
-                                </code>
-                              </div>
 
-                              <div className="pt-4 border-t border-neutral-500/20 space-y-2">
-                                <div className="flex items-center justify-between">
-                                  <div className="text-neutral-500 text-sm">
-                                    Example with <code>curl</code>
+                                <div className="pt-4 border-t border-neutral-500/20 space-y-2">
+                                  <div className="flex items-center justify-between">
+                                    <div className="text-neutral-500 text-sm">
+                                      Example with <code>curl</code>
+                                    </div>
+                                    <Link
+                                      href="https://docs.phase.dev/public-api"
+                                      target="_blank"
+                                      rel="noreferrer"
+                                    >
+                                      <Button variant="secondary">View Docs</Button>
+                                    </Link>
                                   </div>
-                                  <Link
-                                    href="https://docs.phase.dev/public-api"
-                                    target="_blank"
-                                    rel="noreferrer"
-                                  >
-                                    <Button variant="secondary">View Docs</Button>
-                                  </Link>
+                                  <CliCommand
+                                    prefix="curl"
+                                    command={`--request GET --url '${getApiHost()}/v1/secrets/?app_id=${appId}&env=development' --header 'Authorization: Bearer ${apiServiceToken}'`}
+                                  />
                                 </div>
-                                <CliCommand
-                                  prefix="curl"
-                                  command={`--request GET --url '${getApiHost()}/v1/secrets?app_id=${appId}&env=development' --header 'Authorization: ${apiServiceToken}'`}
-                                />
                               </div>
-                            </div>
+                            ) : (
+                              <div className="space-y-2 p-8 bg-zinc-200 dark:bg-zinc-800 rounded-lg">
+                                <div className="text-center">
+                                  <div className="text-lg font-semibold text-black dark:text-white">
+                                    Server-side encryption (SSE)
+                                  </div>
+                                  <div className="text-neutral-500 text-base">
+                                    SSE is not enabled for this app. SSE is required to use this
+                                    token with the REST API.
+                                  </div>
+                                </div>
+
+                                <div className="flex justify-center">
+                                  <EnableSSEDialog appId={appId} />
+                                </div>
+                              </div>
+                            )}
                           </Tab.Panel>
                         </Tab.Panels>
                       </Tab.Group>

--- a/frontend/components/apps/tokens/CreateUserTokenDialog.tsx
+++ b/frontend/components/apps/tokens/CreateUserTokenDialog.tsx
@@ -9,7 +9,14 @@ import { useMutation } from '@apollo/client'
 import { Dialog, RadioGroup, Tab, Transition } from '@headlessui/react'
 import clsx from 'clsx'
 import { useContext, useState, Fragment } from 'react'
-import { FaPlus, FaTimes, FaCircle, FaCheckCircle } from 'react-icons/fa'
+import {
+  FaPlus,
+  FaTimes,
+  FaCircle,
+  FaCheckCircle,
+  FaExternalLinkAlt,
+  FaExternalLinkSquareAlt,
+} from 'react-icons/fa'
 import { toast } from 'react-toastify'
 import { CreateNewUserToken } from '@/graphql/mutations/users/createUserToken.gql'
 import { GetUserTokens } from '@/graphql/queries/users/getUserTokens.gql'
@@ -157,6 +164,22 @@ export const CreateUserTokenDialog = (props: { organisationId: string }) => {
                         Copy this token. You won&apos;t see it again!
                       </Alert>
 
+                      <Alert variant="info" size="sm">
+                        <div>
+                          You will need to enable server-side encryption (SSE) for any Apps that you
+                          want to manage secrets with via the Public API.
+                          <Link
+                            href="https://docs.phase.dev/console/apps#settings"
+                            target="_blank"
+                            rel="noreferrer"
+                          >
+                            <div className="flex items-center gap-1 underline">
+                              Docs <FaExternalLinkSquareAlt />
+                            </div>
+                          </Link>
+                        </div>
+                      </Alert>
+
                       <Tab.Group>
                         <Tab.List className="flex gap-4 w-full border-b border-neutral-500/20">
                           <Tab as={Fragment}>
@@ -245,7 +268,7 @@ export const CreateUserTokenDialog = (props: { organisationId: string }) => {
                                 </div>
                                 <CliCommand
                                   prefix="curl"
-                                  command={`--request GET --url '${getApiHost()}/v1/secrets?app_id=\${appId}&env=development' --header 'Authorization: ${apiUserToken}'`}
+                                  command={`--request GET --url '${getApiHost()}/v1/secrets/?app_id=\${appId}&env=development' --header 'Authorization: Bearer ${apiUserToken}'`}
                                 />
                               </div>
                             </div>

--- a/frontend/components/apps/tokens/CreateUserTokenDialog.tsx
+++ b/frontend/components/apps/tokens/CreateUserTokenDialog.tsx
@@ -9,14 +9,7 @@ import { useMutation } from '@apollo/client'
 import { Dialog, RadioGroup, Tab, Transition } from '@headlessui/react'
 import clsx from 'clsx'
 import { useContext, useState, Fragment } from 'react'
-import {
-  FaPlus,
-  FaTimes,
-  FaCircle,
-  FaCheckCircle,
-  FaExternalLinkAlt,
-  FaExternalLinkSquareAlt,
-} from 'react-icons/fa'
+import { FaPlus, FaTimes, FaCircle, FaCheckCircle, FaExternalLinkSquareAlt } from 'react-icons/fa'
 import { toast } from 'react-toastify'
 import { CreateNewUserToken } from '@/graphql/mutations/users/createUserToken.gql'
 import { GetUserTokens } from '@/graphql/queries/users/getUserTokens.gql'

--- a/frontend/components/apps/tokens/CreateUserTokenDialog.tsx
+++ b/frontend/components/apps/tokens/CreateUserTokenDialog.tsx
@@ -157,22 +157,6 @@ export const CreateUserTokenDialog = (props: { organisationId: string }) => {
                         Copy this token. You won&apos;t see it again!
                       </Alert>
 
-                      <Alert variant="info" size="sm">
-                        <div>
-                          You will need to enable server-side encryption (SSE) for any Apps that you
-                          want to manage secrets with via the Public API.
-                          <Link
-                            href="https://docs.phase.dev/console/apps#settings"
-                            target="_blank"
-                            rel="noreferrer"
-                          >
-                            <div className="flex items-center gap-1 underline">
-                              Docs <FaExternalLinkSquareAlt />
-                            </div>
-                          </Link>
-                        </div>
-                      </Alert>
-
                       <Tab.Group>
                         <Tab.List className="flex gap-4 w-full border-b border-neutral-500/20">
                           <Tab as={Fragment}>
@@ -228,6 +212,22 @@ export const CreateUserTokenDialog = (props: { organisationId: string }) => {
                           </Tab.Panel>
                           <Tab.Panel>
                             <div className="space-y-6">
+                              <Alert variant="info" size="sm">
+                                <div>
+                                  You will need to enable server-side encryption (SSE) for any Apps
+                                  that you want to manage secrets with via the Public API.
+                                  <Link
+                                    href="https://docs.phase.dev/console/apps#settings"
+                                    target="_blank"
+                                    rel="noreferrer"
+                                  >
+                                    <div className="flex items-center gap-1 underline">
+                                      Docs <FaExternalLinkSquareAlt />
+                                    </div>
+                                  </Link>
+                                </div>
+                              </Alert>
+
                               <div className="bg-zinc-300/50 dark:bg-zinc-800/50 shadow-inner p-3 rounded-lg group relative">
                                 <div className="w-full flex items-center justify-between pb-4">
                                   <span className="uppercase text-xs tracking-widest text-gray-500">

--- a/frontend/graphql/queries/secrets/getAppEnvironments.gql
+++ b/frontend/graphql/queries/secrets/getAppEnvironments.gql
@@ -13,4 +13,5 @@ query GetAppEnvironments($appId: ID!, $memberId: ID) {
     secretCount
     folderCount
   }
+  sseEnabled(appId: $appId)
 }


### PR DESCRIPTION
## :mag: Overview

This PR fixes incorrect example code snippets when creating api tokens, and adds a check for app encryption mode where possible.

## :bulb: Proposed Changes

* Added a trailing slash and the missing `Bearer` prefix to `Authorization` headers in the example curl requests
* Added a check for the App encryption mode before allowing API service tokens to be created. If SSE is not enabled, a dialog to enable this is shown first
* Added an info alert when creating API PATs to inform users to enable SSE before being able to use the token

## :framed_picture: Screenshots or Demo

### Service tokens

[Screencast from 05-29-2024 02:11:43 PM.webm](https://github.com/phasehq/console/assets/6710327/caac1bfb-91ff-4993-b7a2-6331b2bad9ff)

### User tokens

![Screenshot from 2024-05-29 14-24-35](https://github.com/phasehq/console/assets/6710327/8d5fa007-35d2-4841-882e-0277eb1caf1b)



## :memo: Release Notes

* Fixed incorrect example code snippets when creating API tokens
* Added a step to enable SSE (if disabled) when creating App Service tokens

### :heavy_plus_sign: Additional Context

The enable SSE step cannot be currently added when creating PATs since these are scoped directly to the user rather than a specific App

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



