### PR TITLE
fix: constrain setup tools version to fix broken build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:3.12.1-alpine3.19@sha256:28230397c48cf4e2619822beb834ae7e46ebcd255b8f7cef58eff932fd75d2ce
 
 ADD requirements.txt /app/requirements.txt
+ADD constraints.txt /app/constraints.txt
+
+ENV PIP_CONSTRAINT=/app/constraints.txt
 
 RUN set -ex \
     && apk add --no-cache --virtual .build-deps postgresql-dev build-base gcc musl-dev jpeg-dev zlib-dev libffi-dev cairo-dev pango-dev gdk-pixbuf-dev mariadb-dev python3-dev  \

--- a/backend/constraints.txt
+++ b/backend/constraints.txt
@@ -1,0 +1,1 @@
+setuptools<72


### PR DESCRIPTION
## :mag: Overview

A recent update to `setuptools` which remove the `test` command causes `autobahn` to fail installs:

https://github.com/pypa/setuptools/issues/4519
https://github.com/crossbario/autobahn-python/issues/1644

## :bulb: Proposed Changes

Constrain `setuptools` to version `72` to allow `autobahn` to install correctly.
* Added a `constraints.txt` file 
* Updated the backend Dockerfile to use the `contraints.txt` file when running `pip install`

## :memo: Release Notes

Fixed a broken dependency issue with setuptools and autobahn

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
- [x] Update dependencies and lockfiles (if required)
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
