### PR TITLE
chore: bump posthog

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,7 @@
     "next-auth": "^4.24.5",
     "nextjs-toploader": "^1.6.4",
     "npm": "^10.4.0",
-    "posthog-js": "^1.150.1",
+    "posthog-js": "^1.167.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.2.1",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7847,10 +7847,10 @@ postcss@^8.4.23, postcss@^8.4.33:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-posthog-js@^1.150.1:
-  version "1.150.1"
-  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.150.1.tgz#ce2e0aa0dc30369bf1b1b9a38b9fbf25e5c01ba0"
-  integrity sha512-jHSnqtAWkUQkiedQgHpD00+z8RUF0loDq7ORakBKfQjdntTJIEk16ewqTNRxnpE86guWDoy2J3iAqLgAYfFaLA==
+posthog-js@^1.167.0:
+  version "1.167.0"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.167.0.tgz#9a6f7dc26b292f846938655b513ecda484210d59"
+  integrity sha512-/zXQ6tuJgiF1d4mgg3UsAi/uoyg7UnfFNQtikuALmaE53xFExpcAKbMfHPG/f54QgTvLxSHyGL1kFl/1uspkGg==
   dependencies:
     fflate "^0.4.8"
     preact "^10.19.3"


### PR DESCRIPTION
## :mag: Overview

Bump posthog dependency to the latest version `1.167.0`.

### :green_heart: Did You...

- [ ] Ensure linting passes (code style checks)?
- [x] Update dependencies and lockfiles (if required)
- [ ] Regenerate graphql schema and types (if required)
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
