### PR TITLE
fix: handle missing environment variables for GitHub Enterprise URLs

### DIFF
--- a/backend/ee/authentication/sso/oauth/github_enterprise/views.py
+++ b/backend/ee/authentication/sso/oauth/github_enterprise/views.py
@@ -19,8 +19,8 @@ class GitHubEnterpriseOAuth2Adapter(GitHubOAuth2Adapter):
     provider_id = GitHubProvider.id
     settings = app_settings.PROVIDERS.get(provider_id, {})
 
-    web_url = os.getenv("GITHUB_ENTERPRISE_BASE_URL").rstrip("/")
-    api_url = f"{os.getenv("GITHUB_ENTERPRISE_API_URL").rstrip("/")}/v3"
+    web_url = os.getenv("GITHUB_ENTERPRISE_BASE_URL", "").rstrip("/")
+    api_url = f"{os.getenv("GITHUB_ENTERPRISE_API_URL", "").rstrip("/")}/v3"
 
     access_token_url = f"{web_url}/login/oauth/access_token"
     authorize_url = f"{web_url}/login/oauth/authorize"


### PR DESCRIPTION
## :mag: Overview

Fall back to safe values for GitHub Enterprise OAuth configuration environment values so rstrip doesn't throw an exception. 

### :green_heart: Did You...

- [ ] Ensure linting passes (code style checks)?
- [ ] Update dependencies and lockfiles (if required)
- [ ] Update migrations (if required)
- [ ] Regenerate graphql schema and types (if required)
- [x] Verify the app builds locally?
- [ ] Manually test the changes on different browsers/devices?
