### PR TITLE
fix: release info widget

### DIFF
--- a/frontend/app/[team]/settings/page.tsx
+++ b/frontend/app/[team]/settings/page.tsx
@@ -144,7 +144,7 @@ export default function Settings({ params }: { params: { team: string } }) {
               </Tab.Panel>
 
               <Tab.Panel>
-                <div className="space-y-8">
+                <div className="space-y-8 h-[50vh]">
                   <div>
                     <h2 className="text-2xl font-semibold mb-2">App</h2>
                     <p className="text-neutral-500">

--- a/frontend/components/ReleaseInfo.tsx
+++ b/frontend/components/ReleaseInfo.tsx
@@ -100,7 +100,7 @@ export const ReleaseInfo = () => {
               leaveFrom="transform opacity-100 scale-100"
               leaveTo="transform opacity-0 scale-95"
             >
-              <Popover.Panel className="absolute z-50 right-0 mt-2 w-60 p-4 origin-top-right divide-y divide-neutral-500/20 rounded-md bg-neutral-200 dark:bg-neutral-800 shadow-lg ring-1 ring-inset ring-neutral-500/40 focus:outline-none">
+              <Popover.Panel className="absolute z-50 left-0 mt-2 w-60 p-4 origin-top-right divide-y divide-neutral-500/20 rounded-md bg-neutral-200 dark:bg-neutral-800 shadow-lg ring-1 ring-inset ring-neutral-500/40 focus:outline-none">
                 <div className="flex flex-col space-y-4 border-l border-neutral-500/40">
                   {releases.map((release, index) => (
                     <div key={release.id} className="flex gap-2 items-start">
@@ -110,8 +110,8 @@ export const ReleaseInfo = () => {
                           release.tag_name === healthData.version
                             ? 'bg-emerald-500'
                             : index === 0
-                            ? 'bg-amber-500'
-                            : 'bg-neutral-500'
+                              ? 'bg-amber-500'
+                              : 'bg-neutral-500'
                         )}
                       ></div>
                       <div className="flex flex-col">
@@ -124,8 +124,8 @@ export const ReleaseInfo = () => {
                             release.tag_name === healthData.version
                               ? 'text-emerald-500 font-bold'
                               : index === 0
-                              ? 'text-amber-500 font-bold'
-                              : 'text-neutral-500 hover:text-neutral-400'
+                                ? 'text-amber-500 font-bold'
+                                : 'text-neutral-500 hover:text-neutral-400'
                           )}
                         >
                           {release.tag_name === healthData.version ? (

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -5,7 +5,7 @@ const ContentSecurityPolicy = `
   style-src 'self' 'unsafe-inline';
   object-src 'none';
   base-uri 'self';
-  connect-src 'self' data: http://127.0.0.1:* https://*.phase.dev https://phase.statuspage.io/api/v2/status.json https://checkout.stripe.com https://api.stripe.com; 
+  connect-src 'self' data: http://127.0.0.1:* https://*.phase.dev https://phase.statuspage.io/api/v2/status.json https://checkout.stripe.com https://api.stripe.com https://api.github.com; 
   font-src 'self';
   frame-src 'self' https://checkout.stripe.com https://*.js.stripe.com https://js.stripe.com https://hooks.stripe.com;
   img-src 'self' https://lh3.googleusercontent.com https://avatars.githubusercontent.com https://secure.gravatar.com https://gitlab.com https://*.stripe.com; 


### PR DESCRIPTION
## :mag: Overview

The release info widget fails to fetch the latest releases due to a CSP restriction, and has bugs with its layout and positioning.

## :bulb: Proposed Changes
* Added `https://api.github.com` to the CSP whitelist
* Fixed the layout and positioning

## :framed_picture: Screenshots or Demo

![image](https://github.com/user-attachments/assets/c26fc525-1c4f-414f-ae2c-48900f9f78ce)

## :memo: Release Notes

Fixed release info widget in Console settings

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [ ] Manually test the changes on different browsers/devices?
