### PR TITLE
fix: app id ghost copy button

### DIFF
--- a/frontend/components/apps/AppCard.tsx
+++ b/frontend/components/apps/AppCard.tsx
@@ -306,11 +306,13 @@ const AppCardContent = ({ app, variant }: AppCardProps) => {
             </div>
           ) : (
             <div className="flex items-center justify-between">
-              <CopyButton value={id} buttonVariant="ghost">
-                <span className="text-2xs font-mono md:whitespace-nowrap text-neutral-500">
-                  {id}
-                </span>
-              </CopyButton>
+              <div onClick={(e) => e.stopPropagation()}>
+                <CopyButton value={id} buttonVariant="ghost">
+                  <span className="text-2xs font-mono md:whitespace-nowrap text-neutral-500">
+                    {id}
+                  </span>
+                </CopyButton>
+              </div>
               <div className="lg:hidden">
                 <CondensedAppMetaCounts />
               </div>


### PR DESCRIPTION
## :mag: Overview

Fixed: Clicking the App ID copy button would send the user to the app.

