### PR TITLE
feat: enable http2

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    listen 443 ssl;
+    listen 443 ssl http2;
 
     ssl_certificate /etc/nginx/ssl/nginx.crt;
     ssl_certificate_key /etc/nginx/ssl/nginx.key;


### PR DESCRIPTION
## :mag: Overview

Enabled HTTP2 in nginx config. 

## :bulb: Proposed Changes

HTTP2 needs to be manually enabled on a nginx instance. HTTP2 should improve network performance for the Phase Console and the API/

## :framed_picture: Screenshots or Demo
```fish
λ curl -I -s --http2 https://console.phase.dev
HTTP/2 307 
```

## :sparkles: How to Test the Changes Locally

Run the new nginx config and use any http client like curl to verify that HTTP2 is enabled.

```fish
curl -I -s --http2 https://<HOST>
```

### :green_heart: Did You...

- [ ] Ensure linting passes (code style checks)?
- [ ] Update dependencies and lockfiles (if required)
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



