### PR TITLE
feat: truncate text in navbar

### DIFF
--- a/frontend/components/layout/Navbar.tsx
+++ b/frontend/components/layout/Navbar.tsx
@@ -48,31 +48,31 @@ export const NavBar = (props: { team: string }) => {
 
   return (
     <header className="pr-8 pl-4 w-full h-16 border-b border-neutral-500/20 fixed top-0 z-10 grid grid-cols-3 gap-4 items-center justify-between text-neutral-500 font-medium bg-neutral-100/70 dark:bg-neutral-800/20 backdrop-blur-md">
-      <div className="flex items-center gap-2">
-        <Link href="/">
+      <div className="flex items-center gap-2 min-w-0 overflow-hidden">
+        <Link href="/" className="shrink-0">
           <LogoMark className="w-10 fill-black dark:fill-white" />
         </Link>
-        <span>/</span>
+        <span className="shrink-0">/</span>
 
-        {!activeApp && <span className="text-black dark:text-white">{props.team}</span>}
+        {!activeApp && (<span className="text-black dark:text-white overflow-hidden text-ellipsis whitespace-nowrap">{props.team}</span>)}
 
-        {activeApp && <Link href={`/${props.team}`}>{props.team}</Link>}
+        {activeApp && (<Link href={`/${props.team}`} className="overflow-hidden text-ellipsis whitespace-nowrap">{props.team}</Link>)}
 
-        {activeApp && <span>/</span>}
+        {activeApp && <span className="shrink-0">/</span>}
 
         {activeApp &&
           (appPage ? (
-            <Link href={`/${props.team}/apps/${activeApp.id}`}>{activeApp.name}</Link>
+            <Link href={`/${props.team}/apps/${activeApp.id}`} className="overflow-hidden text-ellipsis whitespace-nowrap">{activeApp.name}</Link>
           ) : (
-            <span className="text-black dark:text-white">{activeApp.name}</span>
+            <span className="text-black dark:text-white overflow-hidden text-ellipsis whitespace-nowrap">{activeApp.name}</span>
           ))}
 
-        {appPage && <span>/</span>}
+        {appPage && <span className="shrink-0">/</span>}
 
         {appPage && (
           <span
             className={clsx(
-              'capitalize',
+              'capitalize overflow-hidden text-ellipsis whitespace-nowrap',
               activeEnv ? 'text-neutral-500' : 'text-black dark:text-white'
             )}
           >
@@ -80,9 +80,9 @@ export const NavBar = (props: { team: string }) => {
           </span>
         )}
 
-        {activeEnv && <span>/</span>}
+        {activeEnv && <span className="shrink-0">/</span>}
 
-        {activeEnv && <span className="text-black dark:text-white">{activeEnv.name}</span>}
+        {activeEnv && (<span className="text-black dark:text-white overflow-hidden text-ellipsis whitespace-nowrap">{activeEnv.name}</span>)}
       </div>
 
       <div className="flex justify-center w-full">


### PR DESCRIPTION
## :mag: Overview
Long application names, environment names, and other elements in the navigation bar currently overflow their containers, leading to layout issues. This affects the UI's cleanliness and usability, particularly with longer text strings.

## :bulb: Proposed Changes
- Added CSS-based text truncation for navigation elements that can overflow
- Implemented flexible width handling while maintaining the navbar's existing structure
- Added `shrink-0` to fixed elements (logo, separators) to preserve their dimensions
- Applied `text-ellipsis` to truncatable elements while allowing them to expand when space permits

## :framed_picture: Screenshots or Demo
**Before:**
![image](https://github.com/user-attachments/assets/26b9b122-baf1-4cca-b238-8116ed783f9d)

**After:**
![image](https://github.com/user-attachments/assets/caac178f-6866-4e70-9dd8-20e498993b7d)

## :memo: Release Notes
- Fixed UI issue where long application names and environment names would overflow in the navigation bar
- Improved responsive behavior of navigation text elements

## :test_tube: Testing
Test cases to verify:
- Very long application names (>30 characters)
- Multiple environment names in the path
- Different viewport widths
- Various browser zoom levels

### :dart: Reviewer Focus
- Check `NavBar.tsx` for the CSS class changes
- Verify truncation behavior at different screen sizes
- Ensure the navbar maintains its layout structure

### :green_heart: Did You...
- [x] Verify the app builds locally
- [x] Manually test the changes on different browsers/devices
- [x] Test with various text lengths and viewport sizes

This is a purely CSS-based fix with no functional changes to the application's behavior.