### PR TITLE
fix: cloudflare syncs

### DIFF
--- a/backend/api/tasks.py
+++ b/backend/api/tasks.py
@@ -193,7 +193,7 @@ def perform_cloudflare_pages_sync(environment_sync):
             .first()
         )
 
-        kv_pairs = get_environment_secrets(
+        secrets = get_environment_secrets(
             environment_sync.environment, environment_sync.path
         )
 
@@ -209,7 +209,7 @@ def perform_cloudflare_pages_sync(environment_sync):
         project_info = environment_sync.options
 
         success, sync_data = sync_cloudflare_secrets(
-            kv_pairs,
+            secrets,
             account_id,
             access_token,
             project_info["project_name"],

--- a/backend/api/utils/syncing/cloudflare/pages.py
+++ b/backend/api/utils/syncing/cloudflare/pages.py
@@ -84,12 +84,12 @@ def sync_cloudflare_secrets(
         )
 
         new_vars = {}
-        for key, value in secrets:
+        for key, value, _ in secrets:
             new_vars[key] = {"type": "secret_text", "value": value}
 
         if existing_vars is not None:
             for existing_key in existing_vars:
-                if not any(key == existing_key for key, value in secrets):
+                if not any(key == existing_key for key, _, _ in secrets):
                     new_vars[existing_key] = None
 
         payload = {


### PR DESCRIPTION
## :mag: Overview

Fixes a regression that broke Cloudflare Pages syncing. This issue was introduced in [v2.26.0](https://github.com/phasehq/console/releases/tag/v2.26.0) that added support for syncing secret comments.

## :bulb: Proposed Changes

Updated worker logic to handle 3-element tuples (key, value, comment) per secret.

## :memo: Release Notes

Fixed a regression with sync jobs for Cloudflare Pages

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



