### PR TITLE
fix: seat count calculation in plan detail resolver

### DIFF
--- a/backend/backend/graphene/queries/quotas.py
+++ b/backend/backend/graphene/queries/quotas.py
@@ -1,5 +1,11 @@
 from api.utils.access.permissions import user_is_org_member
-from api.models import App, Organisation, OrganisationMember, OrganisationMemberInvite
+from api.models import (
+    App,
+    Organisation,
+    OrganisationMember,
+    OrganisationMemberInvite,
+    ServiceAccount,
+)
 from backend.quotas import PLAN_CONFIG
 from django.utils import timezone
 
@@ -11,13 +17,24 @@ def resolve_organisation_plan(self, info, organisation_id):
 
         plan = PLAN_CONFIG[organisation.plan]
 
-        plan["user_count"] = (
-            OrganisationMember.objects.filter(
+        plan["seats_used"] = {
+            "users": (
+                OrganisationMember.objects.filter(
+                    organisation=organisation, deleted_at=None
+                ).count()
+                + OrganisationMemberInvite.objects.filter(
+                    organisation=organisation,
+                    valid=True,
+                    expires_at__gte=timezone.now(),
+                ).count()
+            ),
+            "service_accounts": ServiceAccount.objects.filter(
                 organisation=organisation, deleted_at=None
-            ).count()
-            + OrganisationMemberInvite.objects.filter(
-                organisation=organisation, valid=True, expires_at__gte=timezone.now()
-            ).count()
+            ).count(),
+        }
+
+        plan["seats_used"]["total"] = (
+            plan["seats_used"]["users"] + plan["seats_used"]["service_accounts"]
         )
 
         plan["app_count"] = App.objects.filter(


### PR DESCRIPTION
## :mag: Overview

The seat counts for users and service accounts is incorrectly displayed in certain situations.

## :bulb: Proposed Changes

Fix the seat count calculations in the `OrganisationPlan` resolver

## :memo: Release Notes

Fixed a bug that caused incorrect seat counts to be displayed on various screens in the Console

## 🎯 Reviewer Focus

Verify that the seat counts in the Settings > Usage section are correct

![Screenshot From 2024-12-17 14-11-10](https://github.com/user-attachments/assets/6407ac35-c0f0-4c32-a0c9-bc06f523d975)

Verify that the seat counts in the self checkout screen are correct

![image](https://github.com/user-attachments/assets/51f1bcf8-0fbc-47c1-95da-1bb25a17a716)


### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
