### PR TITLE
fix: use cache + network policy to fetch apps in integrations

### DIFF
--- a/frontend/app/[team]/integrations/page.tsx
+++ b/frontend/app/[team]/integrations/page.tsx
@@ -74,7 +74,8 @@ export default function Integrations({ params }: { params: { team: string } }) {
     skip:
       !organisation ||
       (!userCanReadIntegrationCredentials && !userCanReadIntegrations && !userCanReadApps),
-    nextFetchPolicy: 'cache-and-network',
+    fetchPolicy: 'cache-and-network',
+    nextFetchPolicy: 'cache-and-network'
   })
 
   const apps = data?.apps ?? []


### PR DESCRIPTION
## :mag: Overview

Update the Apps in the integration page on load to prevent stale App data from being served.