### PR TITLE
fix: remove ad-hoc styles on delete service account button

### DIFF
--- a/frontend/app/[team]/access/service-accounts/[account]/_components/DeleteServiceAccountTokenDialog.tsx
+++ b/frontend/app/[team]/access/service-accounts/[account]/_components/DeleteServiceAccountTokenDialog.tsx
@@ -60,7 +60,7 @@ export const DeleteServiceAccountTokenDialog = ({
       <div className="space-y-4">
         <div className="text-neutral-500 py-4">Are you sure you want to delete this token?</div>
         <div className="flex justify-end">
-          <Button variant="danger" onClick={handleDelete} isLoading={loading} className="flex items-center gap-1">
+          <Button variant="danger" onClick={handleDelete} isLoading={loading}>
             <FaTrashAlt /> Delete
           </Button>
         </div>

--- a/frontend/app/[team]/access/service-accounts/_components/DeleteServiceAccountDialog.tsx
+++ b/frontend/app/[team]/access/service-accounts/_components/DeleteServiceAccountDialog.tsx
@@ -52,7 +52,7 @@ export const DeleteServiceAccountDialog = ({ account }: { account: ServiceAccoun
           associated with this account.
         </div>
         <div className="flex justify-end">
-          <Button variant="danger" onClick={handleDelete} className="flex items-center gap-1">
+          <Button variant="danger" onClick={handleDelete}>
             <FaTrashAlt /> Delete
           </Button>
         </div>


### PR DESCRIPTION
## :mag: Overview

Fixes the button style on the "Delete service account" dialog


### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Update migrations (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [ ] Verify the app builds locally?
- [ ] Manually test the changes on different browsers/devices?
