### PR TITLE
feat: update CommandPalette title

### DIFF
--- a/frontend/components/common/CommandPalette.tsx
+++ b/frontend/components/common/CommandPalette.tsx
@@ -396,7 +396,7 @@ const CommandPalette: React.FC = () => {
         <div>
           <FaSearch className="h-4 w-4 flex-shrink-0" />
         </div>
-        <span className="flex-grow text-left truncate">Find something...</span>
+        <span className="flex-grow text-left truncate">Look up secrets...</span>
         <kbd className="flex-shrink-0 text-2xs text-zinc-400 dark:text-zinc-500">
           <kbd className="font-sans">{modifierKey}</kbd>
           <kbd className="font-sans"> + K</kbd>


### PR DESCRIPTION
## :mag: Overview

Many users aren't aware that the command palette can be used to search for secrets globally in addition to navigating. Looking up secrets across across the entire organization is a very powerful feature. This small change make the killer feature explicit. 

## :bulb: Proposed Changes

Switch the command palette title from `Find something...` to ` Look up secrets..`.

## :framed_picture: Screenshots or Demo

<img width="1510" height="1122" alt="image" src="https://github.com/user-attachments/assets/5eb36b4c-d96e-45cb-856f-a45ae96db164" />
