### PR TITLE
fix: use backend:8000 for BACKEND_API_BASE in frontend container env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     env_file: .env
     environment:
       NEXTAUTH_URL: "${HTTP_PROTOCOL}${HOST}"
-      BACKEND_API_BASE: "${HTTP_PROTOCOL}${HOST}/service"
+      BACKEND_API_BASE: "http://backend:8000"
       NEXT_PUBLIC_BACKEND_API_BASE: "${HTTP_PROTOCOL}${HOST}/service"
       NEXT_PUBLIC_NEXTAUTH_PROVIDERS: "${SSO_PROVIDERS}"
     networks:


### PR DESCRIPTION
## :mag: Overview

The `BACKEND_API_BASE` in the frontend env uses `localhost` by default, which resolves within the container and doesn't allow connections to the backend.

## :bulb: Proposed Changes

Use `http://backend:8000` to allow the frontend container to make requests the backend within the internal network, even if the `HOST` is locahost. 

Fixes #270 

## :memo: Release Notes

Updated the BACKEND_API_BASE to work correctly even when using `HOST=localhost`

## :sparkles: How to Test the Changes Locally

Spin up the Console using `docker-compose.yml` and the example env

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



