### PR TITLE
fix: client-side exception during signup due to nested toast container

### DIFF
--- a/frontend/app/[team]/layout.tsx
+++ b/frontend/app/[team]/layout.tsx
@@ -8,8 +8,6 @@ import clsx from 'clsx'
 import { usePathname, useRouter } from 'next/navigation'
 import { useContext, useEffect } from 'react'
 import UnlockKeyringDialog from '@/components/auth/UnlockKeyringDialog'
-import { ToastContainer } from 'react-toastify'
-import { ThemeContext } from '@/contexts/themeContext'
 
 export default function RootLayout({
   children,
@@ -20,8 +18,6 @@ export default function RootLayout({
 }) {
   const { activeOrganisation, setActiveOrganisation, organisations, loading } =
     useContext(organisationContext)
-
-  const { theme } = useContext(ThemeContext)
 
   const router = useRouter()
 
@@ -64,20 +60,6 @@ export default function RootLayout({
           {children}
         </div>
       </div>
-      <ToastContainer
-        position="bottom-right"
-        autoClose={4000}
-        hideProgressBar={false}
-        newestOnTop={false}
-        closeOnClick
-        rtl={false}
-        pauseOnFocusLoss
-        draggable
-        pauseOnHover
-        theme={theme === 'dark' ? 'dark' : 'light'}
-        stacked
-        bodyClassName="text-xs"
-      />
     </div>
   )
 }


### PR DESCRIPTION
## :mag: Overview

There are currently 2 `<ToastContainer/>`s for react-toastify. One at the root layout, and one within the `[team]` layout which is theme-aware. This causes a [client-side exception](https://github.com/fkhadra/react-toastify/issues/1051) when a toast originating in the root layout container is still active, and the route changes to `[team]/*`. This was most commonly experienced during signup, when redirecting to the org home page.

## :bulb: Proposed Changes

Remove the nested toast container in the team layout. 

## :memo: Release Notes

Fixed a bug during signup that cause a client-side exception.

### :dart: Reviewer Focus

Run through the signup process. Observe that the toast drawn on signup remains active once redirected to org home, and no client-side exception occurs

### :heavy_plus_sign: Additional Context

This change makes toasts 'dark' theme regardless of the console theme selection. We will revisit this in the future.


### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
