### PR TITLE
fix: combobox styles

### DIFF
--- a/frontend/components/syncing/AWS/AWSRegionPicker.tsx
+++ b/frontend/components/syncing/AWS/AWSRegionPicker.tsx
@@ -8,7 +8,7 @@ export const AWSRegionPicker = (props: { onChange: (region: string) => void; val
   const { onChange, value } = props
 
   const [region, setRegion] = useState<AwsRegion>(
-    value ? awsRegions.find(r => r.region === value) || awsRegions[0] : awsRegions[0]
+    value ? awsRegions.find((r) => r.region === value) || awsRegions[0] : awsRegions[0]
   )
   const [query, setQuery] = useState('')
 
@@ -27,7 +27,7 @@ export const AWSRegionPicker = (props: { onChange: (region: string) => void; val
   return (
     <div className="space-y-2">
       <div className="relative">
-        <Combobox value={region} onChange={handleSetRegion}>
+        <Combobox as="div" value={region} onChange={handleSetRegion}>
           {({ open }) => (
             <>
               <div className="space-y-2">
@@ -64,13 +64,13 @@ export const AWSRegionPicker = (props: { onChange: (region: string) => void; val
                 leaveTo="transform scale-95 opacity-0"
               >
                 <Combobox.Options as={Fragment}>
-                  <div className="bg-zinc-300 dark:bg-zinc-800 p-2 rounded-md shadow-2xl z-20 absolute max-h-80 overflow-y-auto">
+                  <div className="bg-zinc-300 dark:bg-zinc-800 rounded-b-md shadow-2xl z-20 absolute max-h-80 overflow-y-auto w-full border border-t-none border-neutral-500/20 divide-y divide-neutral-500/20">
                     {filteredRegions.map((region: AwsRegion) => (
-                      <Combobox.Option key={region.region} value={region}>
+                      <Combobox.Option as="div" key={region.region} value={region}>
                         {({ active, selected }) => (
                           <div
                             className={clsx(
-                              'flex flex-col gap-1 p-2 cursor-pointer rounded-md w-full',
+                              'flex flex-col p-2 cursor-pointer rounded-md w-full',
                               active && 'bg-zinc-400 dark:bg-zinc-700'
                             )}
                           >

--- a/frontend/components/syncing/AWS/CreateAWSSecretsSync.tsx
+++ b/frontend/components/syncing/AWS/CreateAWSSecretsSync.tsx
@@ -156,9 +156,7 @@ export const CreateAWSSecretsSync = (props: { appId: string; closeModal: () => v
             <div className="space-y-4">
               <RadioGroup value={phaseEnv} onChange={setPhaseEnv}>
                 <RadioGroup.Label as={Fragment}>
-                  <label className="block text-gray-700 text-sm font-bold mb-2">
-                    Phase Environment
-                  </label>
+                  <label className="block text-neutral-500 text-sm mb-2">Phase Environment</label>
                 </RadioGroup.Label>
                 <div className="flex flex-wrap items-center gap-2">
                   {appEnvsData.appEnvironments.map((env: EnvironmentType) => (

--- a/frontend/components/syncing/Cloudflare/CreateCloudflarePagesSync.tsx
+++ b/frontend/components/syncing/Cloudflare/CreateCloudflarePagesSync.tsx
@@ -140,9 +140,7 @@ export const CreateCloudflarePagesSync = (props: { appId: string; closeModal: ()
             <div className="space-y-4">
               <RadioGroup value={phaseEnv} onChange={setPhaseEnv}>
                 <RadioGroup.Label as={Fragment}>
-                  <label className="block text-gray-700 text-sm font-bold mb-2">
-                    Phase Environment
-                  </label>
+                  <label className="block text-neutral-500 text-sm mb-2">Phase Environment</label>
                 </RadioGroup.Label>
                 <div className="flex flex-wrap items-center gap-2">
                   {appEnvsData.appEnvironments.map((env: EnvironmentType) => (
@@ -175,7 +173,7 @@ export const CreateCloudflarePagesSync = (props: { appId: string; closeModal: ()
 
             <div className="grid grid-cols-2 gap-8">
               <div className="relative">
-                <Combobox value={cfProject} onChange={setCfProject}>
+                <Combobox as="div" value={cfProject} onChange={setCfProject}>
                   {({ open }) => (
                     <>
                       <div className="space-y-2">
@@ -212,9 +210,9 @@ export const CreateCloudflarePagesSync = (props: { appId: string; closeModal: ()
                         leaveTo="transform scale-95 opacity-0"
                       >
                         <Combobox.Options as={Fragment}>
-                          <div className="bg-zinc-300 dark:bg-zinc-800 p-2 rounded-md shadow-2xl z-20 absolute max-h-80 overflow-y-auto">
+                          <div className="bg-zinc-300 dark:bg-zinc-800 p-2 rounded-b-md shadow-2xl z-20 absolute max-h-80 overflow-y-auto border border-t-none border-neutral-500/20 divide-y divide-neutral-500/20">
                             {filteredProjects.map((project: CloudFlarePagesType) => (
-                              <Combobox.Option key={project.deploymentId} value={project}>
+                              <Combobox.Option as="div" key={project.deploymentId} value={project}>
                                 {({ active, selected }) => (
                                   <div
                                     className={clsx(
@@ -243,7 +241,7 @@ export const CreateCloudflarePagesSync = (props: { appId: string; closeModal: ()
               <div>
                 <RadioGroup value={cfEnv} onChange={setCfEnv}>
                   <RadioGroup.Label as={Fragment}>
-                    <label className="block text-gray-700 text-sm font-bold mb-2">
+                    <label className="block text-neutral-500 text-sm mb-2">
                       Cloudflare Project Environment
                     </label>
                   </RadioGroup.Label>

--- a/frontend/components/syncing/Cloudflare/CreateCloudflarePagesSync.tsx
+++ b/frontend/components/syncing/Cloudflare/CreateCloudflarePagesSync.tsx
@@ -210,7 +210,7 @@ export const CreateCloudflarePagesSync = (props: { appId: string; closeModal: ()
                         leaveTo="transform scale-95 opacity-0"
                       >
                         <Combobox.Options as={Fragment}>
-                          <div className="bg-zinc-300 dark:bg-zinc-800 p-2 rounded-b-md shadow-2xl z-20 absolute max-h-80 overflow-y-auto border border-t-none border-neutral-500/20 divide-y divide-neutral-500/20">
+                          <div className="bg-zinc-300 dark:bg-zinc-800 p-2 rounded-b-md shadow-2xl z-20 absolute max-h-80 overflow-y-auto border w-full border-t-none border-neutral-500/20 divide-y divide-neutral-500/20">
                             {filteredProjects.map((project: CloudFlarePagesType) => (
                               <Combobox.Option as="div" key={project.deploymentId} value={project}>
                                 {({ active, selected }) => (

--- a/frontend/components/syncing/Cloudflare/CreateCloudflareWorkersSync.tsx
+++ b/frontend/components/syncing/Cloudflare/CreateCloudflareWorkersSync.tsx
@@ -202,7 +202,7 @@ export const CreateCloudflareWorkersSync = (props: { appId: string; closeModal: 
                         leaveTo="transform scale-95 opacity-0"
                       >
                         <Combobox.Options as={Fragment}>
-                          <div className="bg-zinc-300 dark:bg-zinc-800 p-2 rounded-b-md shadow-2xl z-20 absolute max-h-80 overflow-y-auto border border-t-none border-neutral-500/20 divide-y divide-neutral-500/20">
+                          <div className="bg-zinc-300 dark:bg-zinc-800 p-2 rounded-b-md shadow-2xl z-20 absolute max-h-80 overflow-y-auto w-full border border-t-none border-neutral-500/20 divide-y divide-neutral-500/20">
                             {filteredWorkers.map((worker: CloudflareWorkerType) => (
                               <Combobox.Option as="div" key={worker.scriptId} value={worker}>
                                 {({ active, selected }) => (

--- a/frontend/components/syncing/Cloudflare/CreateCloudflareWorkersSync.tsx
+++ b/frontend/components/syncing/Cloudflare/CreateCloudflareWorkersSync.tsx
@@ -132,9 +132,7 @@ export const CreateCloudflareWorkersSync = (props: { appId: string; closeModal: 
             <div className="space-y-4">
               <RadioGroup value={phaseEnv} onChange={setPhaseEnv}>
                 <RadioGroup.Label as={Fragment}>
-                  <label className="block text-gray-700 text-sm font-bold mb-2">
-                    Phase Environment
-                  </label>
+                  <label className="block text-neutral-500 text-sm mb-2">Phase Environment</label>
                 </RadioGroup.Label>
                 <div className="flex flex-wrap items-center gap-2">
                   {appEnvsData?.appEnvironments.map((env: EnvironmentType) => (
@@ -167,12 +165,12 @@ export const CreateCloudflareWorkersSync = (props: { appId: string; closeModal: 
 
             <div className="space-y-4">
               <div className="relative">
-                <Combobox value={cfWorker} onChange={setCfWorker}>
+                <Combobox as="div" value={cfWorker} onChange={setCfWorker}>
                   {({ open }) => (
                     <>
                       <div className="space-y-2">
                         <Combobox.Label as={Fragment}>
-                          <label className="block text-gray-700 text-sm font-bold" htmlFor="name">
+                          <label className="block text-neutral-500 text-sm" htmlFor="name">
                             Cloudflare Worker
                           </label>
                         </Combobox.Label>
@@ -204,9 +202,9 @@ export const CreateCloudflareWorkersSync = (props: { appId: string; closeModal: 
                         leaveTo="transform scale-95 opacity-0"
                       >
                         <Combobox.Options as={Fragment}>
-                          <div className="bg-zinc-300 dark:bg-zinc-800 p-2 rounded-md shadow-2xl z-20 absolute max-h-80 overflow-y-auto">
+                          <div className="bg-zinc-300 dark:bg-zinc-800 p-2 rounded-b-md shadow-2xl z-20 absolute max-h-80 overflow-y-auto border border-t-none border-neutral-500/20 divide-y divide-neutral-500/20">
                             {filteredWorkers.map((worker: CloudflareWorkerType) => (
-                              <Combobox.Option key={worker.scriptId} value={worker}>
+                              <Combobox.Option as="div" key={worker.scriptId} value={worker}>
                                 {({ active, selected }) => (
                                   <div
                                     className={clsx(
@@ -249,4 +247,4 @@ export const CreateCloudflareWorkersSync = (props: { appId: string; closeModal: 
       </form>
     </div>
   )
-} 
+}

--- a/frontend/components/syncing/GitHub/CreateGhActionsSync.tsx
+++ b/frontend/components/syncing/GitHub/CreateGhActionsSync.tsx
@@ -153,9 +153,7 @@ export const CreateGhActionsSync = (props: { appId: string; closeModal: () => vo
             <div className="space-y-4">
               <RadioGroup value={phaseEnv} onChange={setPhaseEnv}>
                 <RadioGroup.Label as={Fragment}>
-                  <label className="block text-gray-700 text-sm font-bold mb-2">
-                    Phase Environment
-                  </label>
+                  <label className="block text-neutral-500 text-sm mb-2">Phase Environment</label>
                 </RadioGroup.Label>
                 <div className="flex flex-wrap items-center gap-2">
                   {appEnvsData.appEnvironments.map((env: EnvironmentType) => (
@@ -188,12 +186,12 @@ export const CreateGhActionsSync = (props: { appId: string; closeModal: () => vo
 
             <div className="grid grid-cols-2 gap-8">
               <div className="relative col-span-2">
-                <Combobox value={selectedRepo} onChange={setSelectedRepo}>
+                <Combobox as="div" value={selectedRepo} onChange={setSelectedRepo}>
                   {({ open }) => (
                     <>
                       <div className="space-y-2">
                         <Combobox.Label as={Fragment}>
-                          <label className="block text-gray-700 text-sm font-bold" htmlFor="name">
+                          <label className="block text-neutral-500 text-sm" htmlFor="name">
                             GitHub Repo
                           </label>
                         </Combobox.Label>
@@ -227,9 +225,13 @@ export const CreateGhActionsSync = (props: { appId: string; closeModal: () => vo
                         leaveTo="transform scale-95 opacity-0"
                       >
                         <Combobox.Options as={Fragment}>
-                          <div className="bg-zinc-200 dark:bg-zinc-800 p-2 rounded-md shadow-2xl z-20 absolute max-h-96 overflow-y-auto">
+                          <div className="bg-zinc-200 dark:bg-zinc-800 p-2 rounded-b-md shadow-2xl z-20 absolute max-h-96 overflow-y-auto w-full border border-t-none border-neutral-500/20">
                             {filteredRepos.map((repo: GitHubRepoType) => (
-                              <Combobox.Option key={`${repo.owner}/${repo.name}`} value={repo}>
+                              <Combobox.Option
+                                as="div"
+                                key={`${repo.owner}/${repo.name}`}
+                                value={repo}
+                              >
                                 {({ active, selected }) => (
                                   <div
                                     className={clsx(

--- a/frontend/components/syncing/GitLab/CreateGitLabCISync.tsx
+++ b/frontend/components/syncing/GitLab/CreateGitLabCISync.tsx
@@ -187,9 +187,7 @@ export const CreateGitLabCISync = (props: { appId: string; closeModal: () => voi
             <div className="space-y-4">
               <RadioGroup value={phaseEnv} onChange={setPhaseEnv}>
                 <RadioGroup.Label as={Fragment}>
-                  <label className="block text-gray-700 text-sm font-bold mb-2">
-                    Phase Environment
-                  </label>
+                  <label className="block text-neutral-500 text-sm mb-2">Phase Environment</label>
                 </RadioGroup.Label>
                 <div className="flex flex-wrap items-center gap-2">
                   {appEnvsData.appEnvironments.map((env: EnvironmentType) => (
@@ -258,13 +256,13 @@ export const CreateGitLabCISync = (props: { appId: string; closeModal: () => voi
                   </Tab.List>
                   <Tab.Panels className="py-4">
                     <Tab.Panel>
-                      <Combobox value={selectedProject} onChange={setSelectedProject}>
+                      <Combobox as="div" value={selectedProject} onChange={setSelectedProject}>
                         {({ open }) => (
                           <>
                             <div className="space-y-2">
                               <Combobox.Label as={Fragment}>
                                 <label
-                                  className="block text-gray-700 text-sm font-bold"
+                                  className="block text-neutral-500 text-sm font-bold"
                                   htmlFor="name"
                                 >
                                   GitLab Project
@@ -302,9 +300,10 @@ export const CreateGitLabCISync = (props: { appId: string; closeModal: () => voi
                               leaveTo="transform scale-95 opacity-0"
                             >
                               <Combobox.Options as={Fragment}>
-                                <div className="bg-zinc-200 dark:bg-zinc-800 p-2 rounded-md shadow-2xl z-20 absolute max-h-96 w-full overflow-y-auto">
+                                <div className="bg-zinc-200 dark:bg-zinc-800 p-2 rounded-b-md shadow-2xl z-20 absolute max-h-96 w-full overflow-y-auto border border-t-none border-neutral-500/20 divide-y divide-neutral-500/20">
                                   {filteredProjects.map((project: GitLabProjectType) => (
                                     <Combobox.Option
+                                      as="div"
                                       key={`${project.namespace?.fullPath}/${project.name}`}
                                       value={project}
                                     >
@@ -346,10 +345,7 @@ export const CreateGitLabCISync = (props: { appId: string; closeModal: () => voi
                           <>
                             <div className="space-y-2">
                               <Combobox.Label as={Fragment}>
-                                <label
-                                  className="block text-gray-700 text-sm font-bold"
-                                  htmlFor="name"
-                                >
+                                <label className="block text-neutral-500 text-sm" htmlFor="name">
                                   GitLab Group
                                 </label>
                               </Combobox.Label>

--- a/frontend/components/syncing/Railway/CreateRailwaySync.tsx
+++ b/frontend/components/syncing/Railway/CreateRailwaySync.tsx
@@ -163,9 +163,7 @@ export const CreateRailwaySync = (props: { appId: string; closeModal: () => void
             <div className="space-y-4">
               <RadioGroup value={phaseEnv} onChange={setPhaseEnv}>
                 <RadioGroup.Label as={Fragment}>
-                  <label className="block text-gray-700 text-sm font-bold mb-2">
-                    Phase Environment
-                  </label>
+                  <label className="block text-neutral-500 text-sm mb-2">Phase Environment</label>
                 </RadioGroup.Label>
                 <div className="flex flex-wrap items-center gap-2">
                   {appEnvsData.appEnvironments.map((env: EnvironmentType) => (
@@ -198,12 +196,12 @@ export const CreateRailwaySync = (props: { appId: string; closeModal: () => void
 
             <div className="grid grid-cols-2 gap-8">
               <div className="relative col-span-2">
-                <Combobox value={railwayProject} onChange={setRailwayProject}>
+                <Combobox as="div" value={railwayProject} onChange={setRailwayProject}>
                   {({ open }) => (
                     <>
                       <div className="space-y-2">
                         <Combobox.Label as={Fragment}>
-                          <label className="block text-gray-700 text-sm font-bold" htmlFor="name">
+                          <label className="block text-neutral-500 text-sm" htmlFor="name">
                             Railway Project <span className="text-red-500">*</span>
                           </label>
                         </Combobox.Label>
@@ -235,9 +233,9 @@ export const CreateRailwaySync = (props: { appId: string; closeModal: () => void
                         leaveTo="transform scale-95 opacity-0"
                       >
                         <Combobox.Options as={Fragment}>
-                          <div className="bg-zinc-300 dark:bg-zinc-800 p-2 rounded-md shadow-2xl z-20 absolute max-h-80 overflow-y-auto w-full">
+                          <div className="bg-zinc-300 dark:bg-zinc-800 p-2 rounded-b-md shadow-2xl z-20 absolute max-h-80 overflow-y-auto w-full border border-t-none border-neutral-500/20 divide-y divide-neutral-500/20">
                             {filteredProjects.map((project: RailwayProjectType) => (
-                              <Combobox.Option key={project.id} value={project}>
+                              <Combobox.Option as="div" key={project.id} value={project}>
                                 {({ active, selected }) => (
                                   <div
                                     className={clsx(
@@ -268,7 +266,7 @@ export const CreateRailwaySync = (props: { appId: string; closeModal: () => void
                     onChange={setRailwayEnvironment}
                   >
                     <RadioGroup.Label as={Fragment}>
-                      <label className="block text-gray-700 text-sm font-bold mb-2">
+                      <label className="block text-neutral-500 text-sm font-bold mb-2">
                         Project Environment <span className="text-red-500">*</span>
                       </label>
                     </RadioGroup.Label>
@@ -305,7 +303,10 @@ export const CreateRailwaySync = (props: { appId: string; closeModal: () => void
                       <>
                         <div className="space-y-2">
                           <Combobox.Label as={Fragment}>
-                            <label className="block text-gray-700 text-sm font-bold" htmlFor="name">
+                            <label
+                              className="block text-neutral-500 text-sm font-bold"
+                              htmlFor="name"
+                            >
                               Railway Service (Optional)
                             </label>
                           </Combobox.Label>

--- a/frontend/components/syncing/Vercel/CreateVercelSync.tsx
+++ b/frontend/components/syncing/Vercel/CreateVercelSync.tsx
@@ -171,9 +171,7 @@ export const CreateVercelSync = (props: { appId: string; closeModal: () => void 
             <div className="space-y-4">
               <RadioGroup value={phaseEnv} onChange={setPhaseEnv}>
                 <RadioGroup.Label as={Fragment}>
-                  <label className="block text-gray-700 text-sm font-bold mb-2">
-                    Phase Environment
-                  </label>
+                  <label className="block text-neutral-500 text-sm mb-2">Phase Environment</label>
                 </RadioGroup.Label>
                 <div className="flex flex-wrap items-center gap-2">
                   {appEnvsData.appEnvironments.map((env: EnvironmentType) => (
@@ -206,12 +204,12 @@ export const CreateVercelSync = (props: { appId: string; closeModal: () => void 
 
             <div className="grid grid-cols-2 gap-8">
               <div className="relative">
-                <Combobox value={vercelTeam} onChange={setVercelTeam}>
+                <Combobox as="div" value={vercelTeam} onChange={setVercelTeam}>
                   {({ open }) => (
                     <>
                       <div className="space-y-2">
                         <Combobox.Label as={Fragment}>
-                          <label className="block text-gray-700 text-sm font-bold">
+                          <label className="block text-neutral-500 text-sm">
                             Vercel Team <span className="text-red-500">*</span>
                           </label>
                         </Combobox.Label>
@@ -243,9 +241,9 @@ export const CreateVercelSync = (props: { appId: string; closeModal: () => void 
                         leaveTo="transform scale-95 opacity-0"
                       >
                         <Combobox.Options as={Fragment}>
-                          <div className="bg-zinc-300 dark:bg-zinc-800 p-2 rounded-md shadow-2xl z-20 absolute max-h-80 overflow-y-auto w-full">
+                          <div className="bg-zinc-300 dark:bg-zinc-800 p-2 rounded-b-md shadow-2xl z-20 absolute max-h-80 overflow-y-auto w-full border border-t-none border-neutral-500/20 divide-y divide-neutral-500/20">
                             {filteredTeams.map((team) => (
-                              <Combobox.Option key={team.id} value={team}>
+                              <Combobox.Option as="div" key={team.id} value={team}>
                                 {({ active }) => (
                                   <div
                                     className={clsx(
@@ -275,7 +273,7 @@ export const CreateVercelSync = (props: { appId: string; closeModal: () => void 
                       <>
                         <div className="space-y-2">
                           <Combobox.Label as={Fragment}>
-                            <label className="block text-gray-700 text-sm font-bold">
+                            <label className="block text-neutral-500 text-sm">
                               Vercel Project <span className="text-red-500">*</span>
                             </label>
                           </Combobox.Label>
@@ -339,7 +337,7 @@ export const CreateVercelSync = (props: { appId: string; closeModal: () => void 
               <div>
                 <RadioGroup value={environment} onChange={setEnvironment}>
                   <RadioGroup.Label as={Fragment}>
-                    <label className="block text-gray-700 text-sm font-bold mb-2">
+                    <label className="block text-neutral-500 text-sm  mb-2">
                       Target Environment <span className="text-red-500">*</span>
                     </label>
                   </RadioGroup.Label>
@@ -367,7 +365,7 @@ export const CreateVercelSync = (props: { appId: string; closeModal: () => void 
               <div>
                 <RadioGroup value={secretType} onChange={setSecretType}>
                   <RadioGroup.Label as={Fragment}>
-                    <label className="block text-gray-700 text-sm font-bold mb-2">
+                    <label className="block text-neutral-500 text-sm mb-2">
                       Secret Type <span className="text-red-500">*</span>
                     </label>
                   </RadioGroup.Label>


### PR DESCRIPTION
## :mag: Overview

Removes the marker indicator from `Combox.Option` elements, and standardizes the styles for Comboboxes and field labels in various syncing screens.

## :framed_picture: Screenshots or Demo

### Before
![Screenshot From 2025-07-02 14-05-14](https://github.com/user-attachments/assets/f6e08237-9112-4784-b18b-19a5357fbe6b)

### After
![Screenshot From 2025-07-02 14-05-30](https://github.com/user-attachments/assets/f8da4950-22a2-4e8c-a21d-02905bbaf771)


## :memo: Release Notes

Cleaned up the styling for Comboboxes on various syncing screens

## :sparkles: How to Test the Changes Locally

- Verify the styling changes by opening various "Create a sync" dialogs
- Verify the changes on Chromium browsers particularly, as the markers were particularly obnoxious

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Update migrations (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
