### PR TITLE
feat: improved formatting of signup sudo password feedback

### DIFF
--- a/frontend/app/invite/[invite]/page.tsx
+++ b/frontend/app/invite/[invite]/page.tsx
@@ -89,7 +89,7 @@ export default function Invite({ params }: { params: { invite: string } }) {
       icon: <MdOutlinePassword />,
       title: 'Set a sudo password',
       description:
-        'This will be used to encrypt your account keys. You will be need to enter this password to perform administrative tasks.',
+        'This will be used to encrypt your account keys. You may need to enter this password to perform administrative tasks.',
     },
     {
       index: 1,

--- a/frontend/app/signup/page.tsx
+++ b/frontend/app/signup/page.tsx
@@ -92,7 +92,7 @@ const Onboard = () => {
       icon: <MdOutlinePassword />,
       title: 'Set a sudo password',
       description:
-        'This will be used to encrypt your account keys. You will need to enter this password to unlock your workspace when logging in.',
+        'This will be used to encrypt your account keys. You may need to enter this password to unlock your workspace when logging in.',
     },
     {
       index: 2,

--- a/frontend/components/onboarding/AccountPassword.tsx
+++ b/frontend/components/onboarding/AccountPassword.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { ZXCVBNResult } from 'zxcvbn'
 import { FaCheck, FaEye, FaEyeSlash, FaInfo, FaShieldAlt } from 'react-icons/fa'
 import clsx from 'clsx'
@@ -23,10 +23,10 @@ export const AccountPassword = (props: AccountPasswordProps) => {
     const zxcvbn = require('zxcvbn')
     const strength = zxcvbn(pw)
     setPwStrength(strength)
-  }, [pw, setPwStrength])
+  }, [pw])
 
   /**
-   * Returns a color name based on the current password stength score
+   * Returns a color name based on the current password strength score
    *
    * @returns {string}
    */
@@ -50,17 +50,14 @@ export const AccountPassword = (props: AccountPasswordProps) => {
         color = 'bg-red-500'
         break
     }
-
     return color
   }
 
   const pwStrengthPercent = (): string => {
-    let score = '0%'
-    if (pw) score = `${(pwStrength.score / 4) * 100}%`
-    return score
+    return pw ? `${(pwStrength.score / 4) * 100}%` : '0%'
   }
 
-  const passwordIsStrong = pwStrength?.feedback?.suggestions?.length == 0 || false
+  const passwordIsStrong = pwStrength?.feedback?.suggestions?.length === 0
 
   return (
     <div className="space-y-4 max-w-md mx-auto">
@@ -124,17 +121,28 @@ export const AccountPassword = (props: AccountPasswordProps) => {
             }}
           ></div>
         </div>
-        <div className="flex w-full items-center gap-4 p-3 bg-zinc-200 dark:bg-zinc-800 dark:bg-opacity-60 rounded-b-md text-black/50 dark:text-white/50">
-          {passwordIsStrong ? <FaCheck /> : <FaInfo />}
-          {passwordIsStrong ? 'Strong password' : pwStrength?.feedback?.suggestions}
+        <div className="flex w-full items-start gap-4 p-3 bg-zinc-200 dark:bg-zinc-800 dark:bg-opacity-60 rounded-b-md text-black/50 dark:text-white/50">
+          <div className="mt-1">
+            {passwordIsStrong ? <FaCheck /> : <FaInfo />}
+          </div>
+          <div className="flex-grow">
+            {passwordIsStrong ? (
+              'Strong password'
+            ) : (
+              <ul className="list-disc pl-5 space-y-1">
+                {pwStrength?.feedback?.suggestions?.map((suggestion, index) => (
+                  <li key={index}>{suggestion}</li>
+                ))}
+              </ul>
+            )}
+          </div>
         </div>
       </div>
 
       <div className="flex items-center justify-between gap-2 py-2">
         <div className="flex items-center gap-2">
-          {' '}
           <FaShieldAlt className="text-emerald-500" />
-          <span className="text-neutral-500 text-sm">Remember password on this device </span>
+          <span className="text-neutral-500 text-sm">Remember password on this device</span>
         </div>
         <ToggleSwitch value={savePassword} onToggle={() => setSavePassword(!savePassword)} />
       </div>

--- a/frontend/components/onboarding/AccountPassword.tsx
+++ b/frontend/components/onboarding/AccountPassword.tsx
@@ -121,7 +121,7 @@ export const AccountPassword = (props: AccountPasswordProps) => {
             }}
           ></div>
         </div>
-        <div className="flex w-full items-start gap-4 p-3 bg-zinc-200 dark:bg-zinc-800 dark:bg-opacity-60 rounded-b-md text-black/50 dark:text-white/50">
+        <div className="flex w-full items-start gap-6 p-3 bg-zinc-200 dark:bg-zinc-800 dark:bg-opacity-60 rounded-b-md text-black/50 dark:text-white/50 text-sm">
           <div className="mt-1">
             {passwordIsStrong ? <FaCheck /> : <FaInfo />}
           </div>
@@ -129,7 +129,7 @@ export const AccountPassword = (props: AccountPasswordProps) => {
             {passwordIsStrong ? (
               'Strong password'
             ) : (
-              <ul className="list-disc pl-5 space-y-1">
+              <ul className="list-disc pl-4">
                 {pwStrength?.feedback?.suggestions?.map((suggestion, index) => (
                   <li key={index}>{suggestion}</li>
                 ))}


### PR DESCRIPTION
## :mag: Overview
The password feedback returned from `zxcvbn` is often incorrectly formatting resulting in typos. This PR improved the presentation of said feedback in the form of dynamic bullet points in the info box. 

This PR addresses some of the feedback from Graham in our Slack: https://phase-community.slack.com/archives/C05F92D60HE/p1717838191385539

## :bulb: Proposed Changes
- Simplify the password strength feedback rendering by directly mapping over the suggestions provided by zxcvbn.
- Fixed typos and grammar

## :framed_picture: Screenshots or Demo
Before:

![image](https://github.com/user-attachments/assets/26c59479-0848-402a-a15b-9bade10224f4)

After:

![image](https://github.com/user-attachments/assets/986f9ed2-db1f-4861-90f9-a029b8abb584)

## :sparkles: How to Test the Changes Locally
1. Check out this branch and dev server
4. Navigate to the signup screen / password recovery page
5. Test various password inputs, ensuring that:
   - Password strength is correctly displayed
   - Suggestions appear as bullet points when the password is weak
   - The "Strong password" message appears for strong passwords

### :green_heart: Did You...
- [x] Ensure linting passes (code style checks)?
- [x] Update dependencies and lockfiles (if required)
- [ ] Regenerate graphql schema and types (if required)
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?