### PR TITLE
fix:  third-party credentials create flow

### DIFF
--- a/frontend/app/[team]/integrations/page.tsx
+++ b/frontend/app/[team]/integrations/page.tsx
@@ -199,7 +199,7 @@ export default function Integrations({ params }: { params: { team: string } }) {
         <p className="text-neutral-500">Manage integrations with third party services</p>
       </div>
 
-      <Tab.Group>
+      <Tab.Group defaultIndex={providerFromUrl ? 1 : 0}>
         <Tab.List className="flex gap-4 w-full border-b border-neutral-500/20">
           <Tab as={Fragment}>
             {({ selected }) => (


### PR DESCRIPTION
## :mag: Overview

Fix tab index to the third party credentials so that the create credential popup is brought up for the correct provider when routed to via the App syncing tab.

