### PR TITLE
chore: optimize frontend container image size

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -42,10 +42,10 @@ RUN yarn build
 
 # ---- Release ----
 FROM base AS release
-# Copy production node_modules
-COPY --from=dependencies /tmp/node_modules ./node_modules
-# Copy app sources
-COPY --from=build /app/.next ./.next
+# Copy standalone output
+COPY --from=build /app/.next/standalone ./
+# Copy static files
+COPY --from=build /app/.next/static ./.next/static
 COPY --from=build /app/public ./public
 # Copy scripts directory
 COPY --chown=app:app scripts ./scripts

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -69,6 +69,7 @@ const nextConfig = {
           },
         ]
   },
+  output: "standalone",
   experimental: {
     esmExternals: 'loose',
   },

--- a/frontend/scripts/start.sh
+++ b/frontend/scripts/start.sh
@@ -2,4 +2,4 @@
 
 # Set up runtime env vars and start next server
 bash scripts/replace-variable.sh && 
-yarn start
+node server.js


### PR DESCRIPTION
## :mag: Overview

The frontend docker image running next js can be optimized and reduced in size by using `next.config.output="standalone"`. 

More context: https://nextjs.org/docs/app/api-reference/next-config-js/output

## :bulb: Proposed Changes

Use `standalone` output for nextjs to significantly reduce the frontend image size.

## :memo: Release Notes

Reduced the frontend container size

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
- [x] Update dependencies and lockfiles (if required)
- [x] Verify the app builds locally?
- [ ] Manually test the changes on different browsers/devices?



