### PR TITLE
feat: added a app view table

### DIFF
--- a/frontend/app/[team]/apps/page.tsx
+++ b/frontend/app/[team]/apps/page.tsx
@@ -92,8 +92,13 @@ export default function AppsHome({ params }: { params: { team: string } }) {
     app.name.toLowerCase().includes(searchTerm.toLowerCase())
   ) || []
 
-  const handleRowClick = (appId: string) => {
-    router.push(`/${params.team}/apps/${appId}`)
+  const handleRowClick = (appId: string, e?: React.MouseEvent) => {
+    // If ctrl/cmd key was pressed, open in new tab
+    if (e && (e.ctrlKey || e.metaKey)) {
+      window.open(`/${params.team}/apps/${appId}`, '_blank')
+    } else {
+      router.push(`/${params.team}/apps/${appId}`)
+    }
   }
 
   const renderListView = () => {
@@ -156,11 +161,11 @@ export default function AppsHome({ params }: { params: { team: string } }) {
                 <tr 
                   key={app.id} 
                   className="hover:bg-zinc-50 dark:hover:bg-neutral-800 cursor-pointer group"
-                  onClick={() => handleRowClick(app.id)}
+                  onClick={(e) => handleRowClick(app.id, e)}
                 >
                   <td className="px-4 py-3">
                     <div className="flex items-center gap-2">
-                      <span className="font-medium">{app.name}</span>
+                      <span className="font-medium group-hover:underline">{app.name}</span>
                     </div>
                   </td>
                   {!isMobile && (

--- a/frontend/app/[team]/apps/page.tsx
+++ b/frontend/app/[team]/apps/page.tsx
@@ -4,19 +4,32 @@ import { useQuery } from '@apollo/client'
 import { GetApps } from '@/graphql/queries/getApps.gql'
 import { AppType } from '@/apollo/graphql'
 import NewAppDialog from '@/components/apps/NewAppDialog'
-import { useContext, useEffect, useRef } from 'react'
+import { useContext, useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import Spinner from '@/components/common/Spinner'
 import { AppCard } from '@/components/apps/AppCard'
 import { organisationContext } from '@/contexts/organisationContext'
-import { useSearchParams } from 'next/navigation'
+import { useSearchParams, useRouter } from 'next/navigation'
 import { userHasPermission } from '@/utils/access/permissions'
 import { EmptyState } from '@/components/common/EmptyState'
-import { FaBan } from 'react-icons/fa'
-import { FaBoxOpen } from 'react-icons/fa6'
+import { FaBan, FaCopy, FaCog, FaChevronRight, FaSearch, FaTh, FaListUl } from 'react-icons/fa'
+import { FaBoxOpen, FaPlus } from 'react-icons/fa6'
+import { EncryptionModeIndicator } from '@/components/apps/EncryptionModeIndicator'
+import { Avatar } from '@/components/common/Avatar'
+import { BsListColumnsReverse } from 'react-icons/bs'
+import { FaProjectDiagram, FaRobot, FaUsers } from 'react-icons/fa'
+import { ProviderIcon } from '@/components/syncing/ProviderIcon'
+import { Button } from '@/components/common/Button'
+import CopyButton from '@/components/common/CopyButton'
+
+type ViewMode = 'grid' | 'list'
 
 export default function AppsHome({ params }: { params: { team: string } }) {
   const { activeOrganisation: organisation } = useContext(organisationContext)
+  const [viewMode, setViewMode] = useState<ViewMode>('grid')
+  const [searchTerm, setSearchTerm] = useState<string>('')
+  const router = useRouter()
+  const [isMobile, setIsMobile] = useState(false)
 
   const userCanViewApps = userHasPermission(organisation?.role?.permissions, 'Apps', 'read')
   const userCanCreateApps = userHasPermission(organisation?.role?.permissions, 'Apps', 'create')
@@ -24,6 +37,37 @@ export default function AppsHome({ params }: { params: { team: string } }) {
   const dialogRef = useRef<{ openModal: () => void }>(null)
 
   const searchParams = useSearchParams()
+
+  // Handle responsive design
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth <= 768)
+    }
+    
+    // Check initially
+    checkMobile()
+    
+    // Add event listener for resize
+    window.addEventListener('resize', checkMobile)
+    
+    // Cleanup
+    return () => window.removeEventListener('resize', checkMobile)
+  }, [])
+
+  // Load saved view preference
+  useEffect(() => {
+    const savedViewMode = localStorage.getItem('apps-view-mode') as ViewMode
+    if (savedViewMode) {
+      setViewMode(savedViewMode === 'list' ? 'list' : 'grid')
+    }
+  }, [])
+
+  // Save view preference when it changes
+  const handleViewModeChange = () => {
+    const newMode = viewMode === 'grid' ? 'list' : 'grid'
+    setViewMode(newMode)
+    localStorage.setItem('apps-view-mode', newMode)
+  }
 
   useEffect(() => {
     if (searchParams?.get('new')) {
@@ -42,27 +86,291 @@ export default function AppsHome({ params }: { params: { team: string } }) {
   })
 
   const apps = data?.apps as AppType[]
+  
+  // Filter apps based on search term
+  const filteredApps = apps?.filter(app => 
+    app.name.toLowerCase().includes(searchTerm.toLowerCase())
+  ) || []
+
+  const handleRowClick = (appId: string) => {
+    router.push(`/${params.team}/apps/${appId}`)
+  }
+
+  const renderListView = () => {
+    if (!filteredApps.length) {
+      return (
+        <div className="w-full">
+          <EmptyState
+            title="No apps found"
+            subtitle="No apps match your search criteria. Try adjusting your search."
+            graphic={
+              <div className="text-neutral-300 dark:text-neutral-700 text-7xl text-center">
+                <FaSearch />
+              </div>
+            }
+          >
+            <></>
+          </EmptyState>
+        </div>
+      )
+    }
+
+    return (
+      <div className="w-full bg-white dark:bg-neutral-900 rounded-md overflow-hidden shadow">
+        <table className="w-full border-collapse">
+          <thead className="bg-zinc-100 dark:bg-neutral-800 text-neutral-500 dark:text-neutral-400 text-xs uppercase tracking-wider">
+            <tr>
+              <th className="px-4 py-3 text-left font-medium">App Name</th>
+              {!isMobile && (
+                <>
+                  <th className="px-4 py-3 text-left font-medium">Encryption</th>
+                  <th className="px-4 py-3 text-left font-medium">ID</th>
+                  <th className="px-4 py-3 text-left font-medium">Members</th>
+                  <th className="px-4 py-3 text-left font-medium">Service Accounts</th>
+                  <th className="px-4 py-3 text-left font-medium">Environments</th>
+                  <th className="px-4 py-3 text-left font-medium">Integrations</th>
+                  <th className="px-4 py-3 text-left font-medium"></th>
+                </>
+              )}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-zinc-200 dark:divide-neutral-800">
+            {filteredApps.map((app, index) => {
+              const totalSyncCount = app.environments
+                ? app.environments.reduce((acc, env) => acc + (env!.syncs?.length || 0), 0)
+                : 0
+
+              const providers: string[] = app.environments
+                ? app.environments
+                    .flatMap((env) => {
+                      return env!.syncs.map((sync) => {
+                        const serviceInfo = sync!.serviceInfo
+                        const providerId = serviceInfo!.provider!.id
+                        return providerId
+                      })
+                    })
+                    .filter((id, index, array) => array.indexOf(id) === index)
+                : []
+
+              return (
+                <tr 
+                  key={app.id} 
+                  className="hover:bg-zinc-50 dark:hover:bg-neutral-800 cursor-pointer group"
+                  onClick={() => handleRowClick(app.id)}
+                >
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <span className="font-medium">{app.name}</span>
+                    </div>
+                  </td>
+                  {!isMobile && (
+                    <>
+                      <td className="px-4 py-3">
+                        <EncryptionModeIndicator app={app} />
+                      </td>
+                      <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
+                        <CopyButton 
+                          value={app.id} 
+                          buttonVariant="ghost" 
+                          title="Copy App ID"
+                        >
+                          <span className="text-2xs font-mono text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300">{app.id}</span>
+                        </CopyButton>
+                      </td>
+                      <td className="px-4 py-3">
+                        <Link 
+                          href={`/${params.team}/apps/${app.id}/access/members`}
+                          onClick={(e) => e.stopPropagation()}
+                          className="flex items-center gap-1 hover:underline"
+                        >
+                          <span className="mr-1 text-xs">{app.members.length}</span>
+                          {app.members.slice(0, 3).map((member) => (
+                            <Avatar key={member!.id} imagePath={member!.avatarUrl} size="sm" />
+                          ))}
+                          {app.members.length > 3 && (
+                            <span className="text-neutral-500 text-xs">+{app.members.length - 3}</span>
+                          )}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-3">
+                        {app.serviceAccounts.length > 0 ? (
+                          <Link 
+                            href={`/${params.team}/apps/${app.id}/access/service-accounts`}
+                            onClick={(e) => e.stopPropagation()}
+                            className="flex items-center gap-1 hover:underline"
+                          >
+                            <span className="mr-1 text-xs">{app.serviceAccounts.length}</span>
+                            {app.serviceAccounts.slice(0, 3).map((account) => (
+                              <div
+                                key={account!.id}
+                                className="rounded-full flex items-center bg-neutral-500/40 justify-center size-5 p-1"
+                              >
+                                <span className="text-2xs font-semibold text-zinc-900 dark:text-zinc-100">
+                                  {account?.name.slice(0, 1)}
+                                </span>
+                              </div>
+                            ))}
+                            {app.serviceAccounts.length > 3 && (
+                              <span className="text-neutral-500 text-xs">+{app.serviceAccounts.length - 3}</span>
+                            )}
+                          </Link>
+                        ) : (
+                          <span className="text-neutral-500 text-xs">-</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        <Link 
+                          href={`/${params.team}/apps/${app.id}`}
+                          onClick={(e) => e.stopPropagation()}
+                          className="flex items-center gap-1 hover:underline"
+                        >
+                          <span className="mr-1 text-xs">{app.environments.length}</span>
+                          {app.environments.slice(0, 3).map((env) => (
+                            <div
+                              key={env!.id}
+                              className="bg-neutral-400/10 ring-1 ring-neutral-400/20 rounded-full px-2 text-zinc-800 dark:text-zinc-200 text-2xs font-semibold"
+                            >
+                              {env!.name.slice(0, 1)}
+                            </div>
+                          ))}
+                          {app.environments.length > 3 && (
+                            <span className="text-neutral-500 text-xs">+{app.environments.length - 3}</span>
+                          )}
+                        </Link>
+                      </td>
+                      <td className="px-4 py-3">
+                        {totalSyncCount > 0 ? (
+                          <Link 
+                            href={`/${params.team}/apps/${app.id}/syncing`}
+                            onClick={(e) => e.stopPropagation()}
+                            className="flex items-center gap-1 hover:underline"
+                          >
+                            <span className="mr-1 text-xs">{totalSyncCount}</span>
+                            {providers.slice(0, 3).map((providerId) => (
+                              <ProviderIcon key={providerId} providerId={providerId} />
+                            ))}
+                            {providers.length > 3 && (
+                              <span className="text-neutral-500 text-xs">+{providers.length - 3}</span>
+                            )}
+                          </Link>
+                        ) : (
+                          <span className="text-neutral-500 text-xs">-</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 opacity-0 group-hover:opacity-100 transition-opacity">
+                        <Link
+                          href={`/${params.team}/apps/${app.id}/settings`}
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <Button variant="secondary">
+                            Settings <FaChevronRight />
+                          </Button>
+                        </Link>
+                      </td>
+                    </>
+                  )}
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+
+  const renderGridView = () => {
+    if (!filteredApps.length) {
+      return (
+        <div className="xl:col-span-2 1080p:col-span-3 justify-center p-20">
+          <EmptyState
+            title="No apps found"
+            subtitle="No apps match your search criteria. Try adjusting your search."
+            graphic={
+              <div className="text-neutral-300 dark:text-neutral-700 text-7xl text-center">
+                <FaSearch />
+              </div>
+            }
+          >
+            <></>
+          </EmptyState>
+        </div>
+      )
+    }
+
+    return (
+      <div className="grid grid-cols-1 xl:grid-cols-2 1080p:grid-cols-3 gap-8">
+        {filteredApps.map((app) => (
+          <Link href={`/${params.team}/apps/${app.id}`} key={app.id}>
+            <AppCard app={app} />
+          </Link>
+        ))}
+      </div>
+    )
+  }
 
   return (
     <div
-      className="w-full p-8 text-black dark:text-white flex flex-col gap-16 overflow-y-auto"
+      className="w-full p-8 text-black dark:text-white flex flex-col gap-8 overflow-y-auto"
       style={{ height: 'calc(100vh - 64px)' }}
     >
-      <h1 className="text-3xl font-bold capitalize col-span-4">Apps</h1>
-      {userCanViewApps ? (
-        <div className="grid grid-cols-1 xl:grid-cols-2 1080p:grid-cols-3 gap-8">
-          {apps?.map((app) => (
-            <Link href={`/${params.team}/apps/${app.id}`} key={app.id}>
-              <AppCard app={app} />
-            </Link>
-          ))}
-          {organisation && apps && userCanCreateApps && (
-            <div className="bg-zinc-100 dark:bg-neutral-800 opacity-80 hover:opacity-100 transition-opacity ease-in-out shadow-lg rounded-xl flex flex-col gap-y-20 min-h-60">
-              <NewAppDialog organisation={organisation} appCount={apps.length} ref={dialogRef} />
-            </div>
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col md:flex-row md:items-center md:justify-between">
+          <h1 className="text-3xl font-bold capitalize">Apps</h1>
+          
+          {/* Create App Button - Only shown if user has permissions */}
+          {userCanCreateApps && (
+            <Button
+              onClick={() => dialogRef.current?.openModal()}
+              variant="primary"
+              classString="flex items-center gap-2"
+            >
+              <FaPlus className="text-sm" /> Create App
+            </Button>
           )}
+        </div>
+        
+        <div className="flex flex-col gap-4 md:flex-row md:items-center">
+          {/* Search Box */}
+          <div className="relative flex-1 max-w-md">
+            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <FaSearch className="text-neutral-400" />
+            </div>
+            <input
+              type="text"
+              placeholder="Search apps..."
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              className="pl-10 pr-4 py-2 border border-zinc-300 dark:border-neutral-700 rounded-lg bg-white dark:bg-neutral-800 text-black dark:text-white w-full"
+            />
+          </div>
+          
+          {/* View Toggle Button */}
+          <Button
+            onClick={handleViewModeChange}
+            variant="secondary"
+            classString="flex items-center gap-2"
+          >
+            {viewMode === 'grid' ? (
+              <>
+                <FaListUl className="text-sm" /> List View
+              </>
+            ) : (
+              <>
+                <FaTh className="text-sm" /> Grid View
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+
+      {userCanViewApps ? (
+        <>
+          {/* Render view based on selected mode */}
+          {viewMode === 'grid' ? renderGridView() : renderListView()}
+
+          {/* Empty state when no apps exist at all */}
           {apps?.length === 0 && !userCanCreateApps && (
-            <div className="xl:col-span-2 1080p:col-span-3 justify-center p-20">
+            <div className="justify-center p-20">
               <EmptyState
                 title="No apps"
                 subtitle="You don't have access to any apps yet. Contact an Admin to get access."
@@ -76,7 +384,7 @@ export default function AppsHome({ params }: { params: { team: string } }) {
               </EmptyState>
             </div>
           )}
-        </div>
+        </>
       ) : (
         <EmptyState
           title="Access restricted"
@@ -90,9 +398,17 @@ export default function AppsHome({ params }: { params: { team: string } }) {
           <></>
         </EmptyState>
       )}
+
       {loading && (
         <div className="mx-auto my-auto">
           <Spinner size="xl" />
+        </div>
+      )}
+
+      {/* NewAppDialog - hidden but accessible via ref */}
+      {organisation && apps && (
+        <div className="hidden">
+          <NewAppDialog organisation={organisation} appCount={apps.length} ref={dialogRef} />
         </div>
       )}
     </div>

--- a/frontend/app/[team]/apps/page.tsx
+++ b/frontend/app/[team]/apps/page.tsx
@@ -102,7 +102,8 @@ export default function AppsHome({ params }: { params: { team: string } }) {
   }
 
   const renderListView = () => {
-    if (!filteredApps.length) {
+    // When user has searched but found nothing
+    if (searchTerm && filteredApps.length === 0) {
       return (
         <div className="w-full">
           <EmptyState
@@ -119,174 +120,195 @@ export default function AppsHome({ params }: { params: { team: string } }) {
         </div>
       )
     }
+    
+    // When user has apps to display
+    if (filteredApps.length > 0) {
+      return (
+        <div className="w-full bg-white dark:bg-neutral-900 rounded-md overflow-hidden shadow">
+          <div className="overflow-auto">
+            <table className="w-full border-collapse">
+              <thead className="bg-neutral-100/50 dark:bg-neutral-900/60 text-neutral-500 dark:text-neutral-400 text-xs uppercase tracking-wider border-b-2 border-neutral-500/20 backdrop-blur-sm sticky top-0 z-10">
+                <tr>
+                  <th className="px-4 py-3 text-left font-medium">App Name</th>
+                  {!isMobile && (
+                    <>
+                      <th className="px-4 py-3 text-left font-medium">Encryption</th>
+                      <th className="px-4 py-3 text-left font-medium">ID</th>
+                      <th className="px-4 py-3 text-left font-medium">Members</th>
+                      <th className="px-4 py-3 text-left font-medium">Service Accounts</th>
+                      <th className="px-4 py-3 text-left font-medium">Environments</th>
+                      <th className="px-4 py-3 text-left font-medium">Integrations</th>
+                      <th className="px-4 py-3 text-left font-medium"></th>
+                    </>
+                  )}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-zinc-200 dark:divide-neutral-800">
+                {filteredApps.map((app, index) => {
+                  const totalSyncCount = app.environments
+                    ? app.environments.reduce((acc, env) => acc + (env!.syncs?.length || 0), 0)
+                    : 0
 
-    return (
-      <div className="w-full bg-white dark:bg-neutral-900 rounded-md overflow-hidden shadow">
-        <div className="overflow-auto">
-          <table className="w-full border-collapse">
-            <thead className="bg-neutral-100/50 dark:bg-neutral-900/60 text-neutral-500 dark:text-neutral-400 text-xs uppercase tracking-wider border-b-2 border-neutral-500/20 backdrop-blur-sm sticky top-0 z-10">
-              <tr>
-                <th className="px-4 py-3 text-left font-medium">App Name</th>
-                {!isMobile && (
-                  <>
-                    <th className="px-4 py-3 text-left font-medium">Encryption</th>
-                    <th className="px-4 py-3 text-left font-medium">ID</th>
-                    <th className="px-4 py-3 text-left font-medium">Members</th>
-                    <th className="px-4 py-3 text-left font-medium">Service Accounts</th>
-                    <th className="px-4 py-3 text-left font-medium">Environments</th>
-                    <th className="px-4 py-3 text-left font-medium">Integrations</th>
-                    <th className="px-4 py-3 text-left font-medium"></th>
-                  </>
-                )}
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-zinc-200 dark:divide-neutral-800">
-              {filteredApps.map((app, index) => {
-                const totalSyncCount = app.environments
-                  ? app.environments.reduce((acc, env) => acc + (env!.syncs?.length || 0), 0)
-                  : 0
-
-                const providers: string[] = app.environments
-                  ? app.environments
-                      .flatMap((env) => {
-                        return env!.syncs.map((sync) => {
-                          const serviceInfo = sync!.serviceInfo
-                          const providerId = serviceInfo!.provider!.id
-                          return providerId
+                  const providers: string[] = app.environments
+                    ? app.environments
+                        .flatMap((env) => {
+                          return env!.syncs.map((sync) => {
+                            const serviceInfo = sync!.serviceInfo
+                            const providerId = serviceInfo!.provider!.id
+                            return providerId
+                          })
                         })
-                      })
-                      .filter((id, index, array) => array.indexOf(id) === index)
-                  : []
+                        .filter((id, index, array) => array.indexOf(id) === index)
+                    : []
 
-                return (
-                  <tr 
-                    key={app.id} 
-                    className="hover:bg-zinc-50 dark:hover:bg-neutral-700/30 cursor-pointer group border-b border-neutral-500/20"
-                    onClick={(e) => handleRowClick(app.id, e)}
-                  >
-                    <td className="px-4 py-3">
-                      <div className="flex items-center gap-2">
-                        <span className="font-medium group-hover:underline">{app.name}</span>
-                      </div>
-                    </td>
-                    {!isMobile && (
-                      <>
-                        <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
-                          <EncryptionModeIndicator app={app} />
-                        </td>
-                        <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
-                          <CopyButton 
-                            value={app.id} 
-                            buttonVariant="ghost" 
-                            title="Copy App ID"
-                          >
-                            <span className="text-2xs font-mono text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300">{app.id}</span>
-                          </CopyButton>
-                        </td>
-                        <td className="px-4 py-3">
-                          <Link 
-                            href={`/${params.team}/apps/${app.id}/access/members`}
-                            onClick={(e) => e.stopPropagation()}
-                            className="flex items-center gap-1 hover:underline"
-                          >
-                            <span className="mr-1 text-xs">{app.members.length}</span>
-                            {app.members.slice(0, 3).map((member) => (
-                              <Avatar key={member!.id} imagePath={member!.avatarUrl} size="sm" />
-                            ))}
-                            {app.members.length > 3 && (
-                              <span className="text-neutral-500 text-xs">+{app.members.length - 3}</span>
-                            )}
-                          </Link>
-                        </td>
-                        <td className="px-4 py-3">
-                          {app.serviceAccounts.length > 0 ? (
+                  return (
+                    <tr 
+                      key={app.id} 
+                      className="hover:bg-zinc-50 dark:hover:bg-neutral-700/30 cursor-pointer group border-b border-neutral-500/20"
+                      onClick={(e) => handleRowClick(app.id, e)}
+                    >
+                      <td className="px-4 py-3">
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium group-hover:underline">{app.name}</span>
+                        </div>
+                      </td>
+                      {!isMobile && (
+                        <>
+                          <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
+                            <EncryptionModeIndicator app={app} />
+                          </td>
+                          <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
+                            <CopyButton 
+                              value={app.id} 
+                              buttonVariant="ghost" 
+                              title="Copy App ID"
+                            >
+                              <span className="text-2xs font-mono text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300">{app.id}</span>
+                            </CopyButton>
+                          </td>
+                          <td className="px-4 py-3">
                             <Link 
-                              href={`/${params.team}/apps/${app.id}/access/service-accounts`}
+                              href={`/${params.team}/apps/${app.id}/access/members`}
                               onClick={(e) => e.stopPropagation()}
                               className="flex items-center gap-1 hover:underline"
                             >
-                              <span className="mr-1 text-xs">{app.serviceAccounts.length}</span>
-                              {app.serviceAccounts.slice(0, 3).map((account) => (
+                              <span className="mr-1 text-xs">{app.members.length}</span>
+                              {app.members.slice(0, 3).map((member) => (
+                                <Avatar key={member!.id} imagePath={member!.avatarUrl} size="sm" />
+                              ))}
+                              {app.members.length > 3 && (
+                                <span className="text-neutral-500 text-xs">+{app.members.length - 3}</span>
+                              )}
+                            </Link>
+                          </td>
+                          <td className="px-4 py-3">
+                            {app.serviceAccounts.length > 0 ? (
+                              <Link 
+                                href={`/${params.team}/apps/${app.id}/access/service-accounts`}
+                                onClick={(e) => e.stopPropagation()}
+                                className="flex items-center gap-1 hover:underline"
+                              >
+                                <span className="mr-1 text-xs">{app.serviceAccounts.length}</span>
+                                {app.serviceAccounts.slice(0, 3).map((account) => (
+                                  <div
+                                    key={account!.id}
+                                    className="rounded-full flex items-center bg-neutral-500/40 justify-center size-5 p-1"
+                                  >
+                                    <span className="text-2xs font-semibold text-zinc-900 dark:text-zinc-100">
+                                      {account?.name.slice(0, 1)}
+                                    </span>
+                                  </div>
+                                ))}
+                                {app.serviceAccounts.length > 3 && (
+                                  <span className="text-neutral-500 text-xs">+{app.serviceAccounts.length - 3}</span>
+                                )}
+                              </Link>
+                            ) : (
+                              <span className="text-neutral-500 text-xs">-</span>
+                            )}
+                          </td>
+                          <td className="px-4 py-3">
+                            <Link 
+                              href={`/${params.team}/apps/${app.id}`}
+                              onClick={(e) => e.stopPropagation()}
+                              className="flex items-center gap-1 hover:underline"
+                            >
+                              <span className="mr-1 text-xs">{app.environments.length}</span>
+                              {app.environments.slice(0, 3).map((env) => (
                                 <div
-                                  key={account!.id}
-                                  className="rounded-full flex items-center bg-neutral-500/40 justify-center size-5 p-1"
+                                  key={env!.id}
+                                  className="bg-neutral-400/10 ring-1 ring-neutral-400/20 rounded-full px-2 text-zinc-800 dark:text-zinc-200 text-2xs font-semibold"
                                 >
-                                  <span className="text-2xs font-semibold text-zinc-900 dark:text-zinc-100">
-                                    {account?.name.slice(0, 1)}
-                                  </span>
+                                  {env!.name.slice(0, 1)}
                                 </div>
                               ))}
-                              {app.serviceAccounts.length > 3 && (
-                                <span className="text-neutral-500 text-xs">+{app.serviceAccounts.length - 3}</span>
+                              {app.environments.length > 3 && (
+                                <span className="text-neutral-500 text-xs">+{app.environments.length - 3}</span>
                               )}
                             </Link>
-                          ) : (
-                            <span className="text-neutral-500 text-xs">-</span>
-                          )}
-                        </td>
-                        <td className="px-4 py-3">
-                          <Link 
-                            href={`/${params.team}/apps/${app.id}`}
-                            onClick={(e) => e.stopPropagation()}
-                            className="flex items-center gap-1 hover:underline"
-                          >
-                            <span className="mr-1 text-xs">{app.environments.length}</span>
-                            {app.environments.slice(0, 3).map((env) => (
-                              <div
-                                key={env!.id}
-                                className="bg-neutral-400/10 ring-1 ring-neutral-400/20 rounded-full px-2 text-zinc-800 dark:text-zinc-200 text-2xs font-semibold"
+                          </td>
+                          <td className="px-4 py-3">
+                            {totalSyncCount > 0 ? (
+                              <Link 
+                                href={`/${params.team}/apps/${app.id}/syncing`}
+                                onClick={(e) => e.stopPropagation()}
+                                className="flex items-center gap-1 hover:underline"
                               >
-                                {env!.name.slice(0, 1)}
-                              </div>
-                            ))}
-                            {app.environments.length > 3 && (
-                              <span className="text-neutral-500 text-xs">+{app.environments.length - 3}</span>
+                                <span className="mr-1 text-xs">{totalSyncCount}</span>
+                                {providers.slice(0, 3).map((providerId) => (
+                                  <ProviderIcon key={providerId} providerId={providerId} />
+                                ))}
+                                {providers.length > 3 && (
+                                  <span className="text-neutral-500 text-xs">+{providers.length - 3}</span>
+                                )}
+                              </Link>
+                            ) : (
+                              <span className="text-neutral-500 text-xs">-</span>
                             )}
-                          </Link>
-                        </td>
-                        <td className="px-4 py-3">
-                          {totalSyncCount > 0 ? (
-                            <Link 
-                              href={`/${params.team}/apps/${app.id}/syncing`}
+                          </td>
+                          <td className="px-4 py-3 opacity-0 group-hover:opacity-100 transition-opacity">
+                            <Link
+                              href={`/${params.team}/apps/${app.id}/settings`}
                               onClick={(e) => e.stopPropagation()}
-                              className="flex items-center gap-1 hover:underline"
                             >
-                              <span className="mr-1 text-xs">{totalSyncCount}</span>
-                              {providers.slice(0, 3).map((providerId) => (
-                                <ProviderIcon key={providerId} providerId={providerId} />
-                              ))}
-                              {providers.length > 3 && (
-                                <span className="text-neutral-500 text-xs">+{providers.length - 3}</span>
-                              )}
+                              <Button variant="secondary">
+                                Settings <FaChevronRight />
+                              </Button>
                             </Link>
-                          ) : (
-                            <span className="text-neutral-500 text-xs">-</span>
-                          )}
-                        </td>
-                        <td className="px-4 py-3 opacity-0 group-hover:opacity-100 transition-opacity">
-                          <Link
-                            href={`/${params.team}/apps/${app.id}/settings`}
-                            onClick={(e) => e.stopPropagation()}
-                          >
-                            <Button variant="secondary">
-                              Settings <FaChevronRight />
-                            </Button>
-                          </Link>
-                        </td>
-                      </>
-                    )}
-                  </tr>
-                )
-              })}
-            </tbody>
-          </table>
+                          </td>
+                        </>
+                      )}
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
         </div>
+      )
+    }
+    
+    // Default case: User has no apps
+    return (
+      <div className="w-full">
+        <EmptyState
+          title="No apps"
+          subtitle="You don't have access to any apps yet. Contact an Admin to get access."
+          graphic={
+            <div className="text-neutral-300 dark:text-neutral-700 text-7xl text-center">
+              <FaBoxOpen />
+            </div>
+          }
+        >
+          <></>
+        </EmptyState>
       </div>
     )
   }
 
   const renderGridView = () => {
-    if (!filteredApps.length) {
+    // When user has searched but found nothing
+    if (searchTerm && filteredApps.length === 0) {
       return (
         <div className="xl:col-span-2 1080p:col-span-3 justify-center p-20">
           <EmptyState
@@ -303,14 +325,34 @@ export default function AppsHome({ params }: { params: { team: string } }) {
         </div>
       )
     }
-
+    
+    // When user has apps to display
+    if (filteredApps.length > 0) {
+      return (
+        <div className="grid grid-cols-1 xl:grid-cols-2 1080p:grid-cols-3 gap-8">
+          {filteredApps.map((app) => (
+            <Link href={`/${params.team}/apps/${app.id}`} key={app.id}>
+              <AppCard app={app} />
+            </Link>
+          ))}
+        </div>
+      )
+    }
+    
+    // Default case: User has no apps
     return (
-      <div className="grid grid-cols-1 xl:grid-cols-2 1080p:grid-cols-3 gap-8">
-        {filteredApps.map((app) => (
-          <Link href={`/${params.team}/apps/${app.id}`} key={app.id}>
-            <AppCard app={app} />
-          </Link>
-        ))}
+      <div className="xl:col-span-2 1080p:col-span-3 justify-center p-20">
+        <EmptyState
+          title="No apps"
+          subtitle="You don't have access to any apps yet. Contact an Admin to get access."
+          graphic={
+            <div className="text-neutral-300 dark:text-neutral-700 text-7xl text-center">
+              <FaBoxOpen />
+            </div>
+          }
+        >
+          <></>
+        </EmptyState>
       </div>
     )
   }
@@ -374,23 +416,6 @@ export default function AppsHome({ params }: { params: { team: string } }) {
         <div className="flex-1 min-h-0 overflow-auto">
           {/* Render view based on selected mode */}
           {viewMode === 'grid' ? renderGridView() : renderListView()}
-
-          {/* Empty state when no apps exist at all */}
-          {apps?.length === 0 && !userCanCreateApps && (
-            <div className="justify-center p-20">
-              <EmptyState
-                title="No apps"
-                subtitle="You don't have access to any apps yet. Contact an Admin to get access."
-                graphic={
-                  <div className="text-neutral-300 dark:text-neutral-700 text-7xl text-center">
-                    <FaBoxOpen />
-                  </div>
-                }
-              >
-                <></>
-              </EmptyState>
-            </div>
-          )}
         </div>
       ) : (
         <EmptyState

--- a/frontend/app/[team]/apps/page.tsx
+++ b/frontend/app/[team]/apps/page.tsx
@@ -170,7 +170,7 @@ export default function AppsHome({ params }: { params: { team: string } }) {
                   </td>
                   {!isMobile && (
                     <>
-                      <td className="px-4 py-3">
+                      <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
                         <EncryptionModeIndicator app={app} />
                       </td>
                       <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>

--- a/frontend/app/[team]/apps/page.tsx
+++ b/frontend/app/[team]/apps/page.tsx
@@ -123,7 +123,7 @@ export default function AppsHome({ params }: { params: { team: string } }) {
     return (
       <div className="w-full bg-white dark:bg-neutral-900 rounded-md overflow-hidden shadow">
         <table className="w-full border-collapse">
-          <thead className="bg-zinc-100 dark:bg-neutral-800 text-neutral-500 dark:text-neutral-400 text-xs uppercase tracking-wider">
+          <thead className="bg-neutral-100/50 dark:bg-neutral-900/60 text-neutral-500 dark:text-neutral-400 text-xs uppercase tracking-wider border-b-2 border-neutral-500/20 backdrop-blur-sm">
             <tr>
               <th className="px-4 py-3 text-left font-medium">App Name</th>
               {!isMobile && (
@@ -160,7 +160,7 @@ export default function AppsHome({ params }: { params: { team: string } }) {
               return (
                 <tr 
                   key={app.id} 
-                  className="hover:bg-zinc-50 dark:hover:bg-neutral-800 cursor-pointer group"
+                  className="hover:bg-zinc-50 dark:hover:bg-neutral-700/30 cursor-pointer group border-b border-neutral-500/20"
                   onClick={(e) => handleRowClick(app.id, e)}
                 >
                   <td className="px-4 py-3">

--- a/frontend/app/[team]/apps/page.tsx
+++ b/frontend/app/[team]/apps/page.tsx
@@ -122,163 +122,165 @@ export default function AppsHome({ params }: { params: { team: string } }) {
 
     return (
       <div className="w-full bg-white dark:bg-neutral-900 rounded-md overflow-hidden shadow">
-        <table className="w-full border-collapse">
-          <thead className="bg-neutral-100/50 dark:bg-neutral-900/60 text-neutral-500 dark:text-neutral-400 text-xs uppercase tracking-wider border-b-2 border-neutral-500/20 backdrop-blur-sm">
-            <tr>
-              <th className="px-4 py-3 text-left font-medium">App Name</th>
-              {!isMobile && (
-                <>
-                  <th className="px-4 py-3 text-left font-medium">Encryption</th>
-                  <th className="px-4 py-3 text-left font-medium">ID</th>
-                  <th className="px-4 py-3 text-left font-medium">Members</th>
-                  <th className="px-4 py-3 text-left font-medium">Service Accounts</th>
-                  <th className="px-4 py-3 text-left font-medium">Environments</th>
-                  <th className="px-4 py-3 text-left font-medium">Integrations</th>
-                  <th className="px-4 py-3 text-left font-medium"></th>
-                </>
-              )}
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-zinc-200 dark:divide-neutral-800">
-            {filteredApps.map((app, index) => {
-              const totalSyncCount = app.environments
-                ? app.environments.reduce((acc, env) => acc + (env!.syncs?.length || 0), 0)
-                : 0
+        <div className="overflow-auto">
+          <table className="w-full border-collapse">
+            <thead className="bg-neutral-100/50 dark:bg-neutral-900/60 text-neutral-500 dark:text-neutral-400 text-xs uppercase tracking-wider border-b-2 border-neutral-500/20 backdrop-blur-sm sticky top-0 z-10">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium">App Name</th>
+                {!isMobile && (
+                  <>
+                    <th className="px-4 py-3 text-left font-medium">Encryption</th>
+                    <th className="px-4 py-3 text-left font-medium">ID</th>
+                    <th className="px-4 py-3 text-left font-medium">Members</th>
+                    <th className="px-4 py-3 text-left font-medium">Service Accounts</th>
+                    <th className="px-4 py-3 text-left font-medium">Environments</th>
+                    <th className="px-4 py-3 text-left font-medium">Integrations</th>
+                    <th className="px-4 py-3 text-left font-medium"></th>
+                  </>
+                )}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-zinc-200 dark:divide-neutral-800">
+              {filteredApps.map((app, index) => {
+                const totalSyncCount = app.environments
+                  ? app.environments.reduce((acc, env) => acc + (env!.syncs?.length || 0), 0)
+                  : 0
 
-              const providers: string[] = app.environments
-                ? app.environments
-                    .flatMap((env) => {
-                      return env!.syncs.map((sync) => {
-                        const serviceInfo = sync!.serviceInfo
-                        const providerId = serviceInfo!.provider!.id
-                        return providerId
+                const providers: string[] = app.environments
+                  ? app.environments
+                      .flatMap((env) => {
+                        return env!.syncs.map((sync) => {
+                          const serviceInfo = sync!.serviceInfo
+                          const providerId = serviceInfo!.provider!.id
+                          return providerId
+                        })
                       })
-                    })
-                    .filter((id, index, array) => array.indexOf(id) === index)
-                : []
+                      .filter((id, index, array) => array.indexOf(id) === index)
+                  : []
 
-              return (
-                <tr 
-                  key={app.id} 
-                  className="hover:bg-zinc-50 dark:hover:bg-neutral-700/30 cursor-pointer group border-b border-neutral-500/20"
-                  onClick={(e) => handleRowClick(app.id, e)}
-                >
-                  <td className="px-4 py-3">
-                    <div className="flex items-center gap-2">
-                      <span className="font-medium group-hover:underline">{app.name}</span>
-                    </div>
-                  </td>
-                  {!isMobile && (
-                    <>
-                      <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
-                        <EncryptionModeIndicator app={app} />
-                      </td>
-                      <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
-                        <CopyButton 
-                          value={app.id} 
-                          buttonVariant="ghost" 
-                          title="Copy App ID"
-                        >
-                          <span className="text-2xs font-mono text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300">{app.id}</span>
-                        </CopyButton>
-                      </td>
-                      <td className="px-4 py-3">
-                        <Link 
-                          href={`/${params.team}/apps/${app.id}/access/members`}
-                          onClick={(e) => e.stopPropagation()}
-                          className="flex items-center gap-1 hover:underline"
-                        >
-                          <span className="mr-1 text-xs">{app.members.length}</span>
-                          {app.members.slice(0, 3).map((member) => (
-                            <Avatar key={member!.id} imagePath={member!.avatarUrl} size="sm" />
-                          ))}
-                          {app.members.length > 3 && (
-                            <span className="text-neutral-500 text-xs">+{app.members.length - 3}</span>
-                          )}
-                        </Link>
-                      </td>
-                      <td className="px-4 py-3">
-                        {app.serviceAccounts.length > 0 ? (
+                return (
+                  <tr 
+                    key={app.id} 
+                    className="hover:bg-zinc-50 dark:hover:bg-neutral-700/30 cursor-pointer group border-b border-neutral-500/20"
+                    onClick={(e) => handleRowClick(app.id, e)}
+                  >
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium group-hover:underline">{app.name}</span>
+                      </div>
+                    </td>
+                    {!isMobile && (
+                      <>
+                        <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
+                          <EncryptionModeIndicator app={app} />
+                        </td>
+                        <td className="px-4 py-3" onClick={(e) => e.stopPropagation()}>
+                          <CopyButton 
+                            value={app.id} 
+                            buttonVariant="ghost" 
+                            title="Copy App ID"
+                          >
+                            <span className="text-2xs font-mono text-neutral-500 hover:text-neutral-700 dark:hover:text-neutral-300">{app.id}</span>
+                          </CopyButton>
+                        </td>
+                        <td className="px-4 py-3">
                           <Link 
-                            href={`/${params.team}/apps/${app.id}/access/service-accounts`}
+                            href={`/${params.team}/apps/${app.id}/access/members`}
                             onClick={(e) => e.stopPropagation()}
                             className="flex items-center gap-1 hover:underline"
                           >
-                            <span className="mr-1 text-xs">{app.serviceAccounts.length}</span>
-                            {app.serviceAccounts.slice(0, 3).map((account) => (
+                            <span className="mr-1 text-xs">{app.members.length}</span>
+                            {app.members.slice(0, 3).map((member) => (
+                              <Avatar key={member!.id} imagePath={member!.avatarUrl} size="sm" />
+                            ))}
+                            {app.members.length > 3 && (
+                              <span className="text-neutral-500 text-xs">+{app.members.length - 3}</span>
+                            )}
+                          </Link>
+                        </td>
+                        <td className="px-4 py-3">
+                          {app.serviceAccounts.length > 0 ? (
+                            <Link 
+                              href={`/${params.team}/apps/${app.id}/access/service-accounts`}
+                              onClick={(e) => e.stopPropagation()}
+                              className="flex items-center gap-1 hover:underline"
+                            >
+                              <span className="mr-1 text-xs">{app.serviceAccounts.length}</span>
+                              {app.serviceAccounts.slice(0, 3).map((account) => (
+                                <div
+                                  key={account!.id}
+                                  className="rounded-full flex items-center bg-neutral-500/40 justify-center size-5 p-1"
+                                >
+                                  <span className="text-2xs font-semibold text-zinc-900 dark:text-zinc-100">
+                                    {account?.name.slice(0, 1)}
+                                  </span>
+                                </div>
+                              ))}
+                              {app.serviceAccounts.length > 3 && (
+                                <span className="text-neutral-500 text-xs">+{app.serviceAccounts.length - 3}</span>
+                              )}
+                            </Link>
+                          ) : (
+                            <span className="text-neutral-500 text-xs">-</span>
+                          )}
+                        </td>
+                        <td className="px-4 py-3">
+                          <Link 
+                            href={`/${params.team}/apps/${app.id}`}
+                            onClick={(e) => e.stopPropagation()}
+                            className="flex items-center gap-1 hover:underline"
+                          >
+                            <span className="mr-1 text-xs">{app.environments.length}</span>
+                            {app.environments.slice(0, 3).map((env) => (
                               <div
-                                key={account!.id}
-                                className="rounded-full flex items-center bg-neutral-500/40 justify-center size-5 p-1"
+                                key={env!.id}
+                                className="bg-neutral-400/10 ring-1 ring-neutral-400/20 rounded-full px-2 text-zinc-800 dark:text-zinc-200 text-2xs font-semibold"
                               >
-                                <span className="text-2xs font-semibold text-zinc-900 dark:text-zinc-100">
-                                  {account?.name.slice(0, 1)}
-                                </span>
+                                {env!.name.slice(0, 1)}
                               </div>
                             ))}
-                            {app.serviceAccounts.length > 3 && (
-                              <span className="text-neutral-500 text-xs">+{app.serviceAccounts.length - 3}</span>
+                            {app.environments.length > 3 && (
+                              <span className="text-neutral-500 text-xs">+{app.environments.length - 3}</span>
                             )}
                           </Link>
-                        ) : (
-                          <span className="text-neutral-500 text-xs">-</span>
-                        )}
-                      </td>
-                      <td className="px-4 py-3">
-                        <Link 
-                          href={`/${params.team}/apps/${app.id}`}
-                          onClick={(e) => e.stopPropagation()}
-                          className="flex items-center gap-1 hover:underline"
-                        >
-                          <span className="mr-1 text-xs">{app.environments.length}</span>
-                          {app.environments.slice(0, 3).map((env) => (
-                            <div
-                              key={env!.id}
-                              className="bg-neutral-400/10 ring-1 ring-neutral-400/20 rounded-full px-2 text-zinc-800 dark:text-zinc-200 text-2xs font-semibold"
+                        </td>
+                        <td className="px-4 py-3">
+                          {totalSyncCount > 0 ? (
+                            <Link 
+                              href={`/${params.team}/apps/${app.id}/syncing`}
+                              onClick={(e) => e.stopPropagation()}
+                              className="flex items-center gap-1 hover:underline"
                             >
-                              {env!.name.slice(0, 1)}
-                            </div>
-                          ))}
-                          {app.environments.length > 3 && (
-                            <span className="text-neutral-500 text-xs">+{app.environments.length - 3}</span>
+                              <span className="mr-1 text-xs">{totalSyncCount}</span>
+                              {providers.slice(0, 3).map((providerId) => (
+                                <ProviderIcon key={providerId} providerId={providerId} />
+                              ))}
+                              {providers.length > 3 && (
+                                <span className="text-neutral-500 text-xs">+{providers.length - 3}</span>
+                              )}
+                            </Link>
+                          ) : (
+                            <span className="text-neutral-500 text-xs">-</span>
                           )}
-                        </Link>
-                      </td>
-                      <td className="px-4 py-3">
-                        {totalSyncCount > 0 ? (
-                          <Link 
-                            href={`/${params.team}/apps/${app.id}/syncing`}
+                        </td>
+                        <td className="px-4 py-3 opacity-0 group-hover:opacity-100 transition-opacity">
+                          <Link
+                            href={`/${params.team}/apps/${app.id}/settings`}
                             onClick={(e) => e.stopPropagation()}
-                            className="flex items-center gap-1 hover:underline"
                           >
-                            <span className="mr-1 text-xs">{totalSyncCount}</span>
-                            {providers.slice(0, 3).map((providerId) => (
-                              <ProviderIcon key={providerId} providerId={providerId} />
-                            ))}
-                            {providers.length > 3 && (
-                              <span className="text-neutral-500 text-xs">+{providers.length - 3}</span>
-                            )}
+                            <Button variant="secondary">
+                              Settings <FaChevronRight />
+                            </Button>
                           </Link>
-                        ) : (
-                          <span className="text-neutral-500 text-xs">-</span>
-                        )}
-                      </td>
-                      <td className="px-4 py-3 opacity-0 group-hover:opacity-100 transition-opacity">
-                        <Link
-                          href={`/${params.team}/apps/${app.id}/settings`}
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          <Button variant="secondary">
-                            Settings <FaChevronRight />
-                          </Button>
-                        </Link>
-                      </td>
-                    </>
-                  )}
-                </tr>
-              )
-            })}
-          </tbody>
-        </table>
+                        </td>
+                      </>
+                    )}
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
       </div>
     )
   }
@@ -315,7 +317,7 @@ export default function AppsHome({ params }: { params: { team: string } }) {
 
   return (
     <div
-      className="w-full p-8 text-black dark:text-white flex flex-col gap-8 overflow-y-auto"
+      className="w-full p-8 text-black dark:text-white flex flex-col gap-8 overflow-hidden"
       style={{ height: 'calc(100vh - 64px)' }}
     >
       <div className="flex flex-col gap-4">
@@ -369,7 +371,7 @@ export default function AppsHome({ params }: { params: { team: string } }) {
       </div>
 
       {userCanViewApps ? (
-        <>
+        <div className="flex-1 min-h-0 overflow-auto">
           {/* Render view based on selected mode */}
           {viewMode === 'grid' ? renderGridView() : renderListView()}
 
@@ -389,7 +391,7 @@ export default function AppsHome({ params }: { params: { team: string } }) {
               </EmptyState>
             </div>
           )}
-        </>
+        </div>
       ) : (
         <EmptyState
           title="Access restricted"


### PR DESCRIPTION
## :mag: Overview

This PR adds a table view to the Apps screen. This is an alternative to the default grid view. This is particularly useful for users with a large number of Apps and power users who need to quickly access things such as App ID, service accounts, members, integrations and settings page for large number of Apps with a single click. 

This PR draws inspiration from but does not depend on: https://github.com/phasehq/console/pull/486

## :bulb: Proposed Changes

- Added a table which lists all the Apps, related metadata and links for which the user has access to
- Added a simple Create App button that's as a common way to create a new App from the grid view or the table view
- Added a search box that will locally search Apps and filter results based on the names

## :framed_picture: Screenshots or Demo

https://github.com/user-attachments/assets/1ea8ff2e-aa1c-454e-a134-4d68faa522aa

### :dart: Reviewer Focus / Further improvements

@rohan-chaturvedi 

1. Encryption status indicator z index issues
![image](https://github.com/user-attachments/assets/2a6ac0c3-e1ce-47ca-b3bc-f59e002d235d)
2. Clickable environments for one-click access
![image](https://github.com/user-attachments/assets/d37505e4-6f47-4b3d-8374-99aeefb2f0f7)
3. Improved mobile view 
![image](https://github.com/user-attachments/assets/b07c7782-e7c9-41ae-b117-e9d4ac6052d6)

### :green_heart: Did You...

- [ ] Ensure linting passes (code style checks)?
- [ ] Update dependencies and lockfiles (if required)
- [ ] Update migrations (if required)
- [ ] Regenerate graphql schema and types (if required)
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
