### PR TITLE
Fix: disable state for managed roles access policy permissions

### DIFF
--- a/frontend/components/access/AccessTemplateSelector.tsx
+++ b/frontend/components/access/AccessTemplateSelector.tsx
@@ -9,11 +9,13 @@ export const AccessTemplateSelector = ({
   rolePolicy,
   setRolePolicy,
   isAppResource,
+  disabled,
 }: {
   resource: string
   rolePolicy: PermissionPolicy
   setRolePolicy: Dispatch<SetStateAction<PermissionPolicy | null>>
   isAppResource?: boolean
+  disabled?: boolean
 }) => {
   type AccessTemplate = {
     name: string
@@ -96,7 +98,7 @@ export const AccessTemplateSelector = ({
 
   return (
     <div className="relative">
-      <Listbox value={value} onChange={handleChange}>
+      <Listbox value={value} onChange={handleChange} disabled={disabled}>
         {({ open }) => (
           <>
             <Listbox.Button as={Fragment} aria-required>

--- a/frontend/components/access/ManageRoleDialog.tsx
+++ b/frontend/components/access/ManageRoleDialog.tsx
@@ -272,6 +272,7 @@ export const ManageRoleDialog = ({ role, ownerRole }: { role: RoleType; ownerRol
                                     setRolePolicy={setRolePolicy}
                                     resource={resource}
                                     isAppResource={false}
+                                    disabled={!allowEdit}
                                   />
                                 </td>
 


### PR DESCRIPTION
## :mag: Overview

Bug: It was possible to change the local UI state of the access policies of roles managed by Phase by clicking on the drop down. This change was entirely local in the users browser and did not effect any state on the backend. 

Fix: Disable edits on managed role's access policy drop down. 
