### PR TITLE
fix: gracefully handle DoesNotExist exceptions for tokens

### DIFF
--- a/backend/api/utils/rest.py
+++ b/backend/api/utils/rest.py
@@ -87,11 +87,22 @@ def token_is_expired_or_deleted(auth_token):
     prefix, token_type, token_value = auth_token.split(" ")
 
     if token_type == "User":
-        token = UserToken.objects.get(token=token_value)
+        try:
+            token = UserToken.objects.get(token=token_value)
+        except UserToken.DoesNotExist:
+            return True
+
     elif token_type == "Service":
-        token = ServiceToken.objects.get(token=token_value)
+        try:
+            token = ServiceToken.objects.get(token=token_value)
+        except ServiceToken.DoesNotExist:
+            return True
+
     elif token_type == "ServiceAccount":
-        token = ServiceAccountToken.objects.get(token=token_value)
+        try:
+            token = ServiceAccountToken.objects.get(token=token_value)
+        except ServiceAccountToken.DoesNotExist:
+            return True
 
     return token.deleted_at is not None or (
         token.expires_at is not None and token.expires_at < timezone.now()


### PR DESCRIPTION
## :mag: Overview

When the REST api is accessed with a deleted token, it incorrectly errors out with a status `500` code. This due to the token's `DoesNotExist` exception not being handled correctly during the intial token validation check

## :bulb: Proposed Changes

Gracefully hande `DoesNotExist` errors and return status `403` response

## :memo: Release Notes

Fix a bug with REST api authentication when using deleted tokens

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
