### PR TITLE
fix: remove duplicate AWS credential provider from integrations 

### DIFF
--- a/frontend/app/[team]/integrations/credentials/page.tsx
+++ b/frontend/app/[team]/integrations/credentials/page.tsx
@@ -122,15 +122,17 @@ export default function Integrations({ params }: { params: { team: string } }) {
                 {noCredentials ? (
                   <div className="">
                     <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 xl:max-w-none xl:grid-cols-4">
-                      {providers.map((provider: ProviderType) => (
-                        <button
-                          key={provider.id}
-                          type="button"
-                          onClick={() => setProvider(provider)}
-                        >
-                          <ProviderCard provider={provider} />
-                        </button>
-                      ))}
+                      {providers
+                        .filter((provider: ProviderType) => provider.id !== 'aws_assume_role')
+                        .map((provider: ProviderType) => (
+                          <button
+                            key={provider.id}
+                            type="button"
+                            onClick={() => setProvider(provider)}
+                          >
+                            <ProviderCard provider={provider} />
+                          </button>
+                        ))}
                     </div>
                   </div>
                 ) : (


### PR DESCRIPTION
## :mag: Overview

Fixed a small bug where duplicate credential provider for AWS integration would appear as 'AWS Assume Role' in the empty state. This would not break anything in particular, but potentially cause some confusion. Given we are handling multiple authentication types in the AWS provider itself, we can simply filter out the Assume Role provider id for now.

## :bulb: Proposed Changes

*Detail the proposed changes, including new features, bug fixes, or improvements. Explain how these changes impact the project, including any internal structure alterations or refactorings.*

## :framed_picture: Screenshots or Demo

Before the fix:

![image](https://github.com/user-attachments/assets/3b8bc331-de5f-4641-aaf9-48440f50c48c)

After the fix:

![image](https://github.com/user-attachments/assets/c4cc69ed-6bab-4974-b977-b9173aea75e4)
