### PR TITLE
fix: log read for all secrets when exporting to .env

### DIFF
--- a/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
+++ b/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
@@ -547,6 +547,8 @@ export default function EnvironmentPath({
       a.download = `${environment.app.name}.${environment.name.toLowerCase()}${formattedSecretPath}.env`
     }
 
+    logGlobalReveals()
+
     document.body.appendChild(a)
     a.click()
 


### PR DESCRIPTION
## :mag: Overview

Logs a read event for all secrets at the current path when using the "Export as .env" option to export secrets

## :memo: Release Notes

Logs exports from the Console as a Read event for each exported secret


### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
