### PR TITLE
fix: permission checks and rendering for onboarding guide

### DIFF
--- a/frontend/components/dashboard/GetStarted.tsx
+++ b/frontend/components/dashboard/GetStarted.tsx
@@ -124,7 +124,8 @@ export const GetStarted = (props: { organisation: OrganisationType }) => {
   const userCanReadSyncs = userHasPermission(
     organisation?.role?.permissions,
     'Integrations',
-    'read'
+    'read',
+    true
   )
 
   const hasPermissionsForGuide =
@@ -228,6 +229,8 @@ export const GetStarted = (props: { organisation: OrganisationType }) => {
       linkText: 'Join',
     },
   ]
+
+  if (!hasPermissionsForGuide) return <></>
 
   if (!showGuide)
     return (


### PR DESCRIPTION
## :mag: Overview

The "Getting Started" guide does not update to reflect the current state of the completed steps, due to an incorrect permission check that caused the query to be skipped

## :bulb: Proposed Changes

* Fix the permission check to allow the required query to be executed and render the correct state of the guide
* Defer rendering the guide if the required permissions are not available, rather than show the guide with incorrect state

## :framed_picture: Screenshots or Demo
![image](https://github.com/user-attachments/assets/9256096f-27cc-46af-a0ad-a57f8e2225e4)

## :memo: Release Notes

Fixed a bug that caused the "Getting started" guide on the organisation home page to not update correctly.


### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
