### PR TITLE
fix: disable apollo dev tools messages in browser console

### DIFF
--- a/frontend/apollo/client.ts
+++ b/frontend/apollo/client.ts
@@ -38,7 +38,7 @@ const errorLink = onError(({ graphQLErrors, networkError, operation, forward }) 
   // Log network error
   if (networkError) {
     console.log(`[Network error]: ${networkError}`)
-    // Client-side logout when recieving a 403 from the backend
+    // Client-side logout when receiving a 403 from the backend
     if (networkError.message.includes('403')) handleSignout()
   }
 })

--- a/frontend/apollo/client.ts
+++ b/frontend/apollo/client.ts
@@ -46,6 +46,7 @@ const errorLink = onError(({ graphQLErrors, networkError, operation, forward }) 
 export const graphQlClient = new ApolloClient({
   link: from([errorLink, httpLink]),
   cache: new InMemoryCache(),
+  connectToDevTools: false,
   defaultOptions: {
     watchQuery: {
       skipPollAttempt: () => document.hidden


### PR DESCRIPTION
## :mag: Overview

 Prevent Apollo DevTools client messages being logged to the browser console.

![image](https://github.com/user-attachments/assets/0080fa55-3adf-4699-9a64-c80ac24f026b)

