### PR TITLE
feat: added a label to service account token ID

### DIFF
--- a/frontend/app/[team]/access/service-accounts/[account]/page.tsx
+++ b/frontend/app/[team]/access/service-accounts/[account]/page.tsx
@@ -332,9 +332,15 @@ export default function ServiceAccount({ params }: { params: { team: string; acc
                           {token!.name}
                         </span>
                       </div>
-                      <div className="flex items-center gap-2 text-sm text-neutral-500 group/id">
-                        <span className="text-neutral-500 text-2xs flex items-center">Token ID:</span>
-                        <CopyButton value={token!.id} buttonVariant="ghost">
+                      <div className="flex items-center gap-2 text-sm text-neutral-500">
+                        <span className="text-neutral-500 text-xs flex items-center">
+                          Token ID:
+                        </span>
+                        <CopyButton
+                          value={token!.id}
+                          buttonVariant="ghost"
+                          title="Copy Token ID to clipboard"
+                        >
                           <span className="text-neutral-500 text-2xs font-mono">{token!.id}</span>
                         </CopyButton>
                       </div>

--- a/frontend/app/[team]/access/service-accounts/[account]/page.tsx
+++ b/frontend/app/[team]/access/service-accounts/[account]/page.tsx
@@ -230,6 +230,7 @@ export default function ServiceAccount({ params }: { params: { team: string; acc
                         <SseLabel sseEnabled={Boolean(app?.sseEnabled)} />
                       </div>
                       <div className="flex items-center gap-2 text-sm text-neutral-500 group/id">
+                        <span className="text-neutral-500 text-2xs">App ID:</span>
                         <CopyButton value={app.id} buttonVariant="ghost">
                           <span className="text-neutral-500 text-2xs font-mono">{app.id}</span>
                         </CopyButton>

--- a/frontend/app/[team]/access/service-accounts/[account]/page.tsx
+++ b/frontend/app/[team]/access/service-accounts/[account]/page.tsx
@@ -230,7 +230,7 @@ export default function ServiceAccount({ params }: { params: { team: string; acc
                         <SseLabel sseEnabled={Boolean(app?.sseEnabled)} />
                       </div>
                       <div className="flex items-center gap-2 text-sm text-neutral-500 group/id">
-                        <span className="text-neutral-500 text-2xs">App ID:</span>
+                        <span className="text-neutral-500 text-2xs flex items-center">App ID:</span>
                         <CopyButton value={app.id} buttonVariant="ghost">
                           <span className="text-neutral-500 text-2xs font-mono">{app.id}</span>
                         </CopyButton>
@@ -333,7 +333,7 @@ export default function ServiceAccount({ params }: { params: { team: string; acc
                         </span>
                       </div>
                       <div className="flex items-center gap-2 text-sm text-neutral-500 group/id">
-                        <span className="text-neutral-500 text-2xs">Token ID:</span>
+                        <span className="text-neutral-500 text-2xs flex items-center">Token ID:</span>
                         <CopyButton value={token!.id} buttonVariant="ghost">
                           <span className="text-neutral-500 text-2xs font-mono">{token!.id}</span>
                         </CopyButton>

--- a/frontend/app/[team]/access/service-accounts/[account]/page.tsx
+++ b/frontend/app/[team]/access/service-accounts/[account]/page.tsx
@@ -332,6 +332,7 @@ export default function ServiceAccount({ params }: { params: { team: string; acc
                         </span>
                       </div>
                       <div className="flex items-center gap-2 text-sm text-neutral-500 group/id">
+                        <span className="text-neutral-500 text-2xs">Token ID:</span>
                         <CopyButton value={token!.id} buttonVariant="ghost">
                           <span className="text-neutral-500 text-2xs font-mono">{token!.id}</span>
                         </CopyButton>

--- a/frontend/components/common/CopyButton.tsx
+++ b/frontend/components/common/CopyButton.tsx
@@ -8,9 +8,10 @@ type CopyButtonProps = {
   defaultHidden?: boolean
   children?: ReactNode
   buttonVariant?: ButtonVariant
+  title?: string
 }
 
-const CopyButton: React.FC<CopyButtonProps> = ({ value, children, buttonVariant }) => {
+const CopyButton: React.FC<CopyButtonProps> = ({ value, children, buttonVariant, title }) => {
   const [copyCount, setCopyCount] = useState(0)
   const copied = copyCount > 0
 
@@ -28,7 +29,7 @@ const CopyButton: React.FC<CopyButtonProps> = ({ value, children, buttonVariant 
   return (
     <Button
       variant={variant}
-      title="Copy to clipboard"
+      title={title || 'Copy to clipboard'}
       onClick={() => {
         window.navigator.clipboard.writeText(value).then(() => {
           setCopyCount((count) => count + 1)


### PR DESCRIPTION
## :mag: Overview

Added a label to Service Account Token ID & App ID. This make it clear that is in-fact an ID and not a secret. This adds a subtle distinction and avoid confusion among users. 

![image](https://github.com/user-attachments/assets/31ca361b-c5d7-4334-8b32-3f627f3d40aa)
