### PR TITLE
fix: application sse permission validation

### DIFF
--- a/frontend/components/apps/EnableSSEDialog.tsx
+++ b/frontend/components/apps/EnableSSEDialog.tsx
@@ -29,7 +29,7 @@ export const EnableSSEDialog = (props: { appId: string }) => {
   const [enableSse, { loading }] = useMutation(InitAppSyncing)
   const [getEnvKey] = useLazyQuery(GetEnvironmentKey)
 
-  const activeUserIsAdmin = false //organisation ? userIsAdmin(organisation.role!) : false
+  const activeUserIsAdmin = organisation ? userIsAdmin(organisation.role!) : false
 
   const { data: appEnvsData } = useQuery(GetAppEnvironments, {
     variables: {


### PR DESCRIPTION
## :mag: Overview
This PR addresses an issue where the application's owner is unable to enable Server-Side Encryption (SSE) due to an incorrectly hardcoded admin check. The current implementation always treats the user as a non-admin, preventing legitimate owners and admins from enabling SSE.

## :bulb: Proposed Changes
- Update the `activeUserIsAdmin` check in the `EnableSSEDialog` component to properly evaluate the user's role based on the organization context.
- Ensure the `userIsAdmin` function from `@/utils/permissions` is correctly utilized.
- Verify and adjust the `organisationContext` to properly pass down the user's role.

```ts
export const userIsAdmin = (role: string) =>
  ['admin', 'owner'].includes(role.toLowerCase()) ?? false
```

Permissions:
![image](https://github.com/user-attachments/assets/17dcdf7f-2393-4e71-9220-c2699f7c8d2a)


Before the fix (as a `Owner` or `Admin`):
![image](https://github.com/user-attachments/assets/50bcf388-54b8-4a17-af82-fe47ac29ac73)

After the fix (as a `Owner` or `Admin`):
![image](https://github.com/user-attachments/assets/c9c5778a-1d02-4a55-8e65-5672f2c9489b)


### :dart: Reviewer Focus
Please focus on:
1. The changes in `EnableSSEDialog` component, particularly the `activeUserIsAdmin` assignment.
2. The `userIsAdmin` function in `@/utils/permissions`.
3. The usage of `organisationContext` throughout the component.

## :sparkles: How to Test the Changes Locally
1. Log in as an application owner or admin.
2. Navigate to the app settings and attempt to enable SSE.
3. Verify that the SSE dialog appears and allows enabling for admin users.

### :green_heart: Did You...
- [x] Ensure linting passes (code style checks)?
- [ ] Update dependencies and lockfiles (if required)
- [ ] Regenerate graphql schema and types (if required)
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?