### PR TITLE
fix: Nav bar hidding the underneath scrollbar

### DIFF
--- a/frontend/app/[team]/layout.tsx
+++ b/frontend/app/[team]/layout.tsx
@@ -55,7 +55,10 @@ export default function RootLayout({
       {activeOrganisation && <UnlockKeyringDialog organisation={activeOrganisation} />}
       {showNav && <NavBar team={params.team} />}
       {showNav && <Sidebar />}
-      <div className={clsx('min-h-screen overflow-auto', showNav && 'pt-16')}>{children}</div>
+      <div className="grid h-screen">
+        <div></div>
+        <div className={clsx('overflow-auto', showNav && 'mt-16')}>{children}</div>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## :mag: Overview

The scroll bar in the team's page gets hidden due to Navbar having `position: fixed`, therefore only scrollbars of parent elements could be visible. 
This PR fixes the issue of scrollbar being hidden on top.
Fixes #301 

## :bulb: Proposed Changes

Created a `div` that contains an empty div and div of children in layout of `[team]`, which is restricted to screen height. Now, only the `div` containing children can overflow making sure it to shows under `Navbar`.

## :framed_picture: Screenshots or Demo

After fix:
![image](https://github.com/user-attachments/assets/66682aab-3aff-4f0a-886f-63aacdb581e9)


## :memo: Release Notes

Restrict the children div to show under Navbar.

## :sparkles: How to Test the Changes Locally

1. Run the app locally.
2. Visit the organization's home page.

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
- [x] Update dependencies and lockfiles (if required)
- [x] Regenerate graphql schema and types (if required)
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
