### PR TITLE
Feat  add secret path diffs

### DIFF
--- a/frontend/components/environments/secrets/SecretPropertyDiffs.tsx
+++ b/frontend/components/environments/secrets/SecretPropertyDiffs.tsx
@@ -83,6 +83,18 @@ export const SecretPropertyDiffs = (props: {
           </span>
         </div>
       )}
+      
+      {historyItem!.path !== previousItem.path && (
+        <div className="pl-3 font-mono break-all">
+          <span className="text-neutral-500 mr-2">PATH:</span>
+          <s className="bg-red-200 dark:bg-red-950 text-red-500 ph-no-capture">
+            {previousItem.path}
+          </s>
+          <span className="bg-emerald-100 dark:bg-emerald-950 text-emerald-500 ph-no-capture">
+            {historyItem!.path}
+          </span>
+        </div>
+      )}
 
       {!areTagsAreSame(historyItem!.tags, previousItem.tags) && (
         <div className="pl-3 font-mono break-all">

--- a/frontend/graphql/queries/secrets/getSecrets.gql
+++ b/frontend/graphql/queries/secrets/getSecrets.gql
@@ -16,6 +16,7 @@ query GetSecrets($appId: ID!, $envId: ID!, $path: String) {
       id
       key
       value
+      path
       tags {
         id
         name


### PR DESCRIPTION
## :mag: Overview
This pull request addresses the issue of missing secret path diffs in the secret history view, as reported in https://github.com/phasehq/console/issues/194.

## :bulb: Proposed Changes
- Added a new condition to check for path changes between history items
- Implemented a new section in the `SecretPropertyDiffs` component to display path diffs
- Added `path` to getSecrets graphql queries

## :framed_picture:

![image](https://github.com/user-attachments/assets/b4e17c14-9c47-440a-b39e-263e92a45a78)

## :question: Open Questions
- Should we implement a "Restore" functionality for path changes, similar to value changes? - This would require changes in the way we deploy secrets across folders.

### :dart: Reviewer Focus
- The new condition for path changes in the `SecretPropertyDiffs` component
- Styling consistency with other diff sections
- Potential edge cases where path diffs might not render correctly

## :sparkles: How to Test the Changes Locally
1. Navigate to a secret with history
2. Make changes to a secret's path (via the CLI or the API)
3. Verify that path changes are visible in the secret history view

### :green_heart: Did You...
- [x] Ensure linting passes (code style checks)?
- [x] Update dependencies and lockfiles (if required)
- [x] Regenerate graphql schema and types (if required)
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?