### PR TITLE
fix: handle existing secrets during import

### DIFF
--- a/frontend/app/[team]/apps/[app]/_components/AppSecrets.tsx
+++ b/frontend/app/[team]/apps/[app]/_components/AppSecrets.tsx
@@ -403,12 +403,74 @@ export const AppSecrets = ({ team, app }: { team: string; app: string }) => {
     ])
   }
 
-  const bulkAddNewClientSecrets = (newSecrets: AppSecret[]) => {
-    setClientAppSecrets((prevSecrets) => {
-      const updatedSecrets = [...newSecrets, ...prevSecrets]
-      return updatedSecrets
+
+/**
+ * Bulk adds or updates client secrets in state from an import.
+ *
+ * For each secret in `newSecrets`:
+ * - If the secret key already exists, update each environment value if it differs.
+ *   - If the environment exists but has no secret yet, initialize it.
+ *   - If it exists and already has a secret, overwrite its value/comment.
+ *   - If the environment does not exist, add it.
+ * - If the secret key does not exist at all, add it as a new secret.
+ *
+ *
+ * @param {AppSecret[]} newSecrets - Secrets being imported into client state
+ */
+function bulkAddNewClientSecrets(newSecrets) {
+  setClientAppSecrets((prev) => {
+    // Clone all existing secrets so we work on new objects,
+    // avoiding in-place mutations of previous state.
+    const existingMap = new Map(
+      prev.map((s) => [s.key, structuredClone(s)])
+    )
+
+    newSecrets.forEach((ns) => {
+      const existing = existingMap.get(ns.key)
+
+      if (existing) {
+        // This secret key already exists, update environments as needed
+        ns.envs.forEach(({ env, secret }) => {
+          // Find matching environment in existing secret
+          const match = existing.envs.find(
+            (e) => e.env.id === env.id
+          )
+
+          if (secret && match && !match.secret) {
+            // Environment exists but has no secret yet → initialize it
+            match.secret = {
+              id: `new-${crypto.randomUUID()}`,
+              updatedAt: null,
+              version: 1,
+              key: '',
+              value: secret.value,
+              tags: [],
+              comment: secret.comment,
+              path: '/',
+              environment: env,
+            }
+          } else if (match && secret) {
+            // Environment already has a secret → overwrite value and comment
+            match.secret = {
+              ...match.secret,
+              value: secret.value,
+              comment: secret.comment,
+            }
+          } else {
+            // Environment does not exist → add it
+            existing.envs.push({ env, secret })
+          }
+        })
+      } else {
+        // This secret key does not exist at all → add as new secret
+        existingMap.set(ns.key, structuredClone(ns))
+      }
     })
-  }
+
+    return Array.from(existingMap.values())
+  })
+}
+
 
   const handleAddNewEnvValue = (appSecretId: string, environment: EnvironmentType) => {
     setClientAppSecrets((prevSecrets) =>

--- a/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
+++ b/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
@@ -215,11 +215,32 @@ export default function EnvironmentPath({
       : setClientSecrets([...clientSecrets, newSecret])
   }
 
+  /**
+   * Bulk adds secrets to client state from an import
+   * 
+   * If a secret key being imported already exists, we update the value and comment.
+   * Otherwise, we process the import as normal, adding it as a new secret
+   * 
+   * @param {SecretType[]} secrets - Secrets being imported into client state
+   */
   const bulkAddSecrets = (secrets: SecretType[]) => {
-    const secretsWithImportFlag = secrets.map((secret) => ({
+    const existingSecrets = new Map(clientSecrets.map((secret) => [secret.key, secret]))
+    const newSecretsToAdd = secrets.filter((secret) => !existingSecrets.has(secret.key))
+    const secretsToUpdate = secrets.filter((secret) => existingSecrets.has(secret.key))
+
+    secretsToUpdate.forEach((secret) => {
+      setClientSecrets((prev) =>
+        prev.map((s) =>
+          s.key === secret.key ? { ...s, ...{ value: secret.value, comment: secret.comment } } : s
+        )
+      )
+    })
+
+    const secretsWithImportFlag = newSecretsToAdd.map((secret) => ({
       ...secret,
       isImported: true,
     }))
+
     setClientSecrets((prev) => [...prev, ...secretsWithImportFlag])
   }
 


### PR DESCRIPTION
## :mag: Overview

The secret import feature does not detect existing secrets with the same key. If a secret with the same key is imported, the "Duplicate key" error is thrown instead. 

## :bulb: Proposed Changes

Update the import behavior to instead detect existing secrets with the same keys, and if found, update their values and comments with those in the imported secrets. 

## :framed_picture: Screenshots or Demo

[update-values-on-import-720-1751535676616.webm](https://github.com/user-attachments/assets/366042a1-f39f-4237-b338-4f75c3bf85d9)

## :memo: Release Notes

Updated the secret import feature to handle existing secret keys.

### :dart: Reviewer Focus

Test the import feature with existing secrets on the cross-env and single env screens. 

## :sparkles: How to Test the Changes Locally

### Single env
* Verify that secrets are correctly imported into an empty env / path
* Verify that secrets with updated values can be imported into the env, and values + comments are updated for matching secret keys. New secrets should be added to state as normal

### Multi env
* Verify the same behavior, but for each env

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Update migrations (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
