### PR TITLE
feat: validate private api encrypted data format

### DIFF
--- a/backend/api/utils/crypto.py
+++ b/backend/api/utils/crypto.py
@@ -1,3 +1,4 @@
+import re
 from nacl.hash import blake2b
 from nacl.utils import random
 from base64 import b64encode, b64decode
@@ -16,6 +17,7 @@ from nacl.encoding import RawEncoder
 from typing import Tuple
 from typing import List
 
+PREFIX = "ph"
 VERSION = 1
 
 
@@ -69,7 +71,7 @@ def encrypt_asymmetric(plaintext, public_key_hex):
 
     ciphertext = encrypt_string(plaintext, symmetric_keys[1])
 
-    return f"ph:v{VERSION}:{public_key.hex()}:{ciphertext}"
+    return f"{PREFIX}:v{VERSION}:{public_key.hex()}:{ciphertext}"
 
 
 def decrypt_asymmetric(ciphertext_string, private_key_hex, public_key_hex):
@@ -198,3 +200,30 @@ def blake2b_digest(input_str: str, salt: str) -> str:
     )
     hex_encoded = hashed.hex()
     return hex_encoded
+
+
+def validate_encrypted_string(encrypted_string):
+    """
+    Validates if the given string matches the phase encrypted data format.
+
+    The expected format is: `ph:v1:<public_key>:<ciphertext>`
+    where:
+    - `ph` is the fixed prefix.
+    - `v1` is the fixed version.
+    - `<public_key>` is a hexadecimal string.
+    - `<ciphertext>` is a Base64-encoded string.
+
+    Parameters:
+    encrypted_string (str): The encrypted string to validate.
+
+    Returns:
+    bool: True if the string matches the expected format, False otherwise.
+    """
+    # Define the regular expression pattern for an encrypted string
+    pattern = r"^ph:v1:([a-fA-F0-9]+):([a-zA-Z0-9+/=]+)$"
+
+    # Match the string against the pattern
+    match = re.match(pattern, encrypted_string)
+
+    # Return True if it matches, otherwise False
+    return bool(match)

--- a/backend/api/utils/crypto.py
+++ b/backend/api/utils/crypto.py
@@ -219,11 +219,14 @@ def validate_encrypted_string(encrypted_string):
     Returns:
     bool: True if the string matches the expected format, False otherwise.
     """
-    # Define the regular expression pattern for an encrypted string
-    pattern = r"^ph:v1:([a-fA-F0-9]+):([a-zA-Z0-9+/=]+)$"
+    if encrypted_string:
+        # Define the regular expression pattern for an encrypted string
+        pattern = re.compile(f"ph:v{VERSION}:[0-9a-fA-F]{{64}}:.+")
 
-    # Match the string against the pattern
-    match = re.match(pattern, encrypted_string)
+        # Match the string against the pattern
+        match = re.match(pattern, encrypted_string)
 
-    # Return True if it matches, otherwise False
-    return bool(match)
+        # Return True if it matches, otherwise False
+        return bool(match)
+
+    return True

--- a/backend/api/views/secrets.py
+++ b/backend/api/views/secrets.py
@@ -19,7 +19,7 @@ from api.utils.secrets import (
 from api.utils.permissions import user_can_access_environment
 from api.utils.audit_logging import log_secret_event
 
-from api.utils.crypto import encrypt_asymmetric
+from api.utils.crypto import encrypt_asymmetric, validate_encrypted_string
 from api.utils.rest import (
     get_resolver_request_meta,
 )
@@ -106,6 +106,18 @@ class E2EESecretsView(APIView):
             return JsonResponse({"error": "Duplicate secret found"}, status=409)
 
         for secret in request_body["secrets"]:
+
+            # Check that all encrypted fields are valid
+            encrypted_fields = [secret["key"], secret["value"], secret["comment"]]
+            if "override" in secret:
+                encrypted_fields.append(secret["override"]["value"])
+
+            for encrypted_field in encrypted_fields:
+                if not validate_encrypted_string(encrypted_field):
+                    return JsonResponse(
+                        {"error": "Invalid ciphertext format"}, status=400
+                    )
+
             tags = SecretTag.objects.filter(id__in=secret["tags"])
 
             try:
@@ -160,6 +172,18 @@ class E2EESecretsView(APIView):
             return JsonResponse({"error": "Duplicate secret found"}, status=409)
 
         for secret in request_body["secrets"]:
+
+            # Check that all encrypted fields are valid
+            encrypted_fields = [secret["key"], secret["value"], secret["comment"]]
+            if "override" in secret:
+                encrypted_fields.append(secret["override"]["value"])
+
+            for encrypted_field in encrypted_fields:
+                if not validate_encrypted_string(encrypted_field):
+                    return JsonResponse(
+                        {"error": "Invalid ciphertext format"}, status=400
+                    )
+
             secret_obj = Secret.objects.get(id=secret["id"])
 
             tags = SecretTag.objects.filter(id__in=secret["tags"])


### PR DESCRIPTION
## :mag: Overview

The E2E encrypted secrets api accepts secrets that are encrypted client-side (by the CLI or SDKs), but there is currently no validation to ensure that the format of the encrypted data matches the phase ciphertext format. 

## :bulb: Proposed Changes

Add a validation check for encrypted fields sent via `POST` and `PUT` requests to make sure they are encrypted and formatted correctly. Return a `400 Bad request` error if they are malformed. 

## :memo: Release Notes

Added validation to ensure malformed or unencrypted data cannot be saved via the E2E encrypted secrets API.

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?



