### PR TITLE
fix: prevent phantom envs being displayed when importing secrets

### DIFF
--- a/frontend/app/[team]/apps/[app]/_components/AppSecrets.tsx
+++ b/frontend/app/[team]/apps/[app]/_components/AppSecrets.tsx
@@ -451,9 +451,6 @@ export const AppSecrets = ({ team, app }: { team: string; app: string }) => {
                 value: secret.value,
                 comment: secret.comment,
               } as SecretType
-            } else {
-              // Environment does not exist → add it
-              existing.envs.push({ env, secret })
             }
           })
         } else {


### PR DESCRIPTION
## :mag: Overview

When importing secrets on the cross env screen, it is possible select specific envs to import secrets into, rather than all available envs. Doing so with an existing secret in one or more selected envs however, can lead to 'phanton' envs being shown in the UI

## :bulb: Proposed Changes

Correctly handle 'de-selected' envs in the client state when processing bulk imports. 

## :framed_picture: Screenshots or Demo

### Before
De-selecting one or more envs causes phantom envs to appear

https://github.com/user-attachments/assets/fb971fa9-2758-4d2a-9824-b2f2ef5f5966

### After
Import is processed correctly, with no phantom envs

https://github.com/user-attachments/assets/760695c2-e939-480c-ac66-141a26114d7b



## :memo: Release Notes

Fixed a bug when selecting a subset of envs on the cross-env import dialog

## :sparkles: How to Test the Changes Locally

1. Create the following setup:

| KEY | Dev |Stag|Prod |
| ------------- | ------------- |------------- |------------- |
| TEST | dev | *MISSING* | *MISSING* |

2. Import: `TEST=stag`
3. De-select one or more envs via the toggle switches. For example, select only dev + stag

4. Verify that the import is processed correctly. Existing values should be updated, and envs where the value was missing should be added a new values.

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Update migrations (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
