### PR TITLE
fix: correctly set component state when preselecting account

### DIFF
--- a/frontend/app/[team]/apps/[app]/access/service-accounts/_components/AddAccountDialog.tsx
+++ b/frontend/app/[team]/apps/[app]/access/service-accounts/_components/AddAccountDialog.tsx
@@ -140,11 +140,16 @@ export const AddAccountDialog = ({ appId }: { appId: string }) => {
         return
       }
 
-      const preselectedAccount = serviceAccountsData.serviceAccounts.find(
+      const preselectedAccount: ServiceAccountType = serviceAccountsData.serviceAccounts.find(
         (account: ServiceAccountType) => account.id === preselectedAccountId
       )
       if (preselectedAccount) {
-        setSelectedAccounts(preselectedAccount)
+        setSelectedAccounts([
+          {
+            ...preselectedAccount,
+            scope: [],
+          },
+        ])
         openModal()
       }
     }


### PR DESCRIPTION
## :mag: Overview

Fixes #590 

## :bulb: Proposed Changes

Correctly set the component `selectedAccounts` state when an account is pre-selected via the 'new' searchParam

## :framed_picture: Screenshots or Demo

https://github.com/user-attachments/assets/a31482d4-1e90-4f56-b4c8-6d8ca18c74ed


## :memo: Release Notes

Fixed a bug that caused an error when trying to add a Service Account to an app via the "Add App" button on the account page

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Update migrations (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
