### PR TITLE
fix: remove redundant permission check when removing member from org

### DIFF
--- a/backend/backend/graphene/mutations/organisation.py
+++ b/backend/backend/graphene/mutations/organisation.py
@@ -291,17 +291,14 @@ class DeleteOrganisationMemberMutation(graphene.Mutation):
         if org_member.user == info.context.user:
             raise GraphQLError("You can't remove yourself from an organisation")
 
-        if user_is_admin(info.context.user.userId, org_member.organisation.id):
-            org_member.delete()
+        org_member.delete()
 
-            if settings.APP_HOST == "cloud":
-                from ee.billing.stripe import update_stripe_subscription_seats
+        if settings.APP_HOST == "cloud":
+            from ee.billing.stripe import update_stripe_subscription_seats
 
-                update_stripe_subscription_seats(org_member.organisation)
+            update_stripe_subscription_seats(org_member.organisation)
 
-            return DeleteOrganisationMemberMutation(ok=True)
-        else:
-            raise GraphQLError("You don't have permission to perform that action")
+        return DeleteOrganisationMemberMutation(ok=True)
 
 
 class UpdateOrganisationMemberRole(graphene.Mutation):


### PR DESCRIPTION
## :mag: Overview

A redundant permission check prevents users with the `Members:delete` permission from being able to remove org members if they are not either an `Admin` or `Owner`

## :bulb: Proposed Changes

Remove the redundant check and respect the Role permissions.

## :memo: Release Notes

Fixed a bug that prevented users with the `Members:delete` from being able to remove members from an org

## :sparkles: How to Test the Changes Locally

* As a user with the `Members:delete` permission that is not `Admin` or `Owner`, verify that you are able to remove members from an org
* As a user without the `Members:delete` permission, verify that you are **not** able to remove members from an org

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Update migrations (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
