### PR TITLE
Truncate long org names and user menu improvements

### DIFF
--- a/frontend/components/UserMenu.tsx
+++ b/frontend/components/UserMenu.tsx
@@ -39,28 +39,26 @@ export default function UserMenu() {
           leaveFrom="transform opacity-100 scale-100"
           leaveTo="transform opacity-0 scale-95"
         >
-          <Menu.Items className="absolute z-10 -right-2 top-12 mt-2 w-72 origin-bottom-left divide-y divide-neutral-500/20 rounded-md bg-neutral-200 dark:bg-neutral-800 shadow-lg ring-1 ring-inset ring-neutral-500/40 focus:outline-none">
+          <Menu.Items className="absolute z-20 -right-2 top-12 mt-2 w-72 origin-bottom-left divide-y divide-neutral-500/20 rounded-md bg-neutral-200 dark:bg-neutral-800 shadow-lg ring-1 ring-inset ring-neutral-500/40 focus:outline-none">
             <Menu.Item>
               <div className="py-4 flex items-start gap-2 p-2">
                 <div className="py-1.5">
                   <Avatar imagePath={session?.user?.image!} size="md" />
                 </div>
-                <div className="flex flex-col gap-1 flex-grow min-w-0">
+                <div className="flex flex-col flex-grow min-w-0">
                   <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                    <span className="text-xs font-medium text-zinc-900 dark:text-zinc-100">
+                    <span className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
                       {session?.user?.name}
                     </span>
-                    {activeOrganisation && (
-                      <RoleLabel role={activeOrganisation?.role!} />
-                    )}
                   </div>
-                  <span className="text-neutral-500 text-2xs truncate">
-                    {session?.user?.email}
-                  </span>
+                  <span className="text-neutral-500 text-2xs truncate">{session?.user?.email}</span>
                   {activeOrganisation && (
-                    <span className="text-neutral-500 text-2xs truncate">
-                      {activeOrganisation?.name}
-                    </span>
+                    <div className="flex items-center gap-1 text-2xs pt-1">
+                      {activeOrganisation && <RoleLabel role={activeOrganisation?.role!} />} @{' '}
+                      <span className="text-zinc-900 dark:text-zinc-100  truncate">
+                        {activeOrganisation?.name}
+                      </span>
+                    </div>
                   )}
                 </div>
               </div>

--- a/frontend/components/UserMenu.tsx
+++ b/frontend/components/UserMenu.tsx
@@ -41,25 +41,26 @@ export default function UserMenu() {
         >
           <Menu.Items className="absolute z-10 -right-2 top-12 mt-2 w-72 origin-bottom-left divide-y divide-neutral-500/20 rounded-md bg-neutral-200 dark:bg-neutral-800 shadow-lg ring-1 ring-inset ring-neutral-500/40 focus:outline-none">
             <Menu.Item>
-              <div className="py-4 flex items-start gap-2 p-2 ">
+              <div className="py-4 flex items-start gap-2 p-2">
                 <div className="py-1.5">
                   <Avatar imagePath={session?.user?.image!} size="md" />
                 </div>
-                <div className="flex flex-col gap-2 flex-grow min-w-0">
-                  <div className="flex flex-col">
-                    <span className="text-xs font-medium text-zinc-900 dark:text-zinc-100 truncate">
+                <div className="flex flex-col gap-1 flex-grow min-w-0">
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                    <span className="text-xs font-medium text-zinc-900 dark:text-zinc-100">
                       {session?.user?.name}
                     </span>
-                    <span className="text-neutral-500 text-2xs truncate">
-                      {session?.user?.email}
-                    </span>
-                  </div>
-
-                  {activeOrganisation && (
-                    <div className="flex items-center gap-2 text-2xs">
+                    {activeOrganisation && (
                       <RoleLabel role={activeOrganisation?.role!} />
-                      <span className="truncate">at {activeOrganisation?.name}</span>
-                    </div>
+                    )}
+                  </div>
+                  <span className="text-neutral-500 text-2xs truncate">
+                    {session?.user?.email}
+                  </span>
+                  {activeOrganisation && (
+                    <span className="text-neutral-500 text-2xs truncate">
+                      {activeOrganisation?.name}
+                    </span>
                   )}
                 </div>
               </div>

--- a/frontend/components/UserMenu.tsx
+++ b/frontend/components/UserMenu.tsx
@@ -39,18 +39,18 @@ export default function UserMenu() {
           leaveFrom="transform opacity-100 scale-100"
           leaveTo="transform opacity-0 scale-95"
         >
-          <Menu.Items className="absolute z-10 -right-2 top-12 mt-2 w-56 origin-bottom-left divide-y divide-neutral-500/20 rounded-md bg-neutral-200 dark:bg-neutral-800 shadow-lg ring-1 ring-inset ring-neutral-500/40 focus:outline-none">
+          <Menu.Items className="absolute z-10 -right-2 top-12 mt-2 w-72 origin-bottom-left divide-y divide-neutral-500/20 rounded-md bg-neutral-200 dark:bg-neutral-800 shadow-lg ring-1 ring-inset ring-neutral-500/40 focus:outline-none">
             <Menu.Item>
               <div className="py-4 flex items-start gap-2 p-2 ">
                 <div className="py-1.5">
                   <Avatar imagePath={session?.user?.image!} size="md" />
                 </div>
-                <div className="flex flex-col gap-2">
+                <div className="flex flex-col gap-2 flex-grow min-w-0">
                   <div className="flex flex-col">
-                    <span className="text-xs font-medium text-zinc-900 dark:text-zinc-100 truncate w-40">
+                    <span className="text-xs font-medium text-zinc-900 dark:text-zinc-100 truncate">
                       {session?.user?.name}
                     </span>
-                    <span className="text-neutral-500 text-2xs truncate w-40">
+                    <span className="text-neutral-500 text-2xs truncate">
                       {session?.user?.email}
                     </span>
                   </div>
@@ -58,7 +58,7 @@ export default function UserMenu() {
                   {activeOrganisation && (
                     <div className="flex items-center gap-2 text-2xs">
                       <RoleLabel role={activeOrganisation?.role!} />
-                      <span>at {activeOrganisation?.name}</span>
+                      <span className="truncate">at {activeOrganisation?.name}</span>
                     </div>
                   )}
                 </div>

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -16,7 +16,7 @@ import {
 } from 'react-icons/fa'
 import { organisationContext } from '@/contexts/organisationContext'
 import { Fragment, useContext } from 'react'
-import { ApiOrganisationMemberRoleChoices, OrganisationType } from '@/apollo/graphql'
+import { OrganisationType } from '@/apollo/graphql'
 import { Menu, Transition } from '@headlessui/react'
 import { Button } from '../common/Button'
 import { PlanLabel } from '../settings/organisation/PlanLabel'
@@ -59,14 +59,14 @@ const Sidebar = () => {
 
   const OrgsMenu = () => {
     return (
-      <Menu as="div" className="relative inline-block text-left ">
+      <Menu as="div" className="relative inline-block text-left w-full">
         {({ open }) => (
           <>
             <Menu.Button
               as="div"
               className="p-2 text-neutral-500 cursor-pointer flex items-center justify-between w-full group bg-neutral-500/10 ring-1 ring-inset ring-neutral-400/10 rounded-lg"
             >
-              <div className="flex flex-col gap-0.5">
+              <div className="flex flex-col gap-0.5 min-w-0">
                 <div>
                   <PlanLabel plan={activeOrganisation?.plan!} />
                 </div>
@@ -76,7 +76,7 @@ const Sidebar = () => {
               </div>
               <FaChevronDown
                 className={clsx(
-                  'transition ease opacity-0 group-hover:opacity-100 text-zinc-800 dark:text-zinc-100',
+                  'transition ease opacity-0 group-hover:opacity-100 text-zinc-800 dark:text-zinc-100 flex-shrink-0 ml-2',
                   open ? 'rotate-180 opacity-100' : 'rotate-0'
                 )}
               />
@@ -101,19 +101,19 @@ const Sidebar = () => {
                               title={`Switch to ${org.name}`}
                               className={`${
                                 active
-                                  ? 'hover:text-zinc-900  dark:hover:text-zinc-100 hover:bg-neutral-100 dark:hover:bg-neutral-700'
+                                  ? 'hover:text-zinc-900 dark:hover:text-zinc-100 hover:bg-neutral-100 dark:hover:bg-neutral-700'
                                   : 'text-zinc-700 dark:text-zinc-300 dark:hover:text-emerald-500'
                               } group flex w-full gap-2 items-center justify-between px-2 py-2 border-b border-neutral-500/20`}
                             >
-                              <div className="flex flex-col gap-0.5 w-full">
+                              <div className="flex flex-col gap-0.5 min-w-0 flex-grow">
                                 <div>
                                   <PlanLabel plan={org?.plan!} />
                                 </div>
-                                <span className="truncate w-[80%] text-left font-medium text-base">
+                                <span className="truncate text-left font-medium text-base">
                                   {org.name}
                                 </span>
                               </div>
-                              <FaExchangeAlt />
+                              <FaExchangeAlt className="flex-shrink-0" />
                             </div>
                           </Link>
                         )}

--- a/frontend/components/users/RoleLabel.tsx
+++ b/frontend/components/users/RoleLabel.tsx
@@ -15,7 +15,7 @@ export const RoleLabel = (props: { role: string }) => {
   return (
     <span
       className={clsx(
-        'px-2 py-1 rounded-full ring-1 ring-inset uppercase text-2xs font-medium tracking-wide',
+        'px-2 py-0.5 rounded-full ring-1 ring-inset uppercase text-2xs font-medium tracking-wide',
         roleStyle()
       )}
     >


### PR DESCRIPTION
## :mag: Overview
This pull request addresses multiple UI issues in the UserMenu component:
1. Alignment of the role label (e.g., ADMIN) next to the user's name.
2. Text truncation for long organization names and email addresses.
3. Overall layout improvements for better readability and consistency.

Fixed: https://github.com/phasehq/console/issues/326

## :bulb: Proposed Changes
- Modified the UserMenu component to improve the alignment of user information
- Adjusted the flex layout to ensure the role label appears directly after the user's name
- Implemented text truncation for long organization names and email addresses
- Increased the width of the dropdown menu to accommodate more content
- Improved the overall visual consistency and responsiveness of the user dropdown menu

## :framed_picture: Screenshots or Demo
[Before]
![image](https://github.com/user-attachments/assets/e81ca9e2-f08c-4c96-9094-1237119393a4)
![image](https://github.com/user-attachments/assets/5c9f2e8d-5740-496b-8a36-49c87284f0a5)

[After]
![image](https://github.com/user-attachments/assets/24c731bc-4010-413e-847a-fdc243f6f69a)
![image](https://github.com/user-attachments/assets/8f8f2ae8-3459-4bf1-9d71-d4cdd0b83ebd)

## :memo: Release Notes
- Improved UI: The user role label in the account dropdown menu is now correctly aligned next to the user's name.
- Enhanced readability: Long organization names and email addresses are now properly truncated to prevent overflow.
- Increased usability: The dropdown menu width has been adjusted to better accommodate user information.

## :question: Open Questions
- Should we consider adding a tooltip for truncated text to show the full content on hover?
- Is the current approach for handling long text optimal for all potential use cases?

### :test_tube: Testing
- Manually tested the UserMenu component with various user names, email addresses, and organization names (short, long, with spaces)
- Verified the alignment and truncation in both light and dark themes
- Tested on different screen sizes to ensure responsive behavior
- Checked edge cases with extremely long text to ensure proper handling

### :dart: Reviewer Focus
Please focus on:
- The flex layout implementation in the UserMenu component
- The handling of text truncation for long organization names and email addresses
- The visual consistency across different themes and screen sizes
- The responsiveness of the layout with various content lengths

### :heavy_plus_sign: Additional Context
This change is part of our ongoing effort to improve the UI/UX of the application, ensuring a consistent and polished look across all components while handling diverse user data gracefully.

## :sparkles: How to Test the Changes Locally
1. Checkout the branch and install any new dependencies
2. Run the application locally
3. Log in with different test accounts, especially those with long names, email addresses, or organization names
4. Open the user dropdown menu and verify:
   - The alignment of the role label
   - Proper truncation of long text
   - Overall layout consistency
5. Test in both light and dark themes
6. Test on different screen sizes, including mobile views

### :green_heart: Did You...
- [x] Ensure linting passes (code style checks)?
- [ ] Update dependencies and lockfiles (if required)
- [ ] Regenerate graphql schema and types (if required)
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?