### PR TITLE
fix: app secrets refetch 

### DIFF
--- a/frontend/app/[team]/apps/[app]/_components/AppSecrets.tsx
+++ b/frontend/app/[team]/apps/[app]/_components/AppSecrets.tsx
@@ -140,7 +140,7 @@ export const AppSecrets = ({ team, app }: { team: string; app: string }) => {
   )
 
   useEffect(() => {
-    if (appSecrets.length > 0) {
+    if (appSecrets) {
       setServerAppSecrets(appSecrets)
       setClientAppSecrets(appSecrets)
     }

--- a/frontend/app/[team]/apps/[app]/_hooks/useAppSecrets.ts
+++ b/frontend/app/[team]/apps/[app]/_hooks/useAppSecrets.ts
@@ -14,7 +14,7 @@ export const useAppSecrets = (appId: string, allowFetch: boolean, pollInterval: 
   const { keyring } = useContext(KeyringContext);
 
   // Fetch environments and secrets in a single query with polling
-  const { data: appSecretsData, refetch: refetchAppSecrets } = useQuery(GetAppSecrets, {
+  const { data: appSecretsData, refetch } = useQuery(GetAppSecrets, {
     variables: { appId },
     fetchPolicy: 'cache-and-network',
     skip: !allowFetch,
@@ -86,14 +86,7 @@ export const useAppSecrets = (appId: string, allowFetch: boolean, pollInterval: 
     }
   }, [appSecretsData, keyring, processAppSecrets]);
 
-  // Refetch handler for app secrets and environments
-  const handleRefetch = async () => {
-    setFetching(true);
-    const { data: refetchedAppSecretsData } = await refetchAppSecrets();
-    if (refetchedAppSecretsData?.appEnvironments) {
-      await processAppSecrets(refetchedAppSecretsData.appEnvironments, {});
-    }
-  };
+  
 
-  return { appEnvironments: appSecretsData?.appEnvironments, appSecrets, appFolders, fetching, refetch: handleRefetch };
+  return { appEnvironments: appSecretsData?.appEnvironments, appSecrets, appFolders, fetching, refetch };
 };


### PR DESCRIPTION
## :mag: Overview

Fixes an edge case bug and cleans up refetching logic for the new cross-env screen in app home

## :bulb: Proposed Changes

* If a 'deploy' operation deleted all secrets in the app, the client state update was incorrectly ignored. This has been fixed to update the state based on the network response, even when the list of secrets is empty
* Removed redundant logic for handling refetches


## :memo: Release Notes

Fixed a bug in the cross-env screen in app home that would cause the client to display the wrong state in certain situations

### :dart: Reviewer Focus

* Create one or secrets in the app
* Delete all secrets and hit deploy, such that the resulting state after this operation would be an empty app
* Observe that the state correctly updates after the refetch event

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
