### PR TITLE
Feat  collapsible  sidebar

### DIFF
--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -5,6 +5,7 @@ import { SessionProvider } from 'next-auth/react'
 import { ApolloProvider } from '@apollo/client'
 import { graphQlClient } from '@/apollo/client'
 import { KeyringProvider } from '@/contexts/keyringContext'
+import { SidebarProvider } from '@/contexts/sidebarContext'
 import { OrganisationProvider } from '@/contexts/organisationContext'
 import posthog from 'posthog-js'
 import { PostHogProvider } from 'posthog-js/react'
@@ -21,15 +22,17 @@ export default function Providers({ children }: { children: React.ReactNode }) {
 
   return (
     <ThemeProvider>
-      <SessionProvider>
-        <ApolloProvider client={graphQlClient}>
-          <OrganisationProvider>
-            <KeyringProvider>
-              <PostHogProvider client={posthog}>{children}</PostHogProvider>
-            </KeyringProvider>
-          </OrganisationProvider>
-        </ApolloProvider>
-      </SessionProvider>
+      <SidebarProvider>
+        <SessionProvider>
+          <ApolloProvider client={graphQlClient}>
+            <OrganisationProvider>
+              <KeyringProvider>
+                <PostHogProvider client={posthog}>{children}</PostHogProvider>
+              </KeyringProvider>
+            </OrganisationProvider>
+          </ApolloProvider>
+        </SessionProvider>
+      </SidebarProvider>
     </ThemeProvider>
   )
 }

--- a/frontend/contexts/sidebarContext.tsx
+++ b/frontend/contexts/sidebarContext.tsx
@@ -1,0 +1,41 @@
+import React, { createContext, useState, useEffect } from 'react'
+
+type SidebarState = 'expanded' | 'collapsed'
+
+interface SidebarContextValue {
+  sidebarState: SidebarState
+  setSidebarState: (state: SidebarState) => void
+}
+
+const getInitialState = (): SidebarState => {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    const storedState = window.localStorage.getItem('sidebar-state')
+    if (storedState === 'collapsed') {
+      return 'collapsed'
+    }
+  }
+  return 'expanded' // Default state is expanded
+}
+
+export const SidebarContext = createContext<SidebarContextValue>({
+  sidebarState: 'expanded',
+  setSidebarState: () => {},
+})
+
+interface SidebarProviderProps {
+  children: React.ReactNode
+}
+
+export const SidebarProvider: React.FC<SidebarProviderProps> = ({ children }) => {
+  const [sidebarState, setSidebarState] = useState<SidebarState>(getInitialState())
+
+  useEffect(() => {
+    localStorage.setItem('sidebar-state', sidebarState)
+  }, [sidebarState])
+
+  return (
+    <SidebarContext.Provider value={{ sidebarState, setSidebarState }}>
+      {children}
+    </SidebarContext.Provider>
+  )
+}


### PR DESCRIPTION
## :mag: Overview

This PR brings a few changes to the new side bar added in https://github.com/phasehq/console/pull/383.

- Added collapsible side bar
- Rearranged the sidebar order
- Increased the size of the sidebar icons
- Added local storage context utils to store the state of the sidebar on disk

## :framed_picture: Screenshots or Demo

https://github.com/user-attachments/assets/e2632b71-79ab-43a9-b3db-a02b4695be4c

## :sparkles: How to Test the Changes Locally

- Test the expanded / collapsed state of the sidebar on various devices
- Make sure the state it saved in disk and doesn't reset after a page refresh

### :green_heart: Did You...

- [ ] Ensure linting passes (code style checks)?
- [ ] Update dependencies and lockfiles (if required)
- [ ] Regenerate graphql schema and types (if required)
- [ ] Verify the app builds locally?
- [ ] Manually test the changes on different browsers/devices?
