### PR TITLE
feat: warn when leaving page with unsaved secret changes

### DIFF
--- a/frontend/app/[team]/apps/[app]/_components/AppSecrets.tsx
+++ b/frontend/app/[team]/apps/[app]/_components/AppSecrets.tsx
@@ -54,6 +54,7 @@ import { formatTitle } from '@/utils/meta'
 import MultiEnvImportDialog from '@/components/environments/secrets/import/MultiEnvImportDialog'
 import { TbDownload } from 'react-icons/tb'
 import { duplicateKeysExist } from '@/utils/secrets'
+import { useWarnIfUnsavedChanges } from '@/hooks/warnUnsavedChanges'
 
 export const AppSecrets = ({ team, app }: { team: string; app: string }) => {
   const { activeOrganisation: organisation } = useContext(organisationContext)
@@ -151,6 +152,8 @@ export const AppSecrets = ({ team, app }: { team: string; app: string }) => {
         normalizeValues(clientSecret.envs.map((env) => env.secret?.value))
       )
     })
+
+  useWarnIfUnsavedChanges(unsavedChanges)
 
   const { appEnvironments, appSecrets, appFolders, fetching, refetch } = useAppSecrets(
     app,

--- a/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
+++ b/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
@@ -63,6 +63,7 @@ import { userHasPermission } from '@/utils/access/permissions'
 import Spinner from '@/components/common/Spinner'
 import EnvFileDropZone from '@/components/environments/secrets/import/EnvFileDropZone'
 import SingleEnvImportDialog from '@/components/environments/secrets/import/SingleEnvImportDialog'
+import { useWarnIfUnsavedChanges } from '@/hooks/warnUnsavedChanges'
 
 export default function EnvironmentPath({
   params,
@@ -152,6 +153,8 @@ export default function EnvironmentPath({
         secret.value !== updatedSecret.value
       )
     })
+
+  useWarnIfUnsavedChanges(unsavedChanges)
 
   const { data: appEnvsData } = useQuery(GetAppEnvironments, {
     variables: {

--- a/frontend/hooks/warnUnsavedChanges.ts
+++ b/frontend/hooks/warnUnsavedChanges.ts
@@ -1,0 +1,67 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useTopLoader } from 'nextjs-toploader'
+
+export function useWarnIfUnsavedChanges(unsaved: boolean) {
+  const loader = useTopLoader()
+
+  const CONFIRM_MESSAGE =
+    'You have made changes that have not been deployed yet. Are you sure you want to leave?'
+
+  // Prevent tab close or reload
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (!unsaved) return
+      e.preventDefault()
+      e.returnValue = ''
+      loader.done(true)
+    }
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [unsaved, loader])
+
+  // Prevent back/forward nav
+  useEffect(() => {
+    if (!unsaved) return
+
+    const handlePopState = (e: PopStateEvent) => {
+      const confirmLeave = confirm(CONFIRM_MESSAGE)
+      if (!confirmLeave) {
+        history.pushState(null, '', window.location.href)
+        loader.done(true)
+      }
+    }
+
+    window.addEventListener('popstate', handlePopState)
+    return () => window.removeEventListener('popstate', handlePopState)
+  }, [unsaved, loader])
+
+  // Intercept <Link> clicks (and any <a> with href)
+  useEffect(() => {
+    if (!unsaved) return
+
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as HTMLElement
+      const anchor = target.closest('a[href]') as HTMLAnchorElement | null
+      if (!anchor || anchor.target === '_blank' || anchor.hasAttribute('download')) return
+
+      const href = anchor.href
+      const current = window.location.href
+
+      // Internal navigation only
+      const isInternal = href.startsWith(location.origin) && href !== current
+      if (!isInternal) return
+
+      const confirmed = confirm(CONFIRM_MESSAGE)
+      if (!confirmed) {
+        e.preventDefault()
+        e.stopImmediatePropagation()
+        loader.done(true)
+      }
+    }
+
+    document.addEventListener('click', handleClick, true)
+    return () => document.removeEventListener('click', handleClick, true)
+  }, [unsaved, loader])
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
     "lodash": "^4.17.21",
     "next": "^14.2.25",
     "next-auth": "^4.24.5",
-    "nextjs-toploader": "^1.6.4",
+    "nextjs-toploader": "^3.8.16",
     "npm": "^10.4.0",
     "posthog-js": "^1.198.0",
     "react": "^18.2.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2329,11 +2329,6 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/nprogress@^0.2.1":
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/@types/nprogress/-/nprogress-0.2.3.tgz#b2150b054a13622fabcba12cf6f0b54c48b14287"
-  integrity sha512-k7kRA033QNtC+gLc4VPlfnue58CM1iQLgn1IMAU8VPHGOj7oIHPp9UlhedEnD/Gl8evoCjwkZjlBORtZ3JByUA==
-
 "@types/prop-types@*":
   version "15.7.5"
   resolved "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz"
@@ -7102,12 +7097,11 @@ next@^14.2.25:
     "@next/swc-win32-ia32-msvc" "14.2.25"
     "@next/swc-win32-x64-msvc" "14.2.25"
 
-nextjs-toploader@^1.6.4:
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/nextjs-toploader/-/nextjs-toploader-1.6.4.tgz#1a498fc8c9b073d937fb932382aeb5bb1d007339"
-  integrity sha512-KYLQ+0MvGdFk9JwOQfRtaYBAsyuX67Ca5QTa51RGNO4gQx64KLSE+ryHjUQ5LcDczHotp0l32GgksQW9vucUkw==
+nextjs-toploader@^3.8.16:
+  version "3.8.16"
+  resolved "https://registry.yarnpkg.com/nextjs-toploader/-/nextjs-toploader-3.8.16.tgz#6405116ffdd652ecc049f3a3f672bf7e8f5feef8"
+  integrity sha512-xiejFF9OQD8ovvHfrFhnEmRytvZtwIOY/mMtI9punOAACXpYpgC0y1afJ4DSIEmUi4Syy9A5BsFpUORTJ9z8Ng==
   dependencies:
-    "@types/nprogress" "^0.2.1"
     nprogress "^0.2.0"
     prop-types "^15.8.1"
 


### PR DESCRIPTION
## :mag: Overview

It is possible to make changes to secrets and navigate way from the page before they are deployed, which loses the state of the editor. 

## :bulb: Proposed Changes

Warn the user when attempting to leave the page with unsaved changes to secrets, using `window.confirm()`

## :framed_picture: Screenshots or Demo

https://github.com/user-attachments/assets/b75ddd46-ff62-4601-8207-bf99e64aab3b

## :memo: Release Notes

Added a warning and confirmation when leaving the app / env secrets page with unsaved changes

### :heavy_plus_sign: Additional Context

This currently does not work with the browser "Back" and "Forward" buttons

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
- [x] Update dependencies and lockfiles (if required)
~~- [ ] Update migrations (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
