### PR TITLE
feat: improved recovery kit ux

### DIFF
--- a/frontend/components/settings/account/ViewRecoveryDialog.tsx
+++ b/frontend/components/settings/account/ViewRecoveryDialog.tsx
@@ -183,7 +183,7 @@ export const ViewRecoveryDialog = () => {
                             </div>
                           </div>
                           <div>
-                            <Button type="submit" variant="primary">
+                            <Button type="submit" variant="primary" isLoading={isUnlocking}>
                               Unlock
                             </Button>
                           </div>

--- a/frontend/components/settings/account/ViewRecoveryDialog.tsx
+++ b/frontend/components/settings/account/ViewRecoveryDialog.tsx
@@ -19,14 +19,27 @@ export const ViewRecoveryDialog = () => {
   const [password, setPassword] = useState<string>('')
   const [showPw, setShowPw] = useState<boolean>(false)
   const [recovery, setRecovery] = useState<string>('')
+  const [isUnlocking, setIsUnlocking] = useState<boolean>(false)
 
   const handleDecryptRecovery = async (event: { preventDefault: () => void }) => {
     event.preventDefault()
+    setIsUnlocking(true)
 
-    const deviceKey = await deviceVaultKey(password, session?.user?.email!)
+    try {
+      // Add small delay to ensure loading state is visible for UX reasons
+      await new Promise(resolve => setTimeout(resolve, 100))
+      
+      const deviceKey = await deviceVaultKey(password, session?.user?.email!)
 
-    const decryptedRecovery = await decryptAccountRecovery(activeOrganisation?.recovery!, deviceKey)
-    setRecovery(decryptedRecovery)
+      const decryptedRecovery = await decryptAccountRecovery(activeOrganisation?.recovery!, deviceKey)
+      setRecovery(decryptedRecovery)
+    } catch (error) {
+      toast.error("Invalid sudo password. Please check your password and try again.", {
+        autoClose: 2000,
+      })
+    } finally {
+      setIsUnlocking(false)
+    }
   }
 
   const reset = () => {

--- a/frontend/components/settings/account/ViewRecoveryDialog.tsx
+++ b/frontend/components/settings/account/ViewRecoveryDialog.tsx
@@ -95,7 +95,7 @@ export const ViewRecoveryDialog = () => {
         </Alert>
         <div>
           <Button variant="primary" onClick={openModal} title="View recovery">
-            <FaEye /> View recovery info
+            <FaEye /> View recovery kit
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## :mag: Overview

This PR makes improves the UX around viewing recovery kit in the settings screen.

## :bulb: Proposed Changes

- Added exception handling when an incorrect sudo password has been entered by the user
- Added a spinner on the `Unlock` button to show a loading indicator when users entered a sudo password and clicks Unlock

## :framed_picture: Screenshots or Demo

https://github.com/user-attachments/assets/8c52dc83-d4a2-4438-8cc5-7ffcfeadae56

## :memo: Release Notes

Improved Phase recovery kit UX

### :test_tube: Testing

- Navigate to the settings screen and try to access the recovery kit, with a valid / invalid sudo password

### :heavy_plus_sign: Additional Context

- A 100ms delay has been added to the Unlock button state for DX reasons. Without it the Unlock button seems to execute the decryption process swiftly, but with the just the right amount of delay (disabled) state to potentially confuse the user.
```ts
await new Promise(resolve => setTimeout(resolve, 100))
```

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
- [ ] Update dependencies and lockfiles (if required)
- [ ] Regenerate graphql schema and types (if required)
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices? (Chromium/Firefiox)
