### PR TITLE
fix: new secret overrides, tag history rendering

### DIFF
--- a/frontend/components/environments/secrets/SecretPropertyDiffs.tsx
+++ b/frontend/components/environments/secrets/SecretPropertyDiffs.tsx
@@ -52,14 +52,16 @@ export const SecretPropertyDiffs = (props: {
             <span className="text-neutral-500 mr-2">VALUE:</span>
           </div>
           <div className="flex flex-col">
-            <div className="flex items-center justify-between bg-red-200 dark:bg-red-950">
-              <s className=" text-red-500 ph-no-capture">{previousItem.value}</s>
+            <div className="flex-1 items-end gap-4 justify-between bg-red-200 dark:bg-red-950">
+              <div>
+                <s className=" text-red-500 ph-no-capture">{previousItem.value}</s>
+              </div>
               <Button
                 variant="outline"
                 onClick={() => handleRestoreValue(previousItem.value)}
                 title="Restore this value"
               >
-                <FaRedoAlt />
+                <FaRedoAlt className="shrink-0" />
                 <span className="font-sans text-xs">Restore</span>
               </Button>
             </div>

--- a/frontend/components/environments/secrets/SecretPropertyDiffs.tsx
+++ b/frontend/components/environments/secrets/SecretPropertyDiffs.tsx
@@ -85,12 +85,12 @@ export const SecretPropertyDiffs = (props: {
       {!areTagsAreSame(historyItem!.tags, previousItem.tags) && (
         <div className="pl-3 font-mono break-all">
           <span className="text-neutral-500 mr-2">TAGS:</span>
-          <div className="bg-red-200 dark:bg-red-950 text-red-500 flex-1 w-min gap-2 rounded-full">
+          <div className="bg-red-200 dark:bg-red-950 text-red-500 flex-1 w-max gap-2 rounded-full">
             {getRemovedTags().map((tag) => (
               <Tag key={tag.id} tag={tag} />
             ))}
           </div>
-          <div className="bg-emerald-100 dark:bg-emerald-950 text-emerald-500 flex-1 w-min gap-2 rounded-full">
+          <div className="bg-emerald-100 dark:bg-emerald-950 text-emerald-500 flex-1 w-max gap-2 rounded-full">
             {getAddedTags().map((tag) => (
               <Tag key={tag.id} tag={tag} />
             ))}

--- a/frontend/components/environments/secrets/SecretPropertyDiffs.tsx
+++ b/frontend/components/environments/secrets/SecretPropertyDiffs.tsx
@@ -85,12 +85,12 @@ export const SecretPropertyDiffs = (props: {
       {!areTagsAreSame(historyItem!.tags, previousItem.tags) && (
         <div className="pl-3 font-mono break-all">
           <span className="text-neutral-500 mr-2">TAGS:</span>
-          <div className="bg-red-200 dark:bg-red-950 text-red-500 flex w-min gap-2 rounded-full">
+          <div className="bg-red-200 dark:bg-red-950 text-red-500 flex-1 w-min gap-2 rounded-full">
             {getRemovedTags().map((tag) => (
               <Tag key={tag.id} tag={tag} />
             ))}
           </div>
-          <div className="bg-emerald-100 dark:bg-emerald-950 text-emerald-500 flex w-min gap-2 rounded-full">
+          <div className="bg-emerald-100 dark:bg-emerald-950 text-emerald-500 flex-1 w-min gap-2 rounded-full">
             {getAddedTags().map((tag) => (
               <Tag key={tag.id} tag={tag} />
             ))}

--- a/frontend/components/environments/secrets/SecretPropertyDiffs.tsx
+++ b/frontend/components/environments/secrets/SecretPropertyDiffs.tsx
@@ -87,14 +87,21 @@ export const SecretPropertyDiffs = (props: {
       {!areTagsAreSame(historyItem!.tags, previousItem.tags) && (
         <div className="pl-3 font-mono break-all">
           <span className="text-neutral-500 mr-2">TAGS:</span>
-          <div className="bg-red-200 dark:bg-red-950 text-red-500 flex-1 w-max gap-2 rounded-full">
+          <div className="inline-flex gap-2">
             {getRemovedTags().map((tag) => (
-              <Tag key={tag.id} tag={tag} />
+              <div key={tag.id} className="bg-red-200 dark:bg-red-950 text-red-500 rounded-full">
+                <Tag tag={tag} />
+              </div>
             ))}
           </div>
-          <div className="bg-emerald-100 dark:bg-emerald-950 text-emerald-500 flex-1 w-max gap-2 rounded-full">
+          <div className="inline-flex gap-2">
             {getAddedTags().map((tag) => (
-              <Tag key={tag.id} tag={tag} />
+              <div
+                key={tag.id}
+                className="bg-emerald-100 dark:bg-emerald-950 text-emerald-500 rounded-full"
+              >
+                <Tag tag={tag} />
+              </div>
             ))}
           </div>
         </div>

--- a/frontend/components/environments/secrets/SecretRow.tsx
+++ b/frontend/components/environments/secrets/SecretRow.tsx
@@ -201,19 +201,21 @@ export default function SecretRow(props: {
             />
           </div>
 
-          <div
-            className={clsx(
-              (!secret.override || !secret.override.isActive) &&
-                'opacity-0 group-hover:opacity-100 transition-opacity ease'
-            )}
-          >
-            <OverrideDialog
-              secretName={secret.key}
-              secretId={secret.id}
-              environment={props.environment}
-              override={secret.override!}
-            />
-          </div>
+          {cannonicalSecret && (
+            <div
+              className={clsx(
+                (!secret.override || !secret.override.isActive) &&
+                  'opacity-0 group-hover:opacity-100 transition-opacity ease'
+              )}
+            >
+              <OverrideDialog
+                secretName={secret.key}
+                secretId={secret.id}
+                environment={props.environment}
+                override={secret.override!}
+              />
+            </div>
+          )}
 
           {cannonicalSecret && (
             <div className="opacity-0 group-hover:opacity-100 transition-opacity ease">


### PR DESCRIPTION
## :mag: Overview

* Fixes an issue with secret overrides for new secrets
* Fixes a UI issue with rendering of tags in secret history

## :bulb: Proposed Changes

### Personal secret overrides for new secrets
Disabled the personal secret override button for new secrets till they are saved, since creating a secret override currently requires the secret uuid from the server.

### Tag rendering
Fixed the rendering of tags in the secret history dialog. Fixes #273 

## :framed_picture: Screenshots or Demo

### Overrides

[new-secret-override.webm](https://github.com/phasehq/console/assets/6710327/f8e393b0-f4b4-4a68-a78c-2ffa4b6bff77)

### Tags

**Before**
![Screenshot from 2024-06-19 20-25-58](https://github.com/phasehq/console/assets/6710327/c850a565-3e61-4937-85da-92d8d9e27260)

**After**
![Screenshot from 2024-06-19 20-25-19](https://github.com/phasehq/console/assets/6710327/04ae936d-fe26-45f7-9626-6c5f4084ebef)

## :memo: Release Notes

* New secrets must now be saved before attempting to override them
* Fixed a rendering issue with secret tags in secret history


### :heavy_plus_sign: Additional Context

We should consider adding support for creating a secret and setting a personal override in a single operation.

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



