### PR TITLE
chore: fix dev docker compose

### DIFF
--- a/.env.dev.example
+++ b/.env.dev.example
@@ -57,8 +57,8 @@ ALLOWED_HOSTS=localhost,backend
 ALLOWED_ORIGINS=https://localhost
 SESSION_COOKIE_DOMAIN=localhost
 
-# Database credentials. Change all these values as required, except DATABASE_HOST
-DATABASE_HOST=postgres # don't change this
+# Database credentials. Change all these values if required, but you may need to update the healthcheck in dev-docker-compose.yml services.postgres as well
+DATABASE_HOST=postgres
 DATABASE_PORT=5432
 DATABASE_NAME=postgres-db-name
 DATABASE_USER=postgres-user

--- a/dev-docker-compose.yml
+++ b/dev-docker-compose.yml
@@ -70,8 +70,8 @@ services:
     restart: unless-stopped
     ports:
       - "8081:8081"
-    environment:
-      - DATABASE_URL=postgres://${DATABASE_USER}:${DATABASE_PASSWORD}@postgres:5432/${DATABASE_NAME}?sslmode=disable
+    env_file:
+      - .env.dev
     depends_on:
       postgres:
         condition: service_healthy
@@ -84,17 +84,12 @@ services:
     restart: always
     env_file:
       - .env.dev
-    environment:
-      POSTGRES_DB: ${DATABASE_NAME}
-      POSTGRES_USER: ${DATABASE_USER}
-      POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
-      POSTGRES_HOST_AUTH_METHOD: "trust"
     volumes:
       - phase-postgres-data-dev:/var/lib/postgresql/data
     networks:
       - phase-net-dev
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DATABASE_USER} -d ${DATABASE_NAME}"]
+      test: ["CMD-SHELL", "pg_isready -U postgres-user -d postgres-db-name"] # update the user and db based on your .env.dev
       interval: 5s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## :mag: Overview

The current `dev-docker-compose.yml` has conflcting env var parsing. The `env_file` arg on each service references `.env.dev`, while the `environment` arg overrides these values and attemps to read from `.env` which might not exist

## :bulb: Proposed Changes

* Only read  from `.env.dev`
* Hardcode the db name and user in the postgres health check, since docker compose doesn't offer a way to reference these values from a file other than .env
* Update the instructions in the docker compose file and `.env.dev.example` for clarity
