### PR TITLE
fix: misc UI and copy fixes

### DIFF
--- a/frontend/app/[team]/access/network/_components/ManageOrgGlobalPolicies.tsx
+++ b/frontend/app/[team]/access/network/_components/ManageOrgGlobalPolicies.tsx
@@ -166,7 +166,7 @@ export const ManageOrgGlobalPolicies = () => {
             <tbody className="divide-y divide-zinc-500/20">
               {policies.map((policy: NetworkAccessPolicyType) => (
                 <tr key={policy.id} className="group">
-                  <td className="text-zinc-900 dark:text-zinc-100 font-medium break-all inline-flex items-center gap-1">
+                  <td className="text-zinc-900 dark:text-zinc-100 font-medium break-word inline-flex items-center gap-1">
                     {policy.name}
                   </td>
 

--- a/frontend/components/access/UpdateAccountNetworkPolicies.tsx
+++ b/frontend/components/access/UpdateAccountNetworkPolicies.tsx
@@ -107,7 +107,7 @@ export const UpdateAccountNetworkPolicies = ({
     })
 
     closeModal()
-    toast.success('Update network access policy for this account')
+    toast.success('Updated network access policy for this account')
   }
 
   const availablePolicies =
@@ -169,7 +169,7 @@ export const UpdateAccountNetworkPolicies = ({
               <tbody className="divide-y divide-zinc-500/20">
                 {globalPolicies.map((policy: NetworkAccessPolicyType) => (
                   <tr key={policy.id} className="group">
-                    <td className="text-zinc-900 dark:text-zinc-100 font-medium inline-flex items-center gap-1">
+                    <td className="text-zinc-900 dark:text-zinc-100 font-medium inline-flex items-center gap-1 break-word">
                       {policy.name}{' '}
                       {policy.isGlobal && (
                         <FaGlobe title="Global policy" className="text-neutral-500" />
@@ -194,7 +194,7 @@ export const UpdateAccountNetworkPolicies = ({
                 ))}
                 {availablePolicies.map((policy: NetworkAccessPolicyType) => (
                   <tr key={policy.id} className="group">
-                    <td className="text-zinc-900 dark:text-zinc-100 font-medium break-all inline-flex items-center gap-1">
+                    <td className="text-zinc-900 dark:text-zinc-100 font-medium break-word inline-flex items-center gap-1">
                       {policy.name}{' '}
                       {policy.isGlobal && (
                         <FaGlobe title="Global policy" className="text-neutral-500" />

--- a/frontend/components/logs/SecretLogs.tsx
+++ b/frontend/components/logs/SecretLogs.tsx
@@ -320,8 +320,8 @@ export default function SecretLogs(props: { app: string }) {
               className={clsx(
                 'py-4 border-neutral-500/20 transition duration-300 ease-in-out cursor-pointer',
                 open
-                  ? 'bg-neutral-200 dark:bg-neutral-800 border-r'
-                  : 'border-b hover:bg-neutral-200 dark:hover:bg-neutral-800'
+                  ? 'bg-neutral-100 dark:bg-neutral-800 border-r'
+                  : 'border-b hover:bg-neutral-100 dark:hover:bg-neutral-800'
               )}
             >
               <td
@@ -373,7 +373,7 @@ export default function SecretLogs(props: { app: string }) {
               <td colSpan={6}>
                 <Disclosure.Panel
                   className={clsx(
-                    'p-4 w-full space-y-6 bg-neutral-200 dark:bg-neutral-800 border-neutral-500/20 border-l -ml-px',
+                    'p-4 w-full space-y-6 bg-neutral-100 dark:bg-neutral-800 border-neutral-500/20 border-l -ml-px',
                     open
                       ? 'border-b  border-l-emerald-500 border-r shadow-xl'
                       : 'border-l-transparent'
@@ -517,7 +517,7 @@ export default function SecretLogs(props: { app: string }) {
     <>
       {userCanReadLogs ? (
         <div className="w-full text-black dark:text-white flex flex-col">
-          <div className="flex w-full justify-between p-4 sticky top-0 z-5 bg-neutral-300 dark:bg-neutral-900">
+          <div className="flex w-full justify-between p-4 sticky top-0 z-5 bg-neutral-200 dark:bg-neutral-900">
             <span className="text-neutral-500 font-light text-lg">
               {totalCount !== undefined && <Count from={0} to={totalCount} />} Events
             </span>
@@ -828,7 +828,7 @@ export default function SecretLogs(props: { app: string }) {
             </div>
           </div>
           <table className="table-fixed w-full text-left text-sm">
-            <thead className="border-b-2 border-neutral-500/20 sticky top-[58px] z-1 bg-neutral-300/50 dark:bg-neutral-900/60 backdrop-blur-lg shadow-xl">
+            <thead className="border-b-2 border-neutral-500/20 sticky top-[58px] z-1 bg-neutral-200/50 dark:bg-neutral-900/60 backdrop-blur-lg shadow-xl">
               <tr className="text-gray-500 uppercase text-2xs tracking-wider">
                 <th className="w-10"></th>
                 <th className="px-6 py-4">Account</th>

--- a/frontend/ee/billing/UpgradeDialog.tsx
+++ b/frontend/ee/billing/UpgradeDialog.tsx
@@ -268,7 +268,9 @@ const UpgradeDialog = (props: { userCount: number; onSuccess: () => void }) => {
         <div className="flex items-center gap-1 text-emerald-500 font-medium pt-4 justify-end">
           <Button variant="primary" onClick={handleCheckout}>
             <FaCartShopping />{' '}
-            {activeOrganisation?.plan === ApiOrganisationPlanChoices.Pr ? 'Upgrade' : 'Checkout'}
+            {activeOrganisation?.plan === ApiOrganisationPlanChoices.Pr
+              ? 'Upgrade'
+              : 'Start 14-day trial'}
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## :mag: Overview

Misc UI and copy fixes

## :bulb: Proposed Changes

* Fixed text wrapping and toast copy in the Account Network Access Policy dialog
* Fixed text wrapping in the Global Network Access Policy dialog
* Improved the light theme colors in the logs table
* Updated the button CTA for starting a trial in cloud mode

## :framed_picture: Screenshots or Demo

### Logs Before
![Screenshot From 2025-05-08 14-39-00](https://github.com/user-attachments/assets/991b9984-607b-4191-9e5d-ac53710c8bcd)

### Logs After
![Screenshot From 2025-05-08 14-43-16](https://github.com/user-attachments/assets/8efd62df-c66e-4f71-8227-3a9aeab69cbd)

## :memo: Release Notes

Misc copy and UI polish to logs and network access policy screens

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Update migrations (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
