### PR TITLE
fix: credential picker filter logic

### DIFF
--- a/frontend/components/syncing/ProviderCredentialPicker.tsx
+++ b/frontend/components/syncing/ProviderCredentialPicker.tsx
@@ -41,8 +41,11 @@ export const ProviderCredentialPicker = (props: {
     ? credentials.filter((cred) => cred.provider?.id === providerFilter)
     : credentials
 
+  const credentialMatchesFilter =
+    credential && providerFilter ? credential.provider?.id === providerFilter : true
+
   useEffect(() => {
-    if (setDefault && filteredCredentials.length > 0 && !credential)
+    if (setDefault && filteredCredentials.length > 0 && !credentialMatchesFilter)
       setCredential(filteredCredentials[0])
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [providerFilter, filteredCredentials, setDefault])


### PR DESCRIPTION
## :mag: Overview

The credential picker doesn't correctly filter credentials by the chosen provider when creating a new sync, and auto-selects the credential of a different service.

## :bulb: Proposed Changes

Fix the filtering logic and `useEffect` hook that pre-selects a credential on component mount.

## :framed_picture: Screenshots or Demo
[Screencast from 07-19-2024 02:24:17 PM.webm](https://github.com/user-attachments/assets/2b29453a-bf72-4b7a-8a46-f7ed9ecbac00)


## :memo: Release Notes

Fixed the credential picker pre-selecting invalid credentials when configuring a new sync.

### :dart: Reviewer Focus

Verify that only credentials for the chosen service are pre-selected and listed in the dropdown.

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
