### PR TITLE
Fix: GitHub OAuth SSO

### DIFF
--- a/backend/api/views/auth.py
+++ b/backend/api/views/auth.py
@@ -170,7 +170,16 @@ class CustomGitHubOAuth2Adapter(GitHubOAuth2Adapter):
         resp.raise_for_status()
         extra_data = resp.json()
         if app_settings.QUERY_EMAIL and not extra_data.get("email"):
-            extra_data["email"] = self.get_email(headers)
+            emails = self.get_emails(headers)
+            if emails:
+                # First try to get primary email
+                for email_obj in emails:
+                    if email_obj.get('primary'):
+                        extra_data["email"] = email_obj['email']
+                        break
+                # If no primary email found, use the first one
+                if not extra_data.get("email") and emails:
+                    extra_data["email"] = emails[0]['email']
 
         email = extra_data["email"]
 


### PR DESCRIPTION
## :mag: Overview

This PR fixes the GitHub OAuth SSO by using the new `self.get_emails(headers)` due to the new auth package upgrade. This also make the design decision to parse the primary email from the GitHub response and use it for login / signup. If the primary email is not found we will simply use the first one that's returned by the GitHub API.

GitHub API's email response:
```py
 [{'email': 'user@example.com', 'primary': True, 'verified': True, 'visibility': 'private'}, {'email': '12345678+user@users.noreply.github.com', 'primary': False, 'verified': True, 'visibility': None}, {'email': 'example@example.dev', 'primary': False, 'verified': True, 'visibility': None}]
```
