### PR TITLE
feat: active polling

### DIFF
--- a/frontend/apollo/client.ts
+++ b/frontend/apollo/client.ts
@@ -48,7 +48,7 @@ export const graphQlClient = new ApolloClient({
   cache: new InMemoryCache(),
   defaultOptions: {
     watchQuery: {
-      skipPollAttempt: () => document.hidden || !document.hasFocus()
+      skipPollAttempt: () => document.hidden
     }
   }
 })

--- a/frontend/apollo/client.ts
+++ b/frontend/apollo/client.ts
@@ -46,4 +46,9 @@ const errorLink = onError(({ graphQLErrors, networkError, operation, forward }) 
 export const graphQlClient = new ApolloClient({
   link: from([errorLink, httpLink]),
   cache: new InMemoryCache(),
+  defaultOptions: {
+    watchQuery: {
+      skipPollAttempt: () => document.hidden || !document.hasFocus()
+    }
+  }
 })

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,7 @@
     "codegen": "graphql-codegen --config codegen.ts"
   },
   "dependencies": {
-    "@apollo/client": "^3.8.10",
+    "@apollo/client": "^3.11.10",
     "@headlessui/react": "^1.7.18",
     "@heroicons/react": "^2.1.1",
     "@stripe/react-stripe-js": "^2.7.3",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -20,18 +20,20 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@apollo/client@^3.8.10":
-  version "3.8.10"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.8.10.tgz#db6ee4378212d93c1f22b90a2aa474f6e9664b68"
-  integrity sha512-p/22RZ8ehHyvySnC20EHPPe0gdu8Xp6ZCiXOfdEe1ZORw5cUteD/TLc66tfKv8qu8NLIfbiWoa+6s70XnKvxqg==
+"@apollo/client@^3.11.10":
+  version "3.11.10"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.11.10.tgz#e16ae82ea9b16536ffd109847d24f9293fab5c4d"
+  integrity sha512-IfGc+X4il0rDqVQBBWdxIKM+ciDCiDzBq9+Bg9z4tJMi87uF6po4v+ddiac1wP0ARgVPsFwEIGxK7jhN4pW8jg==
   dependencies:
     "@graphql-typed-document-node/core" "^3.1.1"
+    "@wry/caches" "^1.0.0"
     "@wry/equality" "^0.5.6"
     "@wry/trie" "^0.5.0"
     graphql-tag "^2.12.6"
     hoist-non-react-statics "^3.3.2"
     optimism "^0.18.0"
     prop-types "^15.7.2"
+    rehackt "^0.1.0"
     response-iterator "^0.2.6"
     symbol-observable "^4.0.0"
     ts-invariant "^0.10.3"
@@ -8257,6 +8259,11 @@ regexp.prototype.flags@^1.5.1:
     call-bind "^1.0.2"
     define-properties "^1.2.0"
     set-function-name "^2.0.0"
+
+rehackt@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/rehackt/-/rehackt-0.1.0.tgz#a7c5e289c87345f70da8728a7eb878e5d03c696b"
+  integrity sha512-7kRDOuLHB87D/JESKxQoRwv4DzbIdwkAGQ7p6QKGdVlY1IZheUnVhlk/4UZlNUVxdAXpyxikE3URsG067ybVzw==
 
 relay-runtime@12.0.0:
   version "12.0.0"


### PR DESCRIPTION
## :mag: Overview

The console leverages the `pollInterval` option on the apollo client's `useQuery` hook on various screens to ensure that the user always sees the most recent data, such as sync status, secrets, etc. This works, but causes significant client and server load on aggregate during very long sessions where much of the polling is not required due to the tab or window being either hidden or out of focus.

## :bulb: Proposed Changes

Skip polling attempts when the tab is hidden or out of focus. This is accomplished via the new `skipPollAttempt` option for `useQuery` in apollo-client `3.9.0`

## :framed_picture: Screenshots or Demo


https://github.com/user-attachments/assets/c535d3ba-cb9d-43a3-905f-d4b962304c2e



## :memo: Release Notes

Skip polling the backend on various screens when the Console is hidden or out of focus

## :question: Open Questions

~~Should polling continue when the document is out of focus but not hidden? (like in the demo above, for example)~~
Yes

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
- [x] Update dependencies and lockfiles (if required)
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
