### PR TITLE
fix: environment members resolver returning soft-deleted users

### DIFF
--- a/backend/backend/graphene/types.py
+++ b/backend/backend/graphene/types.py
@@ -226,7 +226,7 @@ class EnvironmentType(DjangoObjectType):
         return [
             env_key.user
             for env_key in EnvironmentKey.objects.filter(
-                environment=self, deleted_at=None
+                environment=self, deleted_at=None, user__deleted_at=None
             )
         ]
 


### PR DESCRIPTION
## :mag: Overview

The the EnvironmentType `members` field incorrectly returns members who are soft-deleted from an Organisation

## :bulb: Proposed Changes

Update the resolver to only return active members

## :framed_picture: Screenshots or Demo

![image](https://github.com/user-attachments/assets/14c4af6b-fc37-4534-a661-a75f73473aa3)

## :memo: Release Notes

Fixed a bug that  showed incorrect Environment members in the Manage Environment dialog

### :dart: Reviewer Focus

Test that the "Members" of an Environment are correctly listed:

* Add a member to an environment
* Observe that they are listed in the Members list
* Delete the member from the organisation
* Observe that they are no longer listed in the Members list

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
