### PR TITLE
feat: webauth improvements

### DIFF
--- a/frontend/app/webauth/[requestCode]/page.tsx
+++ b/frontend/app/webauth/[requestCode]/page.tsx
@@ -369,7 +369,11 @@ export default function WebAuth({ params }: { params: { requestCode: string } })
                   When prompted, paste the following token and press <code className="font-mono font-bold">Enter</code>:
                 </p>
               </div>
-              <code className="text-xs break-all text-blue-500 ph-no-capture">{userToken}</code>
+              <CliCommand 
+                command={userToken} 
+                prefix=""
+                wrap={true}
+              />
             </div>
           </div>
 

--- a/frontend/app/webauth/[requestCode]/page.tsx
+++ b/frontend/app/webauth/[requestCode]/page.tsx
@@ -9,8 +9,9 @@ import OnboardingNavbar from '@/components/layout/OnboardingNavbar'
 import { RoleLabel } from '@/components/users/RoleLabel'
 import { organisationContext } from '@/contexts/organisationContext'
 import { CreateNewUserToken } from '@/graphql/mutations/users/createUserToken.gql'
-
+import { CliCommand } from 'components/dashboard/CliCommand'
 import { copyToClipBoard } from '@/utils/clipboard'
+import { isCloudHosted } from '@/utils/appConfig'
 import {
   OrganisationKeyring,
   getUserKxPublicKey,

--- a/frontend/app/webauth/[requestCode]/page.tsx
+++ b/frontend/app/webauth/[requestCode]/page.tsx
@@ -380,7 +380,7 @@ export default function WebAuth({ params }: { params: { requestCode: string } })
                   3
                 </span>
                 <p className="text-black dark:text-white">
-                  When prompted, paste Personal Access Token (PAT):
+                  When prompted, paste your Personal Access Token (PAT):
                 </p>
               </div>
               <CliCommand 

--- a/frontend/app/webauth/[requestCode]/page.tsx
+++ b/frontend/app/webauth/[requestCode]/page.tsx
@@ -377,19 +377,31 @@ export default function WebAuth({ params }: { params: { requestCode: string } })
             </div>
           </div>
 
-          <div className="space-y-2 pt-20 text-center">
-            <div className="text-neutral-500 text-sm">Still having issues? Get in touch.</div>
-            <div className="flex items-center gap-2 justify-center">
-              <a href="https://slack.phase.dev" target="_blank" rel="noreferrer">
-                <Button variant="secondary">
-                  <SiSlack /> Slack
-                </Button>
+          <div className="space-y-4 pt-16">
+            <div className="text-center">
+              <a 
+                href="https://docs.phase.dev/cli/commands#auth" 
+                target="_blank" 
+                rel="noreferrer"
+                className="text-sm text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300"
+              >
+                Phase CLI authentication documentation
               </a>
-              <a href="https://github.com/phasehq" target="_blank" rel="noreferrer">
-                <Button variant="secondary">
-                  <SiGithub /> GitHub
-                </Button>
-              </a>
+            </div>
+            <div className="text-center">
+              <div className="text-neutral-500 text-sm">Still having issues? Get in touch.</div>
+              <div className="flex items-center gap-2 justify-center mt-2">
+                <a href="https://slack.phase.dev" target="_blank" rel="noreferrer">
+                  <Button variant="secondary">
+                    <SiSlack /> Slack
+                  </Button>
+                </a>
+                <a href="https://github.com/phasehq" target="_blank" rel="noreferrer">
+                  <Button variant="secondary">
+                    <SiGithub /> GitHub
+                  </Button>
+                </a>
+              </div>
             </div>
           </div>
         </div>

--- a/frontend/app/webauth/[requestCode]/page.tsx
+++ b/frontend/app/webauth/[requestCode]/page.tsx
@@ -368,7 +368,7 @@ export default function WebAuth({ params }: { params: { requestCode: string } })
                       Enter the host: <code className="text-emerald-500 cursor-pointer font-mono" onClick={() => handleCopy(getHostname() || '')}>{getHostname()}</code>
                     </li>
                     <li>
-                      Enter your Email: <code className="text-emerald-500 cursor-pointer font-mono" onClick={() => handleCopy(session?.user?.email || '')}>{session?.user?.email}</code>
+                      Enter your email address: <code className="text-emerald-500 cursor-pointer font-mono" onClick={() => handleCopy(session?.user?.email || '')}>{session?.user?.email}</code>
                     </li>
                   </ul>
                 )}

--- a/frontend/app/webauth/[requestCode]/page.tsx
+++ b/frontend/app/webauth/[requestCode]/page.tsx
@@ -321,7 +321,7 @@ export default function WebAuth({ params }: { params: { requestCode: string } })
               <FaExclamationTriangle className="text-amber-500" size="40" />
             </div>
             <h1 className="text-black dark:text-white text-4xl font-semibold">
-              CLI Authentication error
+              CLI Authentication failed
             </h1>
             <p className="text-neutral-500 text-base">
               Something went wrong authenticating with the CLI. Please try the following steps:

--- a/frontend/app/webauth/[requestCode]/page.tsx
+++ b/frontend/app/webauth/[requestCode]/page.tsx
@@ -346,7 +346,7 @@ export default function WebAuth({ params }: { params: { requestCode: string } })
                 <span className="flex h-6 w-6 items-center justify-center rounded-full bg-neutral-500/20 text-sm font-medium">
                   2
                 </span>
-                <p className="text-black dark:text-white">Authenticate  via a Personal Access Token (PAT):</p>
+                <p className="text-black dark:text-white">Retry authentication manually via the <code className="font-mono">token</code> mode:</p>
               </div>
               <CliCommand command="auth --mode token" />
               <div className="pl-8 text-neutral-500 text-sm space-y-2">

--- a/frontend/app/webauth/[requestCode]/page.tsx
+++ b/frontend/app/webauth/[requestCode]/page.tsx
@@ -325,7 +325,7 @@ export default function WebAuth({ params }: { params: { requestCode: string } })
               CLI Authentication failed
             </h1>
             <p className="text-neutral-500 text-base">
-              Not able to connect to your CLI from this page. Please follow these steps to complete the authentication:
+              CLI authentication could not be completed from this page. Please follow these steps to retry the authentication:
             </p>
           </div>
 

--- a/frontend/app/webauth/[requestCode]/page.tsx
+++ b/frontend/app/webauth/[requestCode]/page.tsx
@@ -351,20 +351,29 @@ export default function WebAuth({ params }: { params: { requestCode: string } })
               <CliCommand command="auth --mode token" />
               <div className="pl-8 text-neutral-500 text-sm space-y-2">
                 {isCloudHosted() ? (
-                  <p>
-                    Choose your Phase instance type as: <b>☁️ Phase Cloud</b> <br />
-                    Enter your Email: <code className="text-emerald-500 cursor-pointer font-mono" onClick={() => handleCopy(session?.user?.email || '')}>{session?.user?.email}</code>
-                  </p>
+                  <ul className="list-disc list-inside space-y-2">
+                    <li>
+                      Choose your Phase instance type as: <b>☁️ Phase Cloud</b>
+                    </li>
+                    <li>
+                      Enter your Email: <code className="text-emerald-500 cursor-pointer font-mono" onClick={() => handleCopy(session?.user?.email || '')}>{session?.user?.email}</code>
+                    </li>
+                  </ul>
                 ) : (
-                  <p>
-                    Choose your Phase instance type as: <b>🛠️ Self Hosted</b> <br />
-                    Enter the host: <code className="text-emerald-500 cursor-pointer font-mono" onClick={() => handleCopy(getHostname() || '')}>{getHostname()}</code> <br />
-                    Enter your Email: <code className="text-emerald-500 cursor-pointer font-mono" onClick={() => handleCopy(session?.user?.email || '')}>{session?.user?.email}</code>
-                  </p>
+                  <ul className="list-disc list-inside space-y-2">
+                    <li>
+                      Choose your Phase instance type as: <b>🛠️ Self Hosted</b>
+                    </li>
+                    <li>
+                      Enter the host: <code className="text-emerald-500 cursor-pointer font-mono" onClick={() => handleCopy(getHostname() || '')}>{getHostname()}</code>
+                    </li>
+                    <li>
+                      Enter your Email: <code className="text-emerald-500 cursor-pointer font-mono" onClick={() => handleCopy(session?.user?.email || '')}>{session?.user?.email}</code>
+                    </li>
+                  </ul>
                 )}
               </div>
             </div>
-
             <div className="space-y-2">
               <div className="flex items-center gap-2">
                 <span className="flex h-6 w-6 items-center justify-center rounded-full bg-neutral-500/20 text-sm font-medium">

--- a/frontend/app/webauth/[requestCode]/page.tsx
+++ b/frontend/app/webauth/[requestCode]/page.tsx
@@ -11,7 +11,7 @@ import { organisationContext } from '@/contexts/organisationContext'
 import { CreateNewUserToken } from '@/graphql/mutations/users/createUserToken.gql'
 import { CliCommand } from 'components/dashboard/CliCommand'
 import { copyToClipBoard } from '@/utils/clipboard'
-import { isCloudHosted } from '@/utils/appConfig'
+import { isCloudHosted, getHostname } from '@/utils/appConfig'
 import {
   OrganisationKeyring,
   getUserKxPublicKey,

--- a/frontend/app/webauth/[requestCode]/page.tsx
+++ b/frontend/app/webauth/[requestCode]/page.tsx
@@ -341,7 +341,7 @@ export default function WebAuth({ params }: { params: { requestCode: string } })
               </div>
             </div>
 
-            <div className="space-y-2">
+            <div className="space-y-6">
               <div className="flex items-center gap-2">
                 <span className="flex h-6 w-6 items-center justify-center rounded-full bg-neutral-500/20 text-sm font-medium">
                   2

--- a/frontend/app/webauth/[requestCode]/page.tsx
+++ b/frontend/app/webauth/[requestCode]/page.tsx
@@ -9,7 +9,7 @@ import OnboardingNavbar from '@/components/layout/OnboardingNavbar'
 import { RoleLabel } from '@/components/users/RoleLabel'
 import { organisationContext } from '@/contexts/organisationContext'
 import { CreateNewUserToken } from '@/graphql/mutations/users/createUserToken.gql'
-import { CliCommand } from 'components/dashboard/CliCommand'
+import { CliCommand } from '@/components/dashboard/CliCommand'
 import { copyToClipBoard } from '@/utils/clipboard'
 import { isCloudHosted, getHostname } from '@/utils/appConfig'
 import {

--- a/frontend/app/webauth/[requestCode]/page.tsx
+++ b/frontend/app/webauth/[requestCode]/page.tsx
@@ -356,7 +356,7 @@ export default function WebAuth({ params }: { params: { requestCode: string } })
                       Choose your Phase instance type as: <b>☁️ Phase Cloud</b>
                     </li>
                     <li>
-                      Enter your Email: <code className="text-emerald-500 cursor-pointer font-mono" onClick={() => handleCopy(session?.user?.email || '')}>{session?.user?.email}</code>
+                      Enter your email address: <code className="text-emerald-500 cursor-pointer font-mono" onClick={() => handleCopy(session?.user?.email || '')}>{session?.user?.email}</code>
                     </li>
                   </ul>
                 ) : (

--- a/frontend/app/webauth/[requestCode]/page.tsx
+++ b/frontend/app/webauth/[requestCode]/page.tsx
@@ -346,17 +346,21 @@ export default function WebAuth({ params }: { params: { requestCode: string } })
                 <span className="flex h-6 w-6 items-center justify-center rounded-full bg-neutral-500/20 text-sm font-medium">
                   2
                 </span>
-                <p className="text-black dark:text-white">Retry authentication manually via the <code className="font-mono">token</code> mode:</p>
+                <p className="text-black dark:text-white">Retry authentication manually via the <code className="font-mono font-bold">token</code> mode:</p>
               </div>
               <CliCommand command="auth --mode token" />
               <div className="pl-8 text-neutral-500 text-sm space-y-2">
                 {isCloudHosted() ? (
-                  <p>Choose your Phase instance type as: <b>☁️ Phase Cloud</b> and hit <code className="font-mono">Enter</code> <br />
-                  Enter your Email: <code className="text-emerald-500 cursor-pointer font-mono" onClick={() => handleCopy(session?.user?.email)}>{session?.user?.email}</code> and hit <code className="font-mono">Enter</code></p>
+                  <p>
+                    Choose your Phase instance type as: <b>☁️ Phase Cloud</b> <br />
+                    Enter your Email: <code className="text-emerald-500 cursor-pointer font-mono" onClick={() => handleCopy(session?.user?.email || '')}>{session?.user?.email}</code>
+                  </p>
                 ) : (
-                  <p>Choose your Phase instance type as: <b>🛠️ Self Hosted</b> and hit <code className="font-mono">Enter</code> <br />
-                  Enter the host as: <code className="text-emerald-500 cursor-pointer font-mono" onClick={() => handleCopy(process.env.NEXT_PUBLIC_NEXTAUTH_URL)}>{process.env.NEXT_PUBLIC_NEXTAUTH_URL}</code> <br />
-                  Enter your Email: <code className="text-emerald-500 cursor-pointer font-mono" onClick={() => handleCopy(session?.user?.email)}>{session?.user?.email}</code> and hit <code className="font-mono">Enter</code></p>
+                  <p>
+                    Choose your Phase instance type as: <b>🛠️ Self Hosted</b> <br />
+                    Enter the host: <code className="text-emerald-500 cursor-pointer font-mono" onClick={() => handleCopy(getHostname() || '')}>{getHostname()}</code> <br />
+                    Enter your Email: <code className="text-emerald-500 cursor-pointer font-mono" onClick={() => handleCopy(session?.user?.email || '')}>{session?.user?.email}</code>
+                  </p>
                 )}
               </div>
             </div>
@@ -367,7 +371,7 @@ export default function WebAuth({ params }: { params: { requestCode: string } })
                   3
                 </span>
                 <p className="text-black dark:text-white">
-                  When prompted, paste the following token and press <code className="font-mono font-bold">Enter</code>:
+                  When prompted, paste Personal Access Token (PAT):
                 </p>
               </div>
               <CliCommand 

--- a/frontend/app/webauth/[requestCode]/page.tsx
+++ b/frontend/app/webauth/[requestCode]/page.tsx
@@ -328,30 +328,46 @@ export default function WebAuth({ params }: { params: { requestCode: string } })
             </p>
           </div>
 
-          <ol className="text-left list-decimal list-inside text-black dark:text-white space-y-2">
-            <li>
-              Retry authentication with{' '}
-              <code
-                className="text-emerald-500 cursor-pointer"
-                onClick={() => handleCopy('phase auth --mode token')}
-              >
-                phase auth --mode token
-              </code>
-              .
-            </li>
-            <li>Paste the following token into your terminal when prompted:</li>
-          </ol>
-          <div className="py-0">
-            <div className="bg-blue-200 dark:bg-blue-400/10 shadow-inner p-3 rounded-lg">
-              <div className="w-full flex items-center justify-between pb-4">
-                <span className="uppercase text-xs tracking-widest text-gray-500">user token</span>
-                <div className="flex gap-4">
-                  {userToken && (
-                    <Button variant="outline" onClick={() => handleCopy(userToken)}>
-                      <MdContentCopy /> Copy
-                    </Button>
-                  )}
-                </div>
+          <div className="space-y-6">
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <span className="flex h-6 w-6 items-center justify-center rounded-full bg-neutral-500/20 text-sm font-medium">
+                  1
+                </span>
+                <p className="text-black dark:text-white">
+                  Exit out of the CLI by pressing <code className="font-mono font-bold">Ctrl+C</code>
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <span className="flex h-6 w-6 items-center justify-center rounded-full bg-neutral-500/20 text-sm font-medium">
+                  2
+                </span>
+                <p className="text-black dark:text-white">Authenticate  via a Personal Access Token (PAT):</p>
+              </div>
+              <CliCommand command="auth --mode token" />
+              <div className="pl-8 text-neutral-500 text-sm space-y-2">
+                {isCloudHosted() ? (
+                  <p>Choose your Phase instance type as: <b>☁️ Phase Cloud</b> and hit <code className="font-mono">Enter</code> <br />
+                  Enter your Email: <code className="text-emerald-500 cursor-pointer font-mono" onClick={() => handleCopy(session?.user?.email)}>{session?.user?.email}</code> and hit <code className="font-mono">Enter</code></p>
+                ) : (
+                  <p>Choose your Phase instance type as: <b>🛠️ Self Hosted</b> and hit <code className="font-mono">Enter</code> <br />
+                  Enter the host as: <code className="text-emerald-500 cursor-pointer font-mono" onClick={() => handleCopy(process.env.NEXT_PUBLIC_NEXTAUTH_URL)}>{process.env.NEXT_PUBLIC_NEXTAUTH_URL}</code> <br />
+                  Enter your Email: <code className="text-emerald-500 cursor-pointer font-mono" onClick={() => handleCopy(session?.user?.email)}>{session?.user?.email}</code> and hit <code className="font-mono">Enter</code></p>
+                )}
+              </div>
+            </div>
+
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <span className="flex h-6 w-6 items-center justify-center rounded-full bg-neutral-500/20 text-sm font-medium">
+                  3
+                </span>
+                <p className="text-black dark:text-white">
+                  When prompted, paste the following token and press <code className="font-mono font-bold">Enter</code>:
+                </p>
               </div>
               <code className="text-xs break-all text-blue-500 ph-no-capture">{userToken}</code>
             </div>

--- a/frontend/app/webauth/[requestCode]/page.tsx
+++ b/frontend/app/webauth/[requestCode]/page.tsx
@@ -324,7 +324,7 @@ export default function WebAuth({ params }: { params: { requestCode: string } })
               CLI Authentication failed
             </h1>
             <p className="text-neutral-500 text-base">
-              Something went wrong authenticating with the CLI. Please try the following steps:
+              Not able to connect to your CLI from this page. Please follow these steps to complete the authentication:
             </p>
           </div>
 

--- a/frontend/app/webauth/[requestCode]/page.tsx
+++ b/frontend/app/webauth/[requestCode]/page.tsx
@@ -388,7 +388,7 @@ export default function WebAuth({ params }: { params: { requestCode: string } })
                 href="https://docs.phase.dev/cli/commands#auth" 
                 target="_blank" 
                 rel="noreferrer"
-                className="text-sm text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300"
+                className="text-sm text-emerald-500 hover:text-emerald-400 transition ease"
               >
                 Phase CLI authentication documentation
               </a>

--- a/frontend/components/dashboard/CliCommand.tsx
+++ b/frontend/components/dashboard/CliCommand.tsx
@@ -1,22 +1,34 @@
 import CopyButton from 'components/common/CopyButton'
 
-export const CliCommand = (props: { command: string; comment?: string; prefix?: string }) => {
-  const prefix = props.prefix || 'phase'
+export const CliCommand = (props: { 
+  command: string; 
+  comment?: string; 
+  prefix?: string;
+  wrap?: boolean;
+}) => {
+  const prefix = props.prefix ?? 'phase'
+  const wrap = props.wrap ?? false
 
-  const prefixedCommand = `${prefix} ${props.command}`
+  const prefixedCommand = prefix ? `${prefix} ${props.command}` : props.command
 
   return (
     <div className="group relative rounded-lg border border-neutral-500/40 bg-zinc-300/50 dark:bg-zinc-800/50 p-4 text-left text-sm text-zinc-900 dark:text-zinc-100">
-      <pre className="whitespace-pre-wrap">
-        <span className="text-emerald-800 dark:text-emerald-300">{prefix}</span> {props.command}{' '}
-        {props.comment && (
-          <span className="text-neutral-500">
-            {'#'}
-            {props.comment}
-          </span>
-        )}
-      </pre>
-      <div className="absolute right-4 top-3.5 ">
+      <div className={`${!wrap ? 'overflow-x-auto scrollbar-thin scrollbar-track-transparent scrollbar-thumb-neutral-600' : ''}`}>
+        <pre className={`${wrap ? 'whitespace-pre-wrap break-all' : 'whitespace-pre'}`}>
+          {prefix && (
+            <span className="text-emerald-800 dark:text-emerald-300">{prefix}</span>
+          )}
+          {prefix && ' '}
+          {props.command}{' '}
+          {props.comment && (
+            <span className="text-neutral-500">
+              {'#'}
+              {props.comment}
+            </span>
+          )}
+        </pre>
+      </div>
+      <div className="absolute right-4 top-3.5">
         <CopyButton value={prefixedCommand} />
       </div>
     </div>


### PR DESCRIPTION
## :mag: Overview
This PR improves the CLI authentication error handling by providing clearer, step-by-step instructions when the webauth authentication fails. The changes help users seamlessly switch to token-based authentication, with specific guidance for both Phase Cloud and self-hosted deployments.

## :bulb: Proposed Changes
- Enhanced the error state UI with a numbered step-by-step guide
- Added separate flows for Phase Cloud and self-hosted environments
- Implemented copyable fields for email and host information
- Updated styling to match Phase's design system
- Added direct links to CLI documentation for additional help

## :framed_picture: Screenshots or Demo
### Before
![image](https://github.com/user-attachments/assets/cc2504c7-b8c4-41f0-a0e8-773492f66f06)
### After
On Phase Cloud:
![image](https://github.com/user-attachments/assets/573d100e-30d6-4683-9a3b-9d75aad72056)
On self-hosted:
![image](https://github.com/user-attachments/assets/8002c011-4922-49b1-a7b6-1a27b55da76e)

### :test_tube: Testing
Manually tested:
- Cloud hosted environment authentication flow
- Self-hosted environment authentication flow
- Token display and copying functionality
- Browser compatibility (Chrome, Firefox, Safari)
- Mobile responsiveness
- Dark/light mode compatibility

### :dart: Reviewer Focus
Please focus on:
1. `/webauth/page.tsx` - Main changes to the error handling UI
2. Token display implementation in CliCommand component
3. Environment detection logic
4. Copy functionality implementation
5. Accessibility of the new UI elements

### :heavy_plus_sign: Additional Context
This change is part of our ongoing efforts to improve the CLI authentication experience and reduce support tickets related to authentication failures.

## :sparkles: How to Test the Changes Locally
You may use the following test webauth request:
https://localhost/webauth/OTMwOS0zZTdlMmRmNzVkYTc4YmM5YzJlYjE1N2Y0MjQ4OGI1NWIyMzAzNTI2YTI2N2ZjOWViODllN2ZiZTAyYjllNzY0LXBpQGJsYWNrcm9jaw==

Test Cloud hosted scenario:
```bash
NEXT_PUBLIC_APP_HOST=cloud
```
Test Self-hosted scenario:
```bash
NEXT_PUBLIC_APP_HOST=self-hosted
```
1. Navigate to the CLI auth page and trigger the error state
2. Verify the instructions for both Cloud and Self-hosted scenarios
3. Test copy functionality for all parameters & credentials

### :green_heart: Did You...
- [ ] Ensure linting passes (code style checks)
- [ ] Update dependencies and lockfiles (if required)
- [ ] Regenerate graphql schema and types (if required)
- [x] Verify the app builds locally
- [x] Manually test the changes on different browsers/devices