### PR TITLE
fix: restrict invite roles to prevent service account handler errors

### DIFF
--- a/frontend/app/[team]/access/members/_components/InviteDialog.tsx
+++ b/frontend/app/[team]/access/members/_components/InviteDialog.tsx
@@ -11,12 +11,12 @@ import { useQuery, useMutation } from '@apollo/client'
 import { Listbox } from '@headlessui/react'
 import { useSearchParams } from 'next/navigation'
 import { useContext, useState, useRef, useEffect, Fragment, useMemo } from 'react'
-import { FaChevronDown, FaPlus, FaTimes } from 'react-icons/fa'
+import { FaChevronDown, FaPlus } from 'react-icons/fa'
 import { GetOrganisationPlan } from '@/graphql/queries/organisation/getOrganisationPlan.gql'
 import GetInvites from '@/graphql/queries/organisation/getInvites.gql'
 import { GetRoles } from '@/graphql/queries/organisation/getRoles.gql'
 import InviteMember from '@/graphql/mutations/organisation/inviteNewMember.gql'
-import { userHasPermission } from '@/utils/access/permissions'
+import { userHasGlobalAccess, userHasPermission } from '@/utils/access/permissions'
 import { RoleLabel } from '@/components/users/RoleLabel'
 import clsx from 'clsx'
 import GenericDialog from '@/components/common/GenericDialog'
@@ -45,7 +45,9 @@ export const InviteDialog = (props: { organisationId: string }) => {
   const roleOptions: RoleType[] = useMemo(() => {
     return (
       roleData?.roles.filter(
-        (option: RoleType) => option.name !== 'Owner' && option.name !== 'Admin'
+        (option: RoleType) =>
+          !userHasGlobalAccess(option.permissions) &&
+          !userHasPermission(option.permissions, 'ServiceAccountTokens', 'create')
       ) || []
     )
   }, [roleData])


### PR DESCRIPTION
## :mag: Overview

Users can be assigned a role during the invite process before they have onboarded and set up a keyring. This causes issues with roles that contain the `ServiceAccountTokens:create` permission, as users will not have the required Service Account keys to perform this action. 

Users can be assigned these roles safely after onboarding.

## :bulb: Proposed Changes

Updates the list of available roles on invites to:
* Users without global access
* Users without the `ServiceAccountTokens:create`  permission

## :memo: Release Notes

Updates the list of roles available on the user invite screen to prevent issues with creating Service Account Tokens

### :heavy_plus_sign: Additional Context

We are exploring a mechanism to re-enable these roles during the invite process by wrapping the require keyring server-side, before the user has onboarded. However this needs to be carefully considered to avoid breaking the E2E model.

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Update migrations (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
