### PR TITLE
fix: log secret key and environment for failed local references

### DIFF
--- a/backend/api/utils/secrets.py
+++ b/backend/api/utils/secrets.py
@@ -377,7 +377,7 @@ def decrypt_secret_value(secret, require_resolved_references=False, account=None
             )
         except:
             unresolved_local_references.append(
-                f"The referenced environment or key either does not exist or the server does not have access to it."
+                f"The referenced key {ref_key} does not exist in the {secret.environment.name} environment."
             )
 
     if require_resolved_references and unresolved_local_references:

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1448,7 +1448,7 @@
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
   integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
 
-"@headlessui/react@^1.7.23":
+"@headlessui/react@^1.7.19":
   version "1.7.19"
   resolved "https://registry.yarnpkg.com/@headlessui/react/-/react-1.7.19.tgz#91c78cf5fcb254f4a0ebe96936d48421caf75f40"
   integrity sha512-Ll+8q3OlMJfJbAKM/+/Y2q6PPYbryqNTXDbryx7SXLIDamkF6iQFbriYHga0dY44PvDhvvBWCx1Xj4U5+G4hOw==


### PR DESCRIPTION
## :mag: Overview

When local secret references fail to resolve, the error message in sync logs is ambiguous and makes it difficult to determine which secret could not be referenced. 

## :bulb: Proposed Changes

Add the secret key and environment in the error message when a local reference cannot be resolved.

## :framed_picture: Screenshots or Demo

![image](https://github.com/user-attachments/assets/bbdef84e-adf3-4eda-b635-277d06287c5a)

## :memo: Release Notes

Adds the secret key and environment name in sync error logs when a local reference cannot be resolved.

### :dart: Reviewer Focus

Check that the referenced app, env and key are included in failed sync error logs for:
- Cross app references with the wrong app name
- Cross app references with the wrong env name
- Cross app references with the wrong secret key
- Cross env references with the wrong env name
- Cross env references with the wrong secret key
- Local references with the wrong secret key

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
- [x] Update dependencies and lockfiles (if required)
~~- [ ] Update migrations (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [ ] Manually test the changes on different browsers/devices?
