### PR TITLE
Fixed the spinner for `Unlock User Keyring`

### DIFF
--- a/frontend/components/auth/UnlockKeyringDialog.tsx
+++ b/frontend/components/auth/UnlockKeyringDialog.tsx
@@ -63,7 +63,7 @@ export default function UnlockKeyringDialog(props: { organisation: OrganisationT
           setUnlocking(false)
           reject(e) // Reject the promise with the error
         }  
-      }, 2000);
+      }, 300);
     })
   }
 

--- a/frontend/components/auth/UnlockKeyringDialog.tsx
+++ b/frontend/components/auth/UnlockKeyringDialog.tsx
@@ -46,23 +46,24 @@ export default function UnlockKeyringDialog(props: { organisation: OrganisationT
   const decryptKeyring = (sudoPassword: string) => {
     return new Promise(async (resolve, reject) => {
       setUnlocking(true)
+      setTimeout(async() => {
+        try {
+          if (trustDevice) {
+            setDevicePassword(organisation.memberId!, sudoPassword)
+          }
 
-      try {
-        if (trustDevice) {
-          setDevicePassword(organisation.memberId!, sudoPassword)
-        }
-
-        const decryptedKeyring = await getKeyring(session?.user?.email!, organisation, sudoPassword)
-        setKeyring(decryptedKeyring)
-        setUnlocking(false)
-        reset()
-        closeModal()
-        resolve(true) // Resolve the promise successfully
-      } catch (e) {
-        console.error(e)
-        setUnlocking(false)
-        reject(e) // Reject the promise with the error
-      }
+          const decryptedKeyring = await getKeyring(session?.user?.email!, organisation, sudoPassword)
+          setKeyring(decryptedKeyring)
+          setUnlocking(false)
+          reset()
+          closeModal()
+          resolve(true) // Resolve the promise successfully
+        } catch (e) {
+          console.error(e)
+          setUnlocking(false)
+          reject(e) // Reject the promise with the error
+        }  
+      }, 2000);
     })
   }
 
@@ -265,11 +266,13 @@ export default function UnlockKeyringDialog(props: { organisation: OrganisationT
                               </div>
                             }
                           >
-                            {trustDevice ? (
-                              <FaShieldAlt className="shrink-0" />
-                            ) : (
-                              <FaUnlock className="shrink-0" />
-                            )}{' '}
+                            {!unlocking && (
+                              trustDevice ? (
+                                <FaShieldAlt className="shrink-0" />
+                                  ) : (
+                                <FaUnlock className="shrink-0" />
+                                  )
+                              )}{' '}
                             {trustDevice ? 'Remember' : 'Unlock'}
                           </SplitButton>
                         </div>

--- a/frontend/components/auth/UnlockKeyringDialog.tsx
+++ b/frontend/components/auth/UnlockKeyringDialog.tsx
@@ -46,12 +46,11 @@ export default function UnlockKeyringDialog(props: { organisation: OrganisationT
   const decryptKeyring = (sudoPassword: string) => {
     return new Promise(async (resolve, reject) => {
       setUnlocking(true)
-      setTimeout(async() => {
+      setTimeout( async () => {
         try {
           if (trustDevice) {
             setDevicePassword(organisation.memberId!, sudoPassword)
           }
-
           const decryptedKeyring = await getKeyring(session?.user?.email!, organisation, sudoPassword)
           setKeyring(decryptedKeyring)
           setUnlocking(false)
@@ -63,7 +62,7 @@ export default function UnlockKeyringDialog(props: { organisation: OrganisationT
           setUnlocking(false)
           reject(e) // Reject the promise with the error
         }  
-      }, 300);
+      }, 100);
     })
   }
 


### PR DESCRIPTION
## :mag: Overview

This PR is a fix for the issue #200 . 

## :bulb: Proposed Changes

*Detail the proposed changes, including new features, bug fixes, or improvements. Explain how these changes impact the project, including any internal structure alterations or refactorings.*

## :framed_picture: Screenshots or Demo

Before : the `Unlock button will stay still for few seconds` like the video shown in issue #200 

Fix 

https://github.com/user-attachments/assets/6385906c-676d-40ae-991f-ffe378e4540d


## :memo: Release Notes

*Summarize the changes in a user-friendly manner. Highlight new features, bug fixes, and any breaking changes, including migration steps or deprecated functionalities.*

## :question: Open Questions

*If there are aspects of the changes that you're unsure about or would like feedback on, list them here.*

### :test_tube: Testing

*Describe the testing strategy. List new tests added, existing tests modified, and any testing gaps.*

### :dart: Reviewer Focus

*Guide the reviewer on where to start the review process. Suggest specific files, modules, or functionalities to focus on as entry points.*

### :heavy_plus_sign: Additional Context

*Provide any additional information that might be helpful for reviewers and future contributors, such as links to related issues, discussions, or resources.*

## :sparkles: How to Test the Changes Locally

When the `Unlock User Keyring` Box appears. Enter the sudo password and you will see the spinner instead unlock 🔓 icon 

### :green_heart: Did You...

- [ ✅ ] Ensure linting passes (code style checks)?
- [ ] Update dependencies and lockfiles (if required)
- [ ] Regenerate graphql schema and types (if required)
- [ ] Verify the app builds locally?
- [✅ ] Manually test the changes on different browsers/devices? 
   - Checked in Chrome and Brave
