### PR TITLE
fix: org navigation loop

### DIFF
--- a/frontend/app/[team]/layout.tsx
+++ b/frontend/app/[team]/layout.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import '@/app/globals.css'
-import { HeroPattern } from '@/components/common/HeroPattern'
 import { NavBar } from '@/components/layout/Navbar'
 import Sidebar from '@/components/layout/Sidebar'
 import { organisationContext } from '@/contexts/organisationContext'
@@ -41,11 +40,6 @@ export default function RootLayout({
       else router.push(`/`)
     }
   }, [organisations, params.team, router, loading, setActiveOrganisation])
-
-  useEffect(() => {
-    if (activeOrganisation && params.team !== activeOrganisation.name)
-      router.push(`/${activeOrganisation.name}`)
-  }, [activeOrganisation, params.team, router])
 
   const path = usePathname()
 

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { usePathname, useRouter } from 'next/navigation'
+import { usePathname } from 'next/navigation'
 import clsx from 'clsx'
 import {
   FaChevronDown,
@@ -50,16 +50,11 @@ const SidebarLink = (props: SidebarLinkT) => {
 const Sidebar = () => {
   const team = usePathname()?.split('/')[1]
 
-  const { organisations, activeOrganisation, setActiveOrganisation } =
-    useContext(organisationContext)
+  const { organisations, activeOrganisation } = useContext(organisationContext)
 
   const showOrgsMenu = organisations === null ? false : organisations?.length > 1
 
   const OrgsMenu = () => {
-    const switchOrg = (org: OrganisationType) => {
-      setActiveOrganisation(org)
-    }
-
     return (
       <Menu as="div" className="relative inline-block text-left ">
         {({ open }) => (
@@ -88,18 +83,19 @@ const Sidebar = () => {
                     {organisations?.map((org: OrganisationType) => (
                       <Menu.Item key={org.id}>
                         {({ active }) => (
-                          <button
-                            onClick={() => switchOrg(org)}
-                            title={`Switch to ${org.name}`}
-                            className={`${
-                              active
-                                ? 'hover:text-emerald-500 dark:text-white dark:hover:text-emerald-500'
-                                : 'text-gray-900 dark:text-white dark:hover:text-emerald-500'
-                            } group flex w-full  gap-2 items-center justify-between rounded-md px-2 py-2 text-base font-medium`}
-                          >
-                            <span className="truncate w-[80%] text-left">{org.name}</span>
-                            <FaExchangeAlt />
-                          </button>
+                          <Link href={`/${org.name}`}>
+                            <div
+                              title={`Switch to ${org.name}`}
+                              className={`${
+                                active
+                                  ? 'hover:text-emerald-500 dark:text-white dark:hover:text-emerald-500'
+                                  : 'text-gray-900 dark:text-white dark:hover:text-emerald-500'
+                              } group flex w-full  gap-2 items-center justify-between rounded-md px-2 py-2 text-base font-medium`}
+                            >
+                              <span className="truncate w-[80%] text-left">{org.name}</span>
+                              <FaExchangeAlt />
+                            </div>
+                          </Link>
                         )}
                       </Menu.Item>
                     ))}


### PR DESCRIPTION
## :mag: Overview

Using the browser 'Back' action to switch between Organisations caused the organisation context to infinitely loop between the current and previous orgs

## :bulb: Proposed Changes

Use a `<Link>` to switch orgs rather than directly manipulating the context value. This will make sure the context value and route params remain in sync

## :memo: Release Notes

Fixed a bug when using the browser 'Back' action to move between Organisations

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
- [x] Verify the app builds locally?
- [ ] Manually test the changes on different browsers/devices?



