### PR TITLE
Fix temp display of Something went wrong in invite

### DIFF
--- a/frontend/app/invite/[invite]/page.tsx
+++ b/frontend/app/invite/[invite]/page.tsx
@@ -48,7 +48,7 @@ const InvalidInvite = () => (
 )
 
 export default function Invite({ params }: { params: { invite: string } }) {
-  const [verifyInvite, { data, loading }] = useLazyQuery(VerifyInvite)
+  const [verifyInvite, { data, loading, called }] = useLazyQuery(VerifyInvite)
 
   const [acceptInvite] = useMutation(AcceptOrganisationInvite)
 
@@ -278,7 +278,7 @@ export default function Invite({ params }: { params: { invite: string } }) {
         <HeroPattern />
 
         <div className="flex w-full h-screen max-w-4xl mx-auto flex-col gap-y-16 py-40">
-          {loading ? (
+          {loading || !called ? (
             <Loading />
           ) : invite ? (
             showWelcome ? (


### PR DESCRIPTION
## :mag: Overview
Fixed temporary message of "Something went wrong" while accepting invite. 
Fixes #207 

## :bulb: Proposed Changes
Used `called` property of `useLazyQuery` to check if the `verifyInvite` was ever called. Through this the `Loading` element can be rendered until `called` is true, which happens only after `verifyInvite` is invoked

_Issue was caused due to initial value of `loading` in  Invite element. As data is null and loading is true in the first mount, hence `invite` is null which causes render of `Invalid Invite`_ 

## :framed_picture: Screenshots or Demo
During Issue:
![untitled](https://github.com/user-attachments/assets/8931bcca-448f-4289-b2e4-7e36ddc92789)
After Fix:
![untitled](https://github.com/user-attachments/assets/3d81fb85-0bc5-4c99-b8ff-d67537c08fe6)

## :memo: Release Notes
Modify the Invite element to render `Loading` until `verifyInvite()` is invoked.

## :sparkles: How to Test the Changes Locally
Create a member invite and paste that link into new tab.

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
- [ ] Update dependencies and lockfiles (if required)
- [ ] Regenerate graphql schema and types (if required)
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
