### PR TITLE
fix: app access page error

### DIFF
--- a/backend/backend/graphene/types.py
+++ b/backend/backend/graphene/types.py
@@ -439,6 +439,8 @@ class EnvironmentType(DjangoObjectType):
     secret_count = graphene.Int()
     members = graphene.NonNull(graphene.List(OrganisationMemberType))
     syncs = graphene.NonNull(graphene.List(EnvironmentSyncType))
+    wrapped_seed = graphene.String(required=False)
+    wrapped_salt = graphene.String(required=False)
 
     class Meta:
         model = Environment
@@ -497,21 +499,26 @@ class EnvironmentType(DjangoObjectType):
             user=info.context.user, organisation=self.app.organisation, deleted_at=None
         )
 
-        user_env_key = EnvironmentKey.objects.get(
-            environment=self, user=org_member, deleted_at=None
-        )
-
-        return user_env_key.wrapped_seed
+        try:
+            user_env_key = EnvironmentKey.objects.get(
+                environment=self, user=org_member, deleted_at=None
+            )
+            return user_env_key.wrapped_seed
+        except EnvironmentKey.DoesNotExist:
+            return None
 
     def resolve_wrapped_salt(self, info):
         org_member = OrganisationMember.objects.get(
             user=info.context.user, organisation=self.app.organisation, deleted_at=None
         )
-        user_env_key = EnvironmentKey.objects.get(
-            environment=self, user=org_member, deleted_at=None
-        )
 
-        return user_env_key.wrapped_salt
+        try:
+            user_env_key = EnvironmentKey.objects.get(
+                environment=self, user=org_member, deleted_at=None
+            )
+            return user_env_key.wrapped_salt
+        except EnvironmentKey.DoesNotExist:
+            return None
 
     def resolve_members(self, info):
         return [

--- a/frontend/apollo/graphql.ts
+++ b/frontend/apollo/graphql.ts
@@ -493,8 +493,8 @@ export type EnvironmentType = {
   secrets: Array<Maybe<SecretType>>;
   syncs: Array<Maybe<EnvironmentSyncType>>;
   updatedAt: Scalars['DateTime']['output'];
-  wrappedSalt: Scalars['String']['output'];
-  wrappedSeed: Scalars['String']['output'];
+  wrappedSalt?: Maybe<Scalars['String']['output']>;
+  wrappedSeed?: Maybe<Scalars['String']['output']>;
 };
 
 export type GitHubRepoType = {
@@ -2702,7 +2702,7 @@ export type GetAppEnvironmentsQueryVariables = Exact<{
 }>;
 
 
-export type GetAppEnvironmentsQuery = { __typename?: 'Query', sseEnabled?: boolean | null, serverPublicKey?: string | null, appEnvironments?: Array<{ __typename?: 'EnvironmentType', id: string, name: string, envType: ApiEnvironmentEnvTypeChoices, identityKey: string, wrappedSeed: string, wrappedSalt: string, createdAt?: any | null, secretCount?: number | null, folderCount?: number | null, index: number, app: { __typename?: 'AppType', name: string, id: string }, members: Array<{ __typename?: 'OrganisationMemberType', email?: string | null, fullName?: string | null, avatarUrl?: string | null } | null> } | null> | null };
+export type GetAppEnvironmentsQuery = { __typename?: 'Query', sseEnabled?: boolean | null, serverPublicKey?: string | null, appEnvironments?: Array<{ __typename?: 'EnvironmentType', id: string, name: string, envType: ApiEnvironmentEnvTypeChoices, identityKey: string, wrappedSeed?: string | null, wrappedSalt?: string | null, createdAt?: any | null, secretCount?: number | null, folderCount?: number | null, index: number, app: { __typename?: 'AppType', name: string, id: string }, members: Array<{ __typename?: 'OrganisationMemberType', email?: string | null, fullName?: string | null, avatarUrl?: string | null } | null> } | null> | null };
 
 export type GetAppSecretsQueryVariables = Exact<{
   appId: Scalars['ID']['input'];
@@ -2711,7 +2711,7 @@ export type GetAppSecretsQueryVariables = Exact<{
 }>;
 
 
-export type GetAppSecretsQuery = { __typename?: 'Query', sseEnabled?: boolean | null, serverPublicKey?: string | null, appEnvironments?: Array<{ __typename?: 'EnvironmentType', id: string, name: string, envType: ApiEnvironmentEnvTypeChoices, identityKey: string, wrappedSeed: string, wrappedSalt: string, createdAt?: any | null, secretCount?: number | null, folderCount?: number | null, index: number, app: { __typename?: 'AppType', name: string, id: string }, members: Array<{ __typename?: 'OrganisationMemberType', email?: string | null, fullName?: string | null, avatarUrl?: string | null } | null>, folders: Array<{ __typename?: 'SecretFolderType', id: string, name: string, path: string } | null>, secrets: Array<{ __typename?: 'SecretType', id: string, key: string, value: string, comment: string, path: string } | null> } | null> | null };
+export type GetAppSecretsQuery = { __typename?: 'Query', sseEnabled?: boolean | null, serverPublicKey?: string | null, appEnvironments?: Array<{ __typename?: 'EnvironmentType', id: string, name: string, envType: ApiEnvironmentEnvTypeChoices, identityKey: string, wrappedSeed?: string | null, wrappedSalt?: string | null, createdAt?: any | null, secretCount?: number | null, folderCount?: number | null, index: number, app: { __typename?: 'AppType', name: string, id: string }, members: Array<{ __typename?: 'OrganisationMemberType', email?: string | null, fullName?: string | null, avatarUrl?: string | null } | null>, folders: Array<{ __typename?: 'SecretFolderType', id: string, name: string, path: string } | null>, secrets: Array<{ __typename?: 'SecretType', id: string, key: string, value: string, comment: string, path: string } | null> } | null> | null };
 
 export type GetAppSecretsLogsQueryVariables = Exact<{
   appId: Scalars['ID']['input'];

--- a/frontend/apollo/schema.graphql
+++ b/frontend/apollo/schema.graphql
@@ -292,8 +292,8 @@ type EnvironmentType {
   envType: ApiEnvironmentEnvTypeChoices!
   index: Int!
   identityKey: String!
-  wrappedSeed: String!
-  wrappedSalt: String!
+  wrappedSeed: String
+  wrappedSalt: String
   createdAt: DateTime
   updatedAt: DateTime!
   folders: [SecretFolderType]!

--- a/frontend/app/[team]/apps/[app]/_components/AppSecrets.tsx
+++ b/frontend/app/[team]/apps/[app]/_components/AppSecrets.tsx
@@ -248,7 +248,7 @@ export const AppSecrets = ({ team, app }: { team: string; app: string }) => {
         const serverSecret = serverSecrets.find((secret) => secret.id === id)
 
         const salt = await decryptAsymmetric(
-          clientSecret.environment.wrappedSalt,
+          clientSecret.environment.wrappedSalt!,
           userKxKeys.privateKey!,
           userKxKeys.publicKey!
         )

--- a/frontend/app/[team]/apps/[app]/_hooks/useAppSecrets.ts
+++ b/frontend/app/[team]/apps/[app]/_hooks/useAppSecrets.ts
@@ -35,8 +35,8 @@ export const useAppSecrets = (appId: string, allowFetch: boolean, pollInterval: 
 
         // Decrypt secrets for the environment
         const { publicKey, privateKey } = await unwrapEnvSecretsForUser(
-          wrappedSeed,
-          wrappedSalt,
+          wrappedSeed!,
+          wrappedSalt!,
           keyring!
         )
         const decryptedSecrets = await decryptEnvSecretKVs(secrets, { publicKey, privateKey })

--- a/frontend/app/[team]/apps/[app]/access/members/page.tsx
+++ b/frontend/app/[team]/apps/[app]/access/members/page.tsx
@@ -12,7 +12,6 @@ import { Fragment, useContext, useEffect, useMemo, useState } from 'react'
 import { OrganisationMemberType, EnvironmentType } from '@/apollo/graphql'
 import { Button } from '@/components/common/Button'
 import { organisationContext } from '@/contexts/organisationContext'
-import { relativeTimeFromDates } from '@/utils/time'
 import { Combobox, Dialog, Listbox, Transition } from '@headlessui/react'
 import {
   FaArrowRight,
@@ -23,7 +22,6 @@ import {
   FaPlus,
   FaSquare,
   FaTimes,
-  FaUserCog,
   FaUserTimes,
 } from 'react-icons/fa'
 import clsx from 'clsx'
@@ -31,14 +29,13 @@ import { toast } from 'react-toastify'
 import { useSession } from 'next-auth/react'
 import { Avatar } from '@/components/common/Avatar'
 import { KeyringContext } from '@/contexts/keyringContext'
-import { userHasGlobalAccess, userHasPermission, userIsAdmin } from '@/utils/access/permissions'
+import { userHasGlobalAccess, userHasPermission } from '@/utils/access/permissions'
 import { RoleLabel } from '@/components/users/RoleLabel'
 import { Alert } from '@/components/common/Alert'
 import Link from 'next/link'
 import { unwrapEnvSecretsForUser, wrapEnvSecretsForAccount } from '@/utils/crypto'
 import { EmptyState } from '@/components/common/EmptyState'
 import Spinner from '@/components/common/Spinner'
-import loading from '@/app/loading'
 
 export default function Members({ params }: { params: { team: string; app: string } }) {
   const { keyring } = useContext(KeyringContext)

--- a/frontend/app/[team]/apps/page.tsx
+++ b/frontend/app/[team]/apps/page.tsx
@@ -38,6 +38,7 @@ export default function AppsHome({ params }: { params: { team: string } }) {
       organisationId: organisation?.id,
     },
     skip: !organisation || !userCanViewApps,
+    fetchPolicy: 'cache-and-network',
   })
 
   const apps = data?.apps as AppType[]

--- a/frontend/utils/app.ts
+++ b/frontend/utils/app.ts
@@ -27,7 +27,7 @@ import {
   encryptAppSeed,
   getWrappedKeyShare,
 } from '@/utils/crypto'
-import { graphQlClient as client } from "@/apollo/client";
+import { graphQlClient as client } from '@/apollo/client'
 
 const APP_VERSION = 1
 
@@ -99,7 +99,8 @@ export const DEV_SECRETS = [
   },
   {
     key: 'POSTGRES_CONNECTION_STRING',
-    value: 'postgresql://spacex_stag:c51bdc6b6e8685f113a4ab5d57481b8b20d8d06a6526f5e2e4535ffa398850a2@starlink-telemetry-db-stag.cluster-c9ufzjtplsaq.us-central-1.rds.amazonaws.com:5432/starlink_telemetry',
+    value:
+      'postgresql://spacex_stag:c51bdc6b6e8685f113a4ab5d57481b8b20d8d06a6526f5e2e4535ffa398850a2@starlink-telemetry-db-stag.cluster-c9ufzjtplsaq.us-central-1.rds.amazonaws.com:5432/starlink_telemetry',
     comment: 'RDS Aurora PostgreSQL - US Central - DEV',
   },
 ]
@@ -137,7 +138,8 @@ export const STAG_SECRETS = [
   },
   {
     key: 'POSTGRES_CONNECTION_STRING',
-    value: 'postgresql://spacex_stag:7d48921fc7e85fd3339527d39557@starlink-telemetry-db-stag.cluster-c9ufzjtplsaq.us-central-1.rds.amazonaws.com:5432/starlink_telemetry',
+    value:
+      'postgresql://spacex_stag:7d48921fc7e85fd3339527d39557@starlink-telemetry-db-stag.cluster-c9ufzjtplsaq.us-central-1.rds.amazonaws.com:5432/starlink_telemetry',
     comment: 'RDS Aurora PostgreSQL - US Central',
   },
   {
@@ -171,7 +173,8 @@ export const PROD_SECRETS = [
   },
   {
     key: 'SIGNAL_ENCRYPTION_KEY',
-    value: 'sek_starlink_prod_v2_+ScgHNaH6uZpqFRST+Q2Cq+KlaExlUEtFZrPNrgokzicou97GD/UUsEAJrjb3tfOblUt15e2dir0L671W+OwBw==',
+    value:
+      'sek_starlink_prod_v2_+ScgHNaH6uZpqFRST+Q2Cq+KlaExlUEtFZrPNrgokzicou97GD/UUsEAJrjb3tfOblUt15e2dir0L671W+OwBw==',
     comment: 'Production Signal Encryption Key',
   },
   {
@@ -186,13 +189,14 @@ export const PROD_SECRETS = [
   },
   {
     key: 'POSTGRES_CONNECTION_STRING',
-    value: 'postgresql://spacex_stag:268ff4edd81533a32b80645844b6afdcc48a4041ffda000c3c5ff3505777eda8@starlink-telemetry-db-prod.cluster-c9ufzjtplsaq.us-central-1.rds.amazonaws.com:5432/starlink_telemetry',
+    value:
+      'postgresql://spacex_stag:268ff4edd81533a32b80645844b6afdcc48a4041ffda000c3c5ff3505777eda8@starlink-telemetry-db-prod.cluster-c9ufzjtplsaq.us-central-1.rds.amazonaws.com:5432/starlink_telemetry',
     comment: 'RDS Aurora PostgreSQL - US Central - PROD',
   },
   {
     key: 'DISABLE_STARLINK_COORDINATES',
     value: '46.1092°N,33.6925°E,44.6166°N,33.5254°E,44.5000°N,34.1667°E',
-    comment: 'Prevent WW3 - Elon\'s orders',
+    comment: "Prevent WW3 - Elon's orders",
   },
 ]
 
@@ -219,7 +223,7 @@ async function processSecrets(
   await Promise.all(
     envs.map(async ({ env, secrets }) => {
       const envSalt = await decryptAsymmetric(
-        env.wrappedSalt,
+        env.wrappedSalt!,
         userKxKeys.privateKey,
         userKxKeys.publicKey
       )


### PR DESCRIPTION
## :mag: Overview

Fixes the `EnvironmentKey matching query does not exist` error on the App > Access page. 

This was caused by the default behavior of the `EnvironmentKeyType` field resolvers for `wrapped_seed` and `wrapped_salt`, which would always try and resolve these field values for the user making the request. 

When fetching a list of environments for other users, the user making the request did not necessarily have access to all Environments, and these resolvers would throw a `DoesNotExist` error since no corresponding keys exist.

## :bulb: Proposed Changes

* Catch these exceptions and return `None` for these fields instead
* These fields have also been set as non-required in the schema

## :memo: Release Notes

Fixed a bug on the App > Access page related to fetching environment scope for non-self users


### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
- [x] Regenerate graphql schema and types (if required)
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
