### PR TITLE
fix: display network policy meta inline on hover

### DIFF
--- a/frontend/app/[team]/access/network/page.tsx
+++ b/frontend/app/[team]/access/network/page.tsx
@@ -68,9 +68,7 @@ export default function NetworkPolicies({ params }: { params: { team: string } }
                       Allowlist
                     </th>
 
-                    <th className="py-3 px-6 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                      Activity
-                    </th>
+                    <th></th>
 
                     <th></th>
 
@@ -92,13 +90,13 @@ export default function NetworkPolicies({ params }: { params: { team: string } }
                         </div>
                       </td>
 
-                      <td className="px-6 py-2 text-neutral-500 text-xs whitespace-nowrap">
-                        <div className="space-y-2">
-                          <div className="flex flex-col">
+                      <td className="px-6 py-2 text-neutral-500 text-xs whitespace-nowrap opacity-0 group-hover:opacity-100 transition ease">
+                        <div className="space-y-1">
+                          <div className="flex items-center gap-1">
                             <div>Updated {relativeTimeFromDates(new Date(policy.updatedAt))}</div>
                             {policy.updatedBy && (
-                              <div className="flex items-center gap-1 mt-1">
-                                <span className="text-neutral-500 w-6">by</span>
+                              <div className="flex items-center gap-1">
+                                <span className="text-neutral-500 w-4">by</span>
                                 <Avatar member={policy.updatedBy} size="sm" />
                                 <span className="font-medium text-zinc-900 dark:text-zinc-100">
                                   {policy.updatedBy?.fullName}
@@ -106,11 +104,11 @@ export default function NetworkPolicies({ params }: { params: { team: string } }
                               </div>
                             )}
                           </div>
-                          <div className="flex flex-col">
+                          <div className="flex items-center gap-1">
                             <div>Created {relativeTimeFromDates(new Date(policy.createdAt))}</div>
                             {policy.createdBy && (
-                              <div className="flex items-center gap-1 mt-1">
-                                <span className="text-neutral-500 w-6">by</span>
+                              <div className="flex items-center gap-1 ">
+                                <span className="text-neutral-500 w-4">by</span>
                                 <Avatar member={policy.createdBy} size="sm" />
                                 <span className="font-medium text-zinc-900 dark:text-zinc-100">
                                   {policy.createdBy?.fullName}


### PR DESCRIPTION
## :mag: Overview

Fixes the layout for network policy created / updated meta 

## :bulb: Proposed Changes

Display meta info inline on hover

## :framed_picture: Screenshots or Demo

![image](https://github.com/user-attachments/assets/f7cdde26-c03a-4ec2-8ce6-ff6fadc2f552)


## :memo: Release Notes

Fixed the layout for network policy created / updated meta 


### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Update migrations (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
