### PR TITLE
fix: add early return during account recovery if keys are incorrect

### DIFF
--- a/frontend/app/[team]/recovery/page.tsx
+++ b/frontend/app/[team]/recovery/page.tsx
@@ -79,6 +79,7 @@ export default function Recovery({ params }: { params: { team: string } }) {
         if (accountKeyRing.publicKey !== org?.identityKey) {
           toast.error('Incorrect account recovery key!')
           reject('Incorrect account recovery key')
+          return;
         }
 
         const deviceKey = await deviceVaultKey(pw, session?.user?.email!)


### PR DESCRIPTION
## :mag: Overview

Fixes an issue with the recovery process incorrectly proceeding even when an incorrect recovery phrase is entered. 

## :bulb: Proposed Changes

Add an early return when an incorrect recovery phrase is entered, to prevent further code execution

