### PR TITLE
fix: visibility of environment secrets

### DIFF
--- a/frontend/app/[team]/apps/[app]/_components/AppSecretRow.tsx
+++ b/frontend/app/[team]/apps/[app]/_components/AppSecretRow.tsx
@@ -70,7 +70,7 @@ const EnvSecret = ({
     : false
   const booleanValue = clientEnvSecret.secret?.value.toLowerCase() === 'true'
 
-  // Permisssions
+  // Permissions
   const userCanUpdateSecrets =
     userHasPermission(organisation?.role?.permissions, 'Secrets', 'update', true) ||
     !serverEnvSecret

--- a/frontend/app/[team]/apps/[app]/_components/AppSecretRow.tsx
+++ b/frontend/app/[team]/apps/[app]/_components/AppSecretRow.tsx
@@ -61,8 +61,9 @@ const EnvSecret = ({
   const [readSecret] = useMutation(LogSecretReads)
 
   const valueIsNew = clientEnvSecret.secret?.id.includes('new')
+  const isEmptyValue = clientEnvSecret.secret?.value === ''
 
-  const [showValue, setShowValue] = useState<boolean>(valueIsNew || !serverEnvSecret || false)
+  const [showValue, setShowValue] = useState<boolean>(valueIsNew || !serverEnvSecret || isEmptyValue || false)
 
   const isBoolean = clientEnvSecret?.secret
     ? ['true', 'false'].includes(clientEnvSecret.secret.value.toLowerCase())

--- a/frontend/app/[team]/apps/[app]/_components/AppSecretRow.tsx
+++ b/frontend/app/[team]/apps/[app]/_components/AppSecretRow.tsx
@@ -62,7 +62,7 @@ const EnvSecret = ({
 
   const valueIsNew = clientEnvSecret.secret?.id.includes('new')
 
-  const [showValue, setShowValue] = useState<boolean>(valueIsNew || false)
+  const [showValue, setShowValue] = useState<boolean>(valueIsNew || !serverEnvSecret || false)
 
   const isBoolean = clientEnvSecret?.secret
     ? ['true', 'false'].includes(clientEnvSecret.secret.value.toLowerCase())
@@ -93,6 +93,14 @@ const EnvSecret = ({
     if (isBoolean) setShowValue(true)
   }, [isBoolean])
 
+  // Ensure newly added values or changed values are revealed
+  useEffect(() => {
+    // If there's no server secret (new value) or the client value is different from server value, show it
+    if (!serverEnvSecret || (clientEnvSecret.secret && serverEnvSecret?.secret?.value !== clientEnvSecret.secret.value)) {
+      setShowValue(true);
+    }
+  }, [serverEnvSecret, clientEnvSecret.secret]);
+
   const handleHideSecret = () => setShowValue(false)
 
   const toggleShowValue = () => {
@@ -102,7 +110,11 @@ const EnvSecret = ({
   const handleDeleteValue = () =>
     deleteEnvValue(appSecretId, clientEnvSecret!.env as EnvironmentType)
 
-  const handleAddValue = () => addEnvValue(appSecretId, clientEnvSecret.env as EnvironmentType)
+  const handleAddValue = () => {
+    addEnvValue(appSecretId, clientEnvSecret.env as EnvironmentType);
+    // Ensure the value is visible after adding it
+    setShowValue(true);
+  }
 
   const valueIsModified = () => {
     if (serverEnvSecret) {

--- a/frontend/app/[team]/apps/[app]/_components/AppSecretRow.tsx
+++ b/frontend/app/[team]/apps/[app]/_components/AppSecretRow.tsx
@@ -93,14 +93,6 @@ const EnvSecret = ({
     if (isBoolean) setShowValue(true)
   }, [isBoolean])
 
-  // Ensure newly added values or changed values are revealed
-  useEffect(() => {
-    // If there's no server secret (new value) or the client value is different from server value, show it
-    if (!serverEnvSecret || (clientEnvSecret.secret && serverEnvSecret?.secret?.value !== clientEnvSecret.secret.value)) {
-      setShowValue(true);
-    }
-  }, [serverEnvSecret, clientEnvSecret.secret]);
-
   const handleHideSecret = () => setShowValue(false)
 
   const toggleShowValue = () => {


### PR DESCRIPTION
## :mag: Overview

This PR makes a small quality of life improvement to make sure values are reveled upon entry for blank secrets in the cross environment screen. This allows the user to see what the value they are typing or pasting-in, making the behavior consistent with the secret creation flow.

## :bulb: Proposed Changes

- Updated logic to show environment secret values when newly added or modified.
- Ensured that the secret value is visible after adding a new entry.

## :framed_picture: Screenshots or Demo

https://github.com/user-attachments/assets/12a9d008-fa53-4031-8427-55f21f3a6133
