### PR TITLE
fix: add an empty state when user doesn't have access to any apps

### DIFF
--- a/frontend/app/[team]/apps/page.tsx
+++ b/frontend/app/[team]/apps/page.tsx
@@ -13,6 +13,7 @@ import { useSearchParams } from 'next/navigation'
 import { userHasPermission } from '@/utils/access/permissions'
 import { EmptyState } from '@/components/common/EmptyState'
 import { FaBan } from 'react-icons/fa'
+import { FaBoxOpen } from 'react-icons/fa6'
 
 export default function AppsHome({ params }: { params: { team: string } }) {
   const { activeOrganisation: organisation } = useContext(organisationContext)
@@ -57,6 +58,21 @@ export default function AppsHome({ params }: { params: { team: string } }) {
           {organisation && apps && userCanCreateApps && (
             <div className="bg-zinc-100 dark:bg-neutral-800 opacity-80 hover:opacity-100 transition-opacity ease-in-out shadow-lg rounded-xl flex flex-col gap-y-20 min-h-60">
               <NewAppDialog organisation={organisation} appCount={apps.length} ref={dialogRef} />
+            </div>
+          )}
+          {apps?.length === 0 && !userCanCreateApps && (
+            <div className="xl:col-span-2 1080p:col-span-3 justify-center p-20">
+              <EmptyState
+                title="No apps"
+                subtitle="You don't have access to any apps yet. Contact an Admin to get access."
+                graphic={
+                  <div className="text-neutral-300 dark:text-neutral-700 text-7xl text-center">
+                    <FaBoxOpen />
+                  </div>
+                }
+              >
+                <></>
+              </EmptyState>
             </div>
           )}
         </div>


### PR DESCRIPTION
## :mag: Overview

Fixes #405 

## :bulb: Proposed Changes

Added an empty state when a user:
* Has `Apps:read` permissions
* Does not have access to any apps yet

## :framed_picture: Screenshots or Demo

![image](https://github.com/user-attachments/assets/2814087d-79a4-4d49-b3b6-27507d9efba2)

## :memo: Release Notes

Added an empty state for users who don't have access to any apps.

### :dart: Reviewer Focus

Verify that the correct empty states are shown when the user:
* Has access to no apps, but has `Apps:read` permissions (this is the primary fix for the target issue)
* Has access to no apps, but has `Apps:create` permission (should see create app button isntead)
* Does not have `Apps:read` permission (Should see "access restricted" empty state instead)

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
