### PR TITLE
fix: add error message for tokens api auth failures

### DIFF
--- a/backend/api/views/auth.py
+++ b/backend/api/views/auth.py
@@ -38,7 +38,9 @@ from allauth.socialaccount.providers.google.views import GoogleOAuth2Adapter
 from allauth.socialaccount.providers.github.views import GitHubOAuth2Adapter
 from allauth.socialaccount.providers.oauth2.views import OAuth2Adapter
 from ee.authentication.sso.oidc.util.google.google import GoogleOpenIDConnectAdapter
-from ee.authentication.sso.oidc.util.jumpcloud.jumpcloud import JumpCloudOpenIDConnectAdapter
+from ee.authentication.sso.oidc.util.jumpcloud.jumpcloud import (
+    JumpCloudOpenIDConnectAdapter,
+)
 
 CLOUD_HOSTED = settings.APP_HOST == "cloud"
 
@@ -303,7 +305,7 @@ def secrets_tokens(request):
     auth_token = request.headers["authorization"]
 
     if token_is_expired_or_deleted(auth_token):
-        return HttpResponse(status=403)
+        return JsonResponse({"error": "Token expired or deleted"}, status=403)
 
     token_type = get_token_type(auth_token)
 
@@ -312,4 +314,4 @@ def secrets_tokens(request):
     elif token_type == "User":
         return user_token_kms(request)
     else:
-        return HttpResponse(status=403)
+        return JsonResponse({"error": "Invalid token type"}, status=403)


### PR DESCRIPTION
## :mag: Overview

Adds a verbose error message when authentication fails due to an invalid or expired token for the tokens api



## :framed_picture: Screenshots or Demo

### Before
```bash
Error: 🚫 Not authorized.
```

### After
```bash
Error: 🚫 Not authorized. Token expired or deleted
```

## :memo: Release Notes

Added verbose error messages to authentication failures for the CLI

### :heavy_plus_sign: Additional Context

This only affects the CLI

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
