### PR TITLE
feat: show license expiry date

### DIFF
--- a/frontend/ee/billing/License.tsx
+++ b/frontend/ee/billing/License.tsx
@@ -43,7 +43,9 @@ export const License = (props: {
         {showExpiry && (
           <div className={clsx('text-xs', isExpired() && 'text-red-400')}>
             {isExpired() ? 'Expired' : 'Expires'}{' '}
-            {relativeTimeFromDates(new Date(license.expiresAt))}
+            <span title={new Date(license.expiresAt).toString()}>
+              {relativeTimeFromDates(new Date(license.expiresAt))}
+            </span>
           </div>
         )}
       </div>


### PR DESCRIPTION
## :mag: Overview

This PR introduces a small quality of life improvement which allows the user to see the date and time at which their Phase License is going to expire or has expired with a on hover action.

## :framed_picture: Screenshots or Demo

![image](https://github.com/user-attachments/assets/c13a2b7b-d918-439b-a3bf-9594ba4bde51)

### :green_heart: Did You...

- [ ] Ensure linting passes (code style checks)?
- [ ] Update dependencies and lockfiles (if required)
- [ ] Update migrations (if required)
- [ ] Regenerate graphql schema and types (if required)
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
