### PR TITLE
feat: add environments to app type

### DIFF
--- a/frontend/apollo/graphql.ts
+++ b/frontend/apollo/graphql.ts
@@ -166,6 +166,7 @@ export type AppType = {
   appToken: Scalars['String']['output'];
   appVersion: Scalars['Int']['output'];
   createdAt?: Maybe<Scalars['DateTime']['output']>;
+  environments?: Maybe<Array<Maybe<EnvironmentType>>>;
   id: Scalars['String']['output'];
   identityKey: Scalars['String']['output'];
   name: Scalars['String']['output'];

--- a/frontend/apollo/schema.graphql
+++ b/frontend/apollo/schema.graphql
@@ -195,6 +195,33 @@ type AppType {
   wrappedKeyShare: String!
   createdAt: DateTime
   sseEnabled: Boolean
+  environments: [EnvironmentType]
+}
+
+type EnvironmentType {
+  id: String!
+  app: AppType!
+  name: String!
+  envType: ApiEnvironmentEnvTypeChoices!
+  identityKey: String!
+  wrappedSeed: String!
+  wrappedSalt: String!
+  createdAt: DateTime
+  updatedAt: DateTime!
+  folderCount: Int
+  secretCount: Int
+}
+
+"""An enumeration."""
+enum ApiEnvironmentEnvTypeChoices {
+  """Development"""
+  DEV
+
+  """Staging"""
+  STAGING
+
+  """Production"""
+  PROD
 }
 
 """An enumeration."""
@@ -276,32 +303,6 @@ type SecretType {
   updatedAt: DateTime!
   history: [SecretEventType]
   override: PersonalSecretType
-}
-
-type EnvironmentType {
-  id: String!
-  app: AppType!
-  name: String!
-  envType: ApiEnvironmentEnvTypeChoices!
-  identityKey: String!
-  wrappedSeed: String!
-  wrappedSalt: String!
-  createdAt: DateTime
-  updatedAt: DateTime!
-  folderCount: Int
-  secretCount: Int
-}
-
-"""An enumeration."""
-enum ApiEnvironmentEnvTypeChoices {
-  """Development"""
-  DEV
-
-  """Staging"""
-  STAGING
-
-  """Production"""
-  PROD
 }
 
 type SecretFolderType {


### PR DESCRIPTION
## :bulb: Proposed Changes

Adds `environments` as a query-able field to the `AppType`, to facilitate fetching environments along with apps in a single query

## :framed_picture: Screenshots or Demo

```graphql
query GetApps($organisationId: ID!, $appId: ID) {
  apps(organisationId: $organisationId, appId: $appId) {
    id
    name
    identityKey
    createdAt
    sseEnabled
    environments {
      id
      name
    }
  }
}
```

## :memo: Release Notes

Adds support for querying `environments` as a list of `EnvironmentType` objects in the `AppType`

### :heavy_plus_sign: Additional Context

The sort ordering for environments will need to be added after the merge of #303 

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
- [x] Regenerate graphql schema and types (if required)
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
