### PR TITLE
feat: updated trial period days on Phase Cloud

### DIFF
--- a/backend/ee/billing/graphene/mutations/stripe.py
+++ b/backend/ee/billing/graphene/mutations/stripe.py
@@ -69,7 +69,7 @@ class CreateSubscriptionCheckoutSession(Mutation):
                 customer=organisation.stripe_customer_id,
                 payment_method_types=["card"],
                 subscription_data={
-                    "trial_period_days": 30,
+                    "trial_period_days": 14,
                 },
                 return_url=f"{settings.OAUTH_REDIRECT_URI}/{organisation.name}/settings?stripe_session_id={{CHECKOUT_SESSION_ID}}",
                 saved_payment_method_options={


### PR DESCRIPTION
## :mag: Overview

The the new standard trial period to 14 days on Phase Cloud self-serve Pro and Enterprise tiers.

## :question: Open Questions

- Do we need any other changes in the frontend? 
- Do we need to change anything in Stripe?

## :sparkles: How to Test the Changes Locally

Run the Phase Console in cloud mode and test the checkout flow via test cards. Observe the trail period, make sure it's 14 days.

### :green_heart: Did You...

- [ ] Ensure linting passes (code style checks)?
- [ ] Update dependencies and lockfiles (if required)
- [ ] Update migrations (if required)
- [ ] Regenerate graphql schema and types (if required)
- [x] Verify the app builds locally?
- [ ] Manually test the changes on different browsers/devices?
