### PR TITLE
chore: bump to next 14.2.25

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
     "jspdf": "^2.5.1",
     "libsodium-wrappers-sumo": "^0.7.13",
     "lodash": "^4.17.21",
-    "next": "^14.2.15",
+    "next": "^14.2.25",
     "next-auth": "^4.24.5",
     "nextjs-toploader": "^1.6.4",
     "npm": "^10.4.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -7082,7 +7082,7 @@ next-auth@^4.24.5:
     preact-render-to-string "^5.1.19"
     uuid "^8.3.2"
 
-next@^14.2.15:
+next@^14.2.25:
   version "14.2.25"
   resolved "https://registry.yarnpkg.com/next/-/next-14.2.25.tgz#0657551fde6a97f697cf9870e9ccbdaa465c6008"
   integrity sha512-N5M7xMc4wSb4IkPvEV5X2BRRXUmhVHNyaXwEM86+voXthSZz8ZiRyQW4p9mwAoAPIm6OzuVZtn7idgEJeAJN3Q==


### PR DESCRIPTION
## :mag: Overview

bump next.js to `14.2.25`

