### PR TITLE
feat: renamed the one click access button for clarity

### DIFF
--- a/frontend/components/contextSnippets/ProgrammaticAccessMenu.tsx
+++ b/frontend/components/contextSnippets/ProgrammaticAccessMenu.tsx
@@ -52,7 +52,7 @@ export const ProgrammaticAccessMenu = () => {
           <Menu.Button as={Fragment}>
             <Button variant="secondary" title="One-click programmatic access">
               <FaTerminal className="text-emerald-500" />
-              <span className="font-mono">One-click Access</span>
+             One-click Access
             </Button>
           </Menu.Button>
 

--- a/frontend/components/contextSnippets/ProgrammaticAccessMenu.tsx
+++ b/frontend/components/contextSnippets/ProgrammaticAccessMenu.tsx
@@ -52,7 +52,7 @@ export const ProgrammaticAccessMenu = () => {
           <Menu.Button as={Fragment}>
             <Button variant="secondary" title="One-click programmatic access">
               <FaTerminal className="text-emerald-500" />
-              <span className="font-mono">Access</span>
+              <span className="font-mono">One-click Access</span>
             </Button>
           </Menu.Button>
 

--- a/frontend/components/contextSnippets/SecretsOneLiner.tsx
+++ b/frontend/components/contextSnippets/SecretsOneLiner.tsx
@@ -185,7 +185,7 @@ const SecretsOneLiner = ({
 
       await navigator.clipboard.writeText(command)
       setCopied(true)
-      toast.info(`Generated command expires ${authExpiry}`, {
+      toast.info(`Copied command & token expires ${authExpiry}`, {
         autoClose: 5000,
       })
     } catch (error) {


### PR DESCRIPTION
## :mag: Overview

Renamed the Access button to One-click Access for better clarity. This provide a better description for what the button is for and also avoid overlap with the App Access tab which deals with things related to Access Control.

![image](https://github.com/user-attachments/assets/968f5165-ea7e-440e-aa19-22f008aa3a2c)

