### PR TITLE
fix: removed uuid from health endpoint

### DIFF
--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -17,7 +17,7 @@ urlpatterns = [
     path("social/login/", include("api.urls")),
     path("logout/", csrf_exempt(logout_view)),
     path("graphql/", csrf_exempt(PrivateGraphQLView.as_view(graphiql=True))),
-    path("493c5048-99f9-4eac-ad0d-98c3740b491f/health", health_check),
+    path("/health", health_check),
     path("secrets/", E2EESecretsView.as_view()),
     path("public/v1/secrets/", PublicSecretsView.as_view()),
     path("secrets/tokens/", secrets_tokens),

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -18,6 +18,8 @@ urlpatterns = [
     path("logout/", csrf_exempt(logout_view)),
     path("graphql/", csrf_exempt(PrivateGraphQLView.as_view(graphiql=True))),
     path("/health", health_check),
+    # To not break legacy health checks. TODO: Remove
+    path("493c5048-99f9-4eac-ad0d-98c3740b491f/health", health_check),
     path("secrets/", E2EESecretsView.as_view()),
     path("public/v1/secrets/", PublicSecretsView.as_view()),
     path("secrets/tokens/", secrets_tokens),


### PR DESCRIPTION
## :mag: Overview

Simplified backend health endpoint by removing the unnecessary UUID.

New health endpoint:
`/health`