### PR TITLE
fix: min ttl + logs filter permissions

### DIFF
--- a/backend/api/views/secrets.py
+++ b/backend/api/views/secrets.py
@@ -675,7 +675,7 @@ class PublicSecretsView(APIView):
                             {
                                 "secret_id": str(ds.id),
                                 "secret_name": ds.name,
-                                "error": "Internal error occurred",
+                                "error": str(e),
                             }
                         )
 

--- a/backend/backend/graphene/queries/service_accounts.py
+++ b/backend/backend/graphene/queries/service_accounts.py
@@ -50,9 +50,7 @@ def resolve_app_service_accounts(root, info, app_id):
     if not user_has_permission(
         info.context.user, "read", "ServiceAccounts", app.organisation, True
     ):
-        raise GraphQLError(
-            "You don't have permission to read service accounts in this App"
-        )
+        return []
 
     if not user_can_access_app(info.context.user.userId, app_id):
         raise GraphQLError("You don't have access to this app")

--- a/backend/ee/integrations/secrets/dynamic/utils.py
+++ b/backend/ee/integrations/secrets/dynamic/utils.py
@@ -202,6 +202,15 @@ def create_dynamic_secret_lease(
     try:
         lease_name = lease_name or secret.name
         ttl = ttl or int(secret.default_ttl.total_seconds())
+
+        if ttl > int(secret.max_ttl.total_seconds()):
+            raise TTLExceededError(
+                "The specified TTL exceeds the maximum TTL for this dynamic secret."
+            )
+
+        if ttl < 60:
+            raise ValidationError("The specified TTL must be at least 60 seconds.")
+
         if secret.provider == "aws":
             lease, lease_data, meta = create_aws_dynamic_secret_lease(
                 secret=secret,


### PR DESCRIPTION
## :bulb: Proposed Changes

* Enforced min and max TTLs in the generic `create_dynamic_secret_lease` util
* Return more detail in the api error response when leases fail to be created
* Silently return an empty list when a user does not have permission to list app service accounts (used to populate the 'accounts' filter options in app logs)

## :framed_picture: Screenshots or Demo

```bash
{
  "error": "One or more dynamic secret leases could not be created",
  "failedLeases": [
    {
      "secretId": "fad16679-f4de-4d14-859f-9f1a501012c3",
      "secretName": "AWS IAM credentials",
      "error": "The specified TTL must be at least 60 seconds."
    }
  ],
  "successfulLeases": 0
}
```

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Update migrations (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
