### PR TITLE
feat: add app name in the input placeholder

### DIFF
--- a/frontend/components/apps/DeleteAppDialog.tsx
+++ b/frontend/components/apps/DeleteAppDialog.tsx
@@ -143,19 +143,15 @@ export default function DeleteAppDialog(props: {
                       </Alert>
 
                       <div className="flex flex-col justify-center max-w-md mx-auto">
-                        <label
-                          className="block text-gray-700 text-sm font-bold mb-2"
-                          htmlFor="appname"
-                        >
-                          Please type the App name to confirm
-                        </label>
+                        <div className="text-sm text-gray-500 dark:text-gray-400 mb-2">
+                          Please enter the App name <span className="text-gray-900 dark:text-white font-mono font-medium">{appName}</span> to confirm:
+                        </div>
                         <input
                           id="appname"
                           className="text-lg"
                           required
                           maxLength={64}
                           value={typedName}
-                          placeholder={appName}
                           onChange={(e) => setTypedName(e.target.value)}
                         />
                       </div>

--- a/frontend/components/apps/DeleteAppDialog.tsx
+++ b/frontend/components/apps/DeleteAppDialog.tsx
@@ -155,7 +155,7 @@ export default function DeleteAppDialog(props: {
                           required
                           maxLength={64}
                           value={typedName}
-                          placeholder="MyApp"
+                          placeholder={appName}
                           onChange={(e) => setTypedName(e.target.value)}
                         />
                       </div>


### PR DESCRIPTION
## :mag: Overview
This PR updates the DeleteAppDialog component to improve user experience by displaying the actual app name in the confirmation input field's placeholder text, rather than using a static "MyApp" placeholder. This change makes it clearer to users which app they're about to delete.

## :bulb: Proposed Changes
- Modified the input placeholder in DeleteAppDialog to dynamically use the app name passed via props
- Removed hardcoded "MyApp" placeholder text
- Maintains all existing delete confirmation functionality and validation

### :test_tube: Testing
- Manually tested with various app names to ensure placeholder updates correctly
- Verified that delete confirmation validation still works as expected

### :dart: Reviewer Focus
Please focus on:
- DeleteAppDialog component changes (single line modification)
- Verify that the placeholder text properly updates based on the appName prop
- Confirm that delete functionality and validation remain intact

