### PR TITLE
feat: allow kebab and snake case folders

### DIFF
--- a/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
+++ b/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
@@ -526,8 +526,8 @@ export default function EnvironmentPath({
   const NewFolderMenu = () => {
     const [name, setName] = useState<string>('')
 
-    // Regular expression to match only alphanumeric characters
-    const regex = /^[a-zA-Z0-9]*$/
+    // Regular expression to match only alphanumeric characters along with dashes (-) and underscores (_)
+    const folder_name_pattern = /^[a-zA-Z0-9_-]*$/
 
     const closeModal = () => {
       setFolderMenuIsOpen(false)
@@ -543,11 +543,9 @@ export default function EnvironmentPath({
     }
 
     const handleUpdateName = (newName: string) => {
-      // Regular expression to match only alphanumeric characters
-      const regex = /^[a-zA-Z0-9]*$/
 
       // Check if the new value matches the regular expression
-      if (regex.test(newName) || newName === '') {
+      if (folder_name_pattern.test(newName) || newName === '') {
         // Update the state if the value is alphanumeric or empty (to allow clearing the input)
         setName(newName)
       }


### PR DESCRIPTION
## :mag: Overview
This PR expands the range of possible folder and path names beyond alphanumeric name by adding support snake_case and kebab-case paths.

The new regex pattern:
```tsx
const folder_name_pattern = /^[a-zA-Z0-9_-]*$/
```

## :bulb: Proposed Changes
- Updated the `folder_name_pattern` in `NewFolderMenu`

## :framed_picture: Screenshots or Demo
![image](https://github.com/user-attachments/assets/5528a935-2a3c-4848-9671-2c1719aac952)

## :memo: Release Notes
- Enhanced path handling to support kebab-case and snake_case in folder and path names.
- Users can now use paths like `/backend/user-service/config` or `/frontend/user_profile/settings` in their configurations.

## :sparkles: How to Test the Changes Locally
1. Create folder names with `-` and `_` in the Phase Console
2. Fetch secrets via the CLI, API, SDKs etc.
4. Test secret referencing