### PR TITLE
fix: seat count in self checkout price preview

### DIFF
--- a/frontend/components/settings/organisation/UpsellDialog.tsx
+++ b/frontend/components/settings/organisation/UpsellDialog.tsx
@@ -52,7 +52,7 @@ export const UpsellDialog = ({
           activeOrganisation.plan === ApiOrganisationPlanChoices.Pr ? (
             <UpgradeRequestForm onSuccess={() => {}} />
           ) : (
-            ProUpgradeDialog && <ProUpgradeDialog userCount={data.organisationPlan.userCount} />
+            ProUpgradeDialog && <ProUpgradeDialog userCount={data.organisationPlan.seatsUsed.total} />
           )
         ) : (
           <div className="text-zinc-900 dark:text-zinc-100">


### PR DESCRIPTION
## :mag: Overview

Fixes the seat count in the preview when upgrading to pro via self-checkout. This is related to the schema change in https://github.com/phasehq/console/pull/393/commits/323d47d58c268721567d9433a162d1a945808667


## :framed_picture: Screenshots or Demo

### Before
![Screenshot From 2024-11-26 15-19-21](https://github.com/user-attachments/assets/fceacc91-c4f7-4b22-ae98-639451c3158a)

### After
![Screenshot From 2024-11-26 15-19-12](https://github.com/user-attachments/assets/3fca30f9-ed34-47fb-b857-99329dfe5454)


## :memo: Release Notes

Fixed a bug with Stripe self-checkout for Phase Cloud


### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [ ] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
