### PR TITLE
feat: add support for creating and updating secret overrides via the api

### DIFF
--- a/backend/api/views/secrets.py
+++ b/backend/api/views/secrets.py
@@ -217,7 +217,7 @@ class E2EESecretsView(APIView):
                     user=request.auth["org_member"],
                     defaults={
                         "value": secret["override"]["value"],
-                        "is_active": secret["override"]["is_active"],
+                        "is_active": secret["override"]["isActive"],
                         "updated_at": timezone.now(),
                     },
                 )
@@ -515,7 +515,7 @@ class PublicSecretsView(APIView):
                     user=request.auth["org_member"],
                     defaults={
                         "value": secret["override"]["value"],
-                        "is_active": secret["override"]["is_active"],
+                        "is_active": secret["override"]["isActive"],
                         "updated_at": timezone.now(),
                     },
                 )

--- a/backend/api/views/secrets.py
+++ b/backend/api/views/secrets.py
@@ -1,6 +1,7 @@
 from api.auth import PhaseTokenAuthentication
 from api.models import (
     Environment,
+    PersonalSecret,
     Secret,
     SecretEvent,
     SecretTag,
@@ -141,6 +142,14 @@ class E2EESecretsView(APIView):
                 user_agent,
             )
 
+            # If the request is authenticated as a user and an override is supplied
+            if request.auth["org_member"] and "override" in secret:
+                PersonalSecret.objects.create(
+                    secret=secret_obj,
+                    user=request.auth["org_member"],
+                    value=secret["override"]["value"],
+                )
+
         return Response(status=status.HTTP_200_OK)
 
     def put(self, request):
@@ -200,6 +209,18 @@ class E2EESecretsView(APIView):
                 ip_address,
                 user_agent,
             )
+
+            # If the request is authenticated as a user and an override is supplied
+            if request.auth["org_member"] and "override" in secret:
+                PersonalSecret.objects.update_or_create(
+                    secret=secret_obj,
+                    user=request.auth["org_member"],
+                    defaults={
+                        "value": secret["override"]["value"],
+                        "is_active": secret["override"]["is_active"],
+                        "updated_at": timezone.now(),
+                    },
+                )
 
         return Response(status=status.HTTP_200_OK)
 
@@ -319,6 +340,10 @@ class PublicSecretsView(APIView):
                 secret["comment"] = encrypt_asymmetric(secret["comment"], env_pubkey)
             else:
                 secret["comment"] = ""
+            if "override" in secret:
+                secret["override"]["value"] = encrypt_asymmetric(
+                    (secret["override"]["value"]), env_pubkey
+                )
 
         if check_for_duplicates_blind(secrets, env):
             return JsonResponse({"error": "Duplicate secret found"}, status=409)
@@ -367,6 +392,14 @@ class PublicSecretsView(APIView):
                 user_agent,
             )
 
+            # If the request is authenticated as a user and an override is supplied
+            if request.auth["org_member"] and "override" in secret:
+                PersonalSecret.objects.create(
+                    secret=secret_obj,
+                    user=request.auth["org_member"],
+                    value=secret["override"]["value"],
+                )
+
             created_secrets.append(secret_obj)
 
         serializer = SecretSerializer(
@@ -405,6 +438,10 @@ class PublicSecretsView(APIView):
 
                 if check_for_duplicates_blind(secrets, env):
                     return JsonResponse({"error": "Duplicate secret found"}, status=409)
+            if "override" in secret:
+                secret["override"]["value"] = encrypt_asymmetric(
+                    (secret["override"]["value"]), env_pubkey
+                )
 
         updated_secrets = []
 
@@ -470,6 +507,18 @@ class PublicSecretsView(APIView):
                 ip_address,
                 user_agent,
             )
+
+            # If the request is authenticated as a user and an override is supplied
+            if request.auth["org_member"] and "override" in secret:
+                PersonalSecret.objects.update_or_create(
+                    secret=secret_obj,
+                    user=request.auth["org_member"],
+                    defaults={
+                        "value": secret["override"]["value"],
+                        "is_active": secret["override"]["is_active"],
+                        "updated_at": timezone.now(),
+                    },
+                )
 
             updated_secrets.append(secret_obj)
 


### PR DESCRIPTION
## :mag: Overview

Secret overrides are returned by the API but cannot be created or updated.

## :bulb: Proposed Changes

Add support for creating and updating personal secret overrides via the API. 


## :memo: Release Notes

Added support for creating and updating personal secret overrides via the API

### :dart: Reviewer Focus

Check that overrides are created and updated correctly via the API.

### :heavy_plus_sign: Additional Context

Overrides can only be toggled off via the API for now. Deleting overrides can be done via the Console only. Support for deleting overrides over the API can be added in the future if required.

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



