### PR TITLE
fix: validate role changes for users with global access

### DIFF
--- a/backend/api/utils/access/permissions.py
+++ b/backend/api/utils/access/permissions.py
@@ -107,3 +107,25 @@ def user_has_permission(
 
     except OrganisationMember.DoesNotExist:
         return False  # User is not a member of the organization
+
+
+def role_has_global_access(role):
+    Role = apps.get_model("api", "Role")
+
+    """Check if a given role has global access."""
+    try:
+        # Check if the role is a default role
+        if role.is_default:
+            # Get permissions from the default_roles dictionary
+            role_name = role.name.capitalize()
+            permissions = default_roles.get(role_name, {})
+        else:
+            # Use the permissions stored in the role object
+            permissions = role.permissions
+
+        permission_key = "global_access"
+
+        return permissions.get(permission_key, False)
+
+    except Role.DoesNotExist:
+        return False  # Role is not valid

--- a/frontend/app/[team]/access/members/page.tsx
+++ b/frontend/app/[team]/access/members/page.tsx
@@ -183,6 +183,7 @@ const RoleSelector = (props: { member: OrganisationMemberType }) => {
   }
 
   const handleUpdateRole = async (newRole: RoleType) => {
+    const currentRoleHasGlobalAccess = userHasGlobalAccess(member.role?.permissions)
     const newRoleHasGlobalAccess = userHasGlobalAccess(newRole.permissions)
     const currentUserHasGlobalAccess = userHasGlobalAccess(organisation?.role?.permissions)
 
@@ -191,6 +192,13 @@ const RoleSelector = (props: { member: OrganisationMemberType }) => {
 
     if (newRoleHasGlobalAccess && !currentUserHasGlobalAccess) {
       toast.error('You cannot assign users to this role as it requires global access!', {
+        autoClose: 5000,
+      })
+      return false
+    }
+
+    if (currentRoleHasGlobalAccess && !currentUserHasGlobalAccess) {
+      toast.error("You cannot change this user's role as you don't have global access!", {
         autoClose: 5000,
       })
       return false


### PR DESCRIPTION
## :mag: Overview

A user with `Members:update`  and `Roles:read` permissions can update user roles, however this also allows such users to demote users with "Global Access" (GA) roles. eg: A "Manager" can demote an "Admin"

## :bulb: Proposed Changes

Adds a validation check to make sure only users with GA can modify the role of another user with GA.

### :dart: Reviewer Focus

Verify the following:
* Managers can update user roles (non Admin)
* Managers cannot upgrade users to Admin
* Managers cannot demote users from Admin
* Admins can  upgrade / demote other Admins

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Update migrations (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
