### PR TITLE
feat: added postgres health check and readyness dependency

### DIFF
--- a/dev-docker-compose.yml
+++ b/dev-docker-compose.yml
@@ -35,7 +35,10 @@ services:
     container_name: phase-backend-dev
     restart: unless-stopped
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
     build:
       context: ./backend
       dockerfile: Dockerfile.dev
@@ -60,6 +63,11 @@ services:
       - phase-postgres-data-dev:/var/lib/postgresql/data
     networks:
       - phase-net-dev
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DATABASE_USER} -d ${DATABASE_NAME}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   redis:
     container_name: phase-redis-dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,8 +35,10 @@ services:
     container_name: phase-backend
     restart: unless-stopped
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
     image: phasehq/backend:latest
     env_file: .env
     environment:
@@ -79,6 +81,11 @@ services:
       - phase-postgres-data:/var/lib/postgresql/data
     networks:
       - phase-net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DATABASE_USER} -d ${DATABASE_NAME}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   redis:
     container_name: phase-redis

--- a/staging-docker-compose.yml
+++ b/staging-docker-compose.yml
@@ -41,8 +41,10 @@ services:
     container_name: phase-backend-staging
     restart: unless-stopped
     depends_on:
-      - postgres
-      - redis
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
     build:
       context: ./backend
       dockerfile: Dockerfile
@@ -87,6 +89,11 @@ services:
       - phase-postgres-data-dev:/var/lib/postgresql/data
     networks:
       - phase-net-dev
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DATABASE_USER} -d ${DATABASE_NAME}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   redis:
     container_name: phase-redis


### PR DESCRIPTION
## :mag: Overview

This PR adds a health check to all the docker compose postgresql container configs along with readyness dependency to the backend container. This will ensure that postgresql is up and running, relevant users have been created before the backend starts making connections.