### PR TITLE
fix: account delete UI and loading states

### DIFF
--- a/frontend/app/[team]/access/members/_components/DeleteInviteDialog.tsx
+++ b/frontend/app/[team]/access/members/_components/DeleteInviteDialog.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { OrganisationMemberInviteType, OrganisationMemberType } from '@/apollo/graphql'
+import { Button } from '@/components/common/Button'
+import { organisationContext } from '@/contexts/organisationContext'
+import GetInvites from '@/graphql/queries/organisation/getInvites.gql'
+import DeleteOrgInvite from '@/graphql/mutations/organisation/deleteInvite.gql'
+import { userHasPermission } from '@/utils/access/permissions'
+import { useMutation } from '@apollo/client'
+import { useContext, useRef } from 'react'
+import { FaTrashAlt } from 'react-icons/fa'
+import { toast } from 'react-toastify'
+import { useRouter } from 'next/navigation'
+import GenericDialog from '@/components/common/GenericDialog'
+
+export const DeleteInviteDialog = ({ invite }: { invite: OrganisationMemberInviteType }) => {
+  const { activeOrganisation: organisation } = useContext(organisationContext)
+
+  const [deleteInvite, { loading: deletePending }] = useMutation(DeleteOrgInvite)
+
+  const dialogRef = useRef<{ closeModal: () => void }>(null)
+
+  const router = useRouter()
+
+  const closeModal = () => dialogRef.current?.closeModal()
+
+  const handleDeleteInvite = async () => {
+    await deleteInvite({
+      variables: {
+        inviteId: invite.id,
+      },
+      refetchQueries: [
+        {
+          query: GetInvites,
+          variables: {
+            orgId: organisation?.id,
+          },
+        },
+      ],
+    })
+    toast.success('Deleted invite successfully')
+  }
+
+  const activeUserCanDeleteUsers = organisation?.role?.permissions
+    ? userHasPermission(organisation?.role?.permissions, 'Members', 'delete', false)
+    : false
+
+  if (!activeUserCanDeleteUsers) return <></>
+
+  return (
+    <>
+      <GenericDialog
+        ref={dialogRef}
+        title="Delete Invite"
+        buttonContent={
+          <>
+            <FaTrashAlt /> Delete
+          </>
+        }
+        buttonVariant="danger"
+      >
+        <div className="space-y-6 p-4">
+          <p className="text-neutral-500">
+            Are you sure you want to delete the invite for{' '}
+            <span className="text-zinc-900 dark:text-zinc-100">{invite.inviteeEmail}</span>?
+          </p>
+          <div className="flex items-center justify-between gap-4">
+            <Button variant="secondary" type="button" onClick={closeModal}>
+              Cancel
+            </Button>
+            <Button
+              variant="danger"
+              onClick={handleDeleteInvite}
+              isLoading={deletePending}
+              icon={FaTrashAlt}
+            >
+              Delete Invite
+            </Button>
+          </div>
+        </div>
+      </GenericDialog>
+    </>
+  )
+}

--- a/frontend/app/[team]/access/members/_components/DeleteMemberConfirmDialog.tsx
+++ b/frontend/app/[team]/access/members/_components/DeleteMemberConfirmDialog.tsx
@@ -21,7 +21,7 @@ export const DeleteMemberConfirmDialog = (props: {
 
   const { activeOrganisation: organisation } = useContext(organisationContext)
 
-  const [removeMember] = useMutation(RemoveMember)
+  const [removeMember, { loading }] = useMutation(RemoveMember)
 
   const dialogRef = useRef<{ closeModal: () => void }>(null)
 
@@ -72,14 +72,22 @@ export const DeleteMemberConfirmDialog = (props: {
       >
         <div className="space-y-6 p-4">
           <p className="text-neutral-500">
-            Are you sure you want to remove {member.fullName || member.email} from this
-            organisation? This action cannot be undone.
+            Are you sure you want to remove{' '}
+            <span className="text-zinc-900 dark:text-zinc-100">
+              {member.fullName || member.email}
+            </span>{' '}
+            from this organisation? This action cannot be undone.
           </p>
-          <div className="flex items-center gap-4">
+          <div className="flex items-center justify-between gap-4">
             <Button variant="secondary" type="button" onClick={closeModal}>
               Cancel
             </Button>
-            <Button variant="danger" onClick={handleRemoveMember}>
+            <Button
+              variant="danger"
+              onClick={handleRemoveMember}
+              isLoading={loading}
+              icon={FaTrashAlt}
+            >
               Remove Member
             </Button>
           </div>

--- a/frontend/app/[team]/access/members/page.tsx
+++ b/frontend/app/[team]/access/members/page.tsx
@@ -2,23 +2,13 @@
 
 import GetOrganisationMembers from '@/graphql/queries/organisation/getOrganisationMembers.gql'
 import GetInvites from '@/graphql/queries/organisation/getInvites.gql'
-import DeleteOrgInvite from '@/graphql/mutations/organisation/deleteInvite.gql'
-import { useMutation, useQuery } from '@apollo/client'
-import { Fragment, useContext, useState } from 'react'
+import { useQuery } from '@apollo/client'
+import { useContext, useState } from 'react'
 import { OrganisationMemberInviteType, OrganisationMemberType } from '@/apollo/graphql'
 import { Button } from '@/components/common/Button'
 import { organisationContext } from '@/contexts/organisationContext'
 import { inviteIsExpired, relativeTimeFromDates } from '@/utils/time'
-import { Dialog, Transition } from '@headlessui/react'
-import {
-  FaBan,
-  FaTimes,
-  FaTrashAlt,
-  FaChevronRight,
-  FaSearch,
-  FaTimesCircle,
-  FaCopy,
-} from 'react-icons/fa'
+import { FaBan, FaChevronRight, FaSearch, FaTimesCircle, FaCopy } from 'react-icons/fa'
 import clsx from 'clsx'
 import Link from 'next/link'
 import { Avatar } from '@/components/common/Avatar'
@@ -30,6 +20,7 @@ import Spinner from '@/components/common/Spinner'
 import { InviteDialog } from './_components/InviteDialog'
 import { MdSearchOff } from 'react-icons/md'
 import CopyButton from '@/components/common/CopyButton'
+import { DeleteInviteDialog } from './_components/DeleteInviteDialog'
 
 export default function Members({ params }: { params: { team: string } }) {
   const { activeOrganisation: organisation } = useContext(organisationContext)
@@ -60,108 +51,6 @@ export default function Members({ params }: { params: { team: string } }) {
     pollInterval: 5000,
     skip: !organisation,
   })
-
-  const [deleteInvite] = useMutation(DeleteOrgInvite)
-
-  //const activeUserIsAdmin = organisation ? userIsAdmin(organisation.role!) : false
-
-  const DeleteInviteConfirmDialog = (props: { inviteId: string }) => {
-    const { inviteId } = props
-
-    const [isOpen, setIsOpen] = useState<boolean>(false)
-
-    const closeModal = () => {
-      setIsOpen(false)
-    }
-
-    const openModal = () => {
-      setIsOpen(true)
-    }
-
-    const handleDeleteInvite = async (inviteId: string) => {
-      await deleteInvite({
-        variables: {
-          inviteId,
-        },
-        refetchQueries: [
-          {
-            query: GetInvites,
-            variables: {
-              orgId: organisation?.id,
-            },
-          },
-        ],
-      })
-    }
-
-    return (
-      <>
-        <div className="flex items-center justify-center">
-          <Button variant="danger" onClick={openModal} title="Delete invite">
-            <div className="text-white dark:text-red-500 flex items-center gap-1 p-1">
-              <FaTrashAlt />
-            </div>
-          </Button>
-        </div>
-
-        <Transition appear show={isOpen} as={Fragment}>
-          <Dialog as="div" className="relative z-10" onClose={closeModal}>
-            <Transition.Child
-              as={Fragment}
-              enter="ease-out duration-300"
-              enterFrom="opacity-0"
-              enterTo="opacity-100"
-              leave="ease-in duration-200"
-              leaveFrom="opacity-100"
-              leaveTo="opacity-0"
-            >
-              <div className="fixed inset-0 bg-black/25 backdrop-blur-md" />
-            </Transition.Child>
-
-            <div className="fixed inset-0 overflow-y-auto">
-              <div className="flex min-h-full items-center justify-center p-4 text-center">
-                <Transition.Child
-                  as={Fragment}
-                  enter="ease-out duration-300"
-                  enterFrom="opacity-0 scale-95"
-                  enterTo="opacity-100 scale-100"
-                  leave="ease-in duration-200"
-                  leaveFrom="opacity-100 scale-100"
-                  leaveTo="opacity-0 scale-95"
-                >
-                  <Dialog.Panel className="w-full max-w-2xl transform overflow-hidden rounded-2xl bg-neutral-100 dark:bg-neutral-900 p-6 text-left align-middle shadow-xl transition-all">
-                    <Dialog.Title as="div" className="flex w-full justify-between">
-                      <h3 className="text-lg font-medium leading-6 text-black dark:text-white ">
-                        Delete Invite
-                      </h3>
-
-                      <Button variant="text" onClick={closeModal}>
-                        <FaTimes className="text-zinc-900 dark:text-zinc-400 hover:text-zinc-700 dark:hover:text-zinc-300" />
-                      </Button>
-                    </Dialog.Title>
-
-                    <div className="space-y-6 p-4">
-                      <p className="text-neutral-500">
-                        Are you sure you want to delete this invite?
-                      </p>
-                      <div className="flex items-center gap-4">
-                        <Button variant="secondary" type="button" onClick={closeModal}>
-                          Cancel
-                        </Button>
-                        <Button variant="danger" onClick={() => handleDeleteInvite(inviteId)}>
-                          Delete
-                        </Button>
-                      </div>
-                    </div>
-                  </Dialog.Panel>
-                </Transition.Child>
-              </div>
-            </div>
-          </Dialog>
-        </Transition>
-      </>
-    )
-  }
 
   const filteredMembers = membersData?.organisationMembers
     ? searchQuery !== ''
@@ -314,7 +203,8 @@ export default function Members({ params }: { params: { team: string } }) {
                           </div>
                         </CopyButton>
                       )}
-                      <DeleteInviteConfirmDialog inviteId={invite.id} />
+
+                      <DeleteInviteDialog invite={invite} />
                     </td>
                   </tr>
                 ))}

--- a/frontend/app/[team]/access/service-accounts/_components/DeleteServiceAccountDialog.tsx
+++ b/frontend/app/[team]/access/service-accounts/_components/DeleteServiceAccountDialog.tsx
@@ -15,7 +15,7 @@ export const DeleteServiceAccountDialog = ({ account }: { account: ServiceAccoun
 
   const dialogRef = useRef<{ closeModal: () => void }>(null)
 
-  const [deleteAccount] = useMutation(DeleteServiceAccountOp)
+  const [deleteAccount, { loading }] = useMutation(DeleteServiceAccountOp)
 
   const handleDelete = async () => {
     const deleted = await deleteAccount({
@@ -48,12 +48,13 @@ export const DeleteServiceAccountDialog = ({ account }: { account: ServiceAccoun
     >
       <div className="space-y-4">
         <div className="text-neutral-500 py-4">
-          Are you sure you want to delete this service account? This will delete all service tokens
-          associated with this account.
+          Are you sure you want to delete{' '}
+          <span className="text-zinc-900 dark:text-zinc-100">{account.name}</span>? This will delete
+          all service tokens associated with this account.
         </div>
         <div className="flex justify-end">
-          <Button variant="danger" onClick={handleDelete}>
-            <FaTrashAlt /> Delete
+          <Button variant="danger" icon={FaTrashAlt} onClick={handleDelete} isLoading={loading}>
+            Delete
           </Button>
         </div>
       </div>

--- a/frontend/app/invite/[invite]/page.tsx
+++ b/frontend/app/invite/[invite]/page.tsx
@@ -234,7 +234,8 @@ export default function Invite({ params }: { params: { invite: string } }) {
           <div className="mx-auto pt-8">
             <Button
               variant="primary"
-              arrow="right"
+              iconPosition="right"
+              icon={FaArrowRight}
               onClick={() => (window.location.href = `/${invite.organisation.name}`)}
             >
               Go to Console

--- a/frontend/components/common/Button.tsx
+++ b/frontend/components/common/Button.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import clsx from 'clsx'
 import { forwardRef, type ReactNode } from 'react'
 import Spinner from './Spinner'
+import { IconType } from 'react-icons'
 
 export type ButtonVariant =
   | 'primary'
@@ -17,8 +18,9 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant: ButtonVariant
   classString?: string
   children: ReactNode
-  arrow?: 'left' | 'right'
+  iconPosition?: 'left' | 'right'
   isLoading?: boolean
+  icon?: IconType
 }
 
 function ArrowIcon(props: { className: string }) {
@@ -53,7 +55,7 @@ const variantStyles: Record<string, string> = {
 }
 
 export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
-  { variant, classString, children, arrow, isLoading, ...rest },
+  { variant, classString, children, isLoading, icon, iconPosition = 'left', ...rest },
   ref
 ) {
   const computedClassName = clsx(
@@ -63,16 +65,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
     (rest.disabled || isLoading) && 'opacity-60 pointer-events-none'
   )
 
-  const arrowIcon = (
-    <ArrowIcon
-      className={clsx(
-        'mt-0.5 h-5 w-5',
-        variant === 'text' && 'relative top-px',
-        arrow === 'left' && '-ml-1 rotate-180',
-        arrow === 'right' && '-mr-1'
-      )}
-    />
-  )
+  const Icon = icon
 
   const spinnerColor = () => {
     switch (variant) {
@@ -92,10 +85,11 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
 
   return (
     <button ref={ref} className={computedClassName} disabled={rest.disabled || isLoading} {...rest}>
-      {!isLoading && arrow === 'left' && arrowIcon}
+      {!isLoading && Icon && iconPosition === 'left' && <Icon className="size-4" />}
+
       {isLoading && <Spinner size="sm" color={spinnerColor()} />}
       {children}
-      {!isLoading && arrow === 'right' && arrowIcon}
+      {!isLoading && Icon && iconPosition === 'right' && <Icon className="size-4" />}
     </button>
   )
 })


### PR DESCRIPTION
## :mag: Overview

Misc fixes and improvements to account delete dialogs.

## :bulb: Proposed Changes

* Added loading states and more prominent account names to the Delete dialogs for User and Service Account delete actions
* Refactored the Delete Invite dialog to use a `GenericDialog`, add a toast, loading state and misc fixes to bring the styling in line with other delete dialogs
* Added a new `icon` prop to the common `Button` component. This allows an icon to be passed as prop instead of within the Button's children. This allows better conditional rendering of the icon during loading states (see demo below)

## :framed_picture: Screenshots or Demo

https://github.com/user-attachments/assets/c4b5349f-69c1-4f57-906c-68624e3147a2

## :memo: Release Notes

Misc UI/UX improvements to the delete dialogs for users, invites, and service accounts.

## :sparkles: How to Test the Changes Locally

Verify that loading states are correctly shown when deleting:

* Org Members
* org Member invites
* Org Service Accounts

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Update migrations (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
