### PR TITLE
feat: support manual github credential setup

### DIFF
--- a/backend/api/services.py
+++ b/backend/api/services.py
@@ -28,7 +28,7 @@ class Providers:
         "name": "GitHub",
         "expected_credentials": ["access_token"],
         "optional_credentials": ["host_url", "api_url"],
-        "auth_scheme": "oauth",
+        "auth_scheme": "oauth,token",
     }
 
     GITLAB = {

--- a/backend/api/utils/syncing/github/actions.py
+++ b/backend/api/utils/syncing/github/actions.py
@@ -19,8 +19,11 @@ class GitHubRepoType(ObjectType):
 
 
 def normalize_api_host(api_host):
+    if not api_host or api_host.strip() == "":
+        api_host = GITHUB_CLOUD_API_URL
+
     stripped_host = api_host.rstrip("/")
-    
+
     if stripped_host == GITHUB_CLOUD_API_URL.rstrip("/"):
         return stripped_host
     else:
@@ -77,7 +80,9 @@ def list_repos(credential_id):
             all_repos.extend(serialize_repos(repos_on_page))
             page += 1
         else:
-            raise Exception(f"Error fetching user repositories: {user_repos_response.text}")
+            raise Exception(
+                f"Error fetching user repositories: {user_repos_response.text}"
+            )
 
     return all_repos
 
@@ -122,7 +127,10 @@ def list_environments(credential_id, owner, repo_name):
 
     api_host = normalize_api_host(api_host)
 
-    headers = {"Authorization": f"Bearer {access_token}", "Accept": "application/vnd.github+json"}
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Accept": "application/vnd.github+json",
+    }
 
     environments = []
     page = 1
@@ -180,7 +188,9 @@ def get_all_secrets(repo, owner, headers, api_host=GITHUB_CLOUD_API_URL):
     return all_secrets
 
 
-def get_all_env_secrets(repo, owner, environment_name, headers, api_host=GITHUB_CLOUD_API_URL):
+def get_all_env_secrets(
+    repo, owner, environment_name, headers, api_host=GITHUB_CLOUD_API_URL
+):
     api_host = normalize_api_host(api_host)
     all_secrets = []
     page = 1
@@ -216,11 +226,11 @@ def sync_github_secrets(
         }
 
         if environment_name:
-            public_key_url = (
-                f"{api_host}/repos/{owner}/{repo}/environments/{environment_name}/secrets/public-key"
-            )
+            public_key_url = f"{api_host}/repos/{owner}/{repo}/environments/{environment_name}/secrets/public-key"
         else:
-            public_key_url = f"{api_host}/repos/{owner}/{repo}/actions/secrets/public-key"
+            public_key_url = (
+                f"{api_host}/repos/{owner}/{repo}/actions/secrets/public-key"
+            )
 
         public_key_response = requests.get(public_key_url, headers=headers)
         if public_key_response.status_code != 200:
@@ -249,9 +259,7 @@ def sync_github_secrets(
 
             secret_data = {"encrypted_value": encrypted_value, "key_id": key_id}
             if environment_name:
-                secret_url = (
-                    f"{api_host}/repos/{owner}/{repo}/environments/{environment_name}/secrets/{key}"
-                )
+                secret_url = f"{api_host}/repos/{owner}/{repo}/environments/{environment_name}/secrets/{key}"
             else:
                 secret_url = f"{api_host}/repos/{owner}/{repo}/actions/secrets/{key}"
             response = requests.put(secret_url, headers=headers, json=secret_data)
@@ -265,9 +273,7 @@ def sync_github_secrets(
         for secret_name in existing_secret_names:
             if secret_name not in local_secrets:
                 if environment_name:
-                    delete_url = (
-                        f"{api_host}/repos/{owner}/{repo}/environments/{environment_name}/secrets/{secret_name}"
-                    )
+                    delete_url = f"{api_host}/repos/{owner}/{repo}/environments/{environment_name}/secrets/{secret_name}"
                 else:
                     delete_url = (
                         f"{api_host}/repos/{owner}/{repo}/actions/secrets/{secret_name}"

--- a/frontend/components/syncing/CreateProviderCredentials.tsx
+++ b/frontend/components/syncing/CreateProviderCredentials.tsx
@@ -2,7 +2,7 @@ import { ProviderType } from '@/apollo/graphql'
 import GetProviderList from '@/graphql/queries/syncing/getProviders.gql'
 import GetSavedCredentials from '@/graphql/queries/syncing/getSavedCredentials.gql'
 import SaveNewProviderCreds from '@/graphql/mutations/syncing/saveNewProviderCreds.gql'
-import { useState, useEffect, useContext } from 'react'
+import { useState, useEffect, useContext, Fragment } from 'react'
 import { FaArrowRight } from 'react-icons/fa'
 import { Button } from '../common/Button'
 import { useMutation, useQuery } from '@apollo/client'
@@ -18,6 +18,8 @@ import Link from 'next/link'
 import { SetupGhAuth } from './GitHub/SetupGhAuth'
 import { SetupAWSAuth } from './AWS/SetupAWSAuth'
 import { MdMenuBook } from 'react-icons/md'
+import { Tab } from '@headlessui/react'
+import clsx from 'clsx'
 
 interface CredentialState {
   [key: string]: string
@@ -55,6 +57,7 @@ export const CreateProviderCredentials = (props: {
   const { activeOrganisation: organisation } = useContext(organisationContext)
 
   const [provider, setProvider] = useState<ProviderType | null>(props.provider || null)
+  const [authMethod, setAuthMethod] = useState<'oauth' | 'token'>('token')
   const [name, setName] = useState<string>('')
   const [credentials, setCredentials] = useState<CredentialState>({})
 
@@ -75,7 +78,8 @@ export const CreateProviderCredentials = (props: {
           initialCredentials[cred] = ''
         })
       }
-      if (provider.id === 'aws' || provider.id === 'aws_assume_role') initialCredentials['region'] = awsRegions[0].region
+      if (provider.id === 'aws' || provider.id === 'aws_assume_role')
+        initialCredentials['region'] = awsRegions[0].region
       setCredentials(initialCredentials)
 
       if (name.length === 0) setName(`${provider.name} credentials`)
@@ -148,6 +152,11 @@ export const CreateProviderCredentials = (props: {
     props.onComplete()
   }
 
+  const supportedAuthMethods = provider?.authScheme?.split(',') || []
+
+  const toggleAuthMethod = () =>
+    setAuthMethod((prevAuthMethod) => (prevAuthMethod === 'oauth' ? 'token' : 'oauth'))
+
   if (provider?.id === 'aws' || provider?.id === 'aws_assume_role') {
     return (
       <SetupAWSAuth
@@ -179,15 +188,53 @@ export const CreateProviderCredentials = (props: {
 
         {provider === null && (
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-            {providers.filter(provider => provider.id !== 'aws_assume_role').map((provider) => (
-              <button key={provider.id} type="button" onClick={() => setProvider(provider)}>
-                <ProviderCard provider={provider} />
-              </button>
-            ))}
+            {providers
+              .filter((provider) => provider.id !== 'aws_assume_role')
+              .map((provider) => (
+                <button key={provider.id} type="button" onClick={() => setProvider(provider)}>
+                  <ProviderCard provider={provider} />
+                </button>
+              ))}
           </div>
         )}
 
-        {provider?.authScheme === 'token' &&
+        {provider && supportedAuthMethods.length > 1 && (
+          <Tab.Group selectedIndex={authMethod === 'oauth' ? 0 : 1} onChange={toggleAuthMethod}>
+            <Tab.List className="flex gap-4 w-full border-b border-neutral-500/20">
+              <Tab as={Fragment}>
+                {({ selected }) => (
+                  <div
+                    className={clsx(
+                      'p-3 font-medium border-b focus:outline-none text-black dark:text-white',
+                      selected
+                        ? 'border-emerald-500 font-semibold text-emerald-500'
+                        : ' border-transparent cursor-pointer'
+                    )}
+                  >
+                    Setup with OAuth
+                  </div>
+                )}
+              </Tab>
+
+              <Tab as={Fragment}>
+                {({ selected }) => (
+                  <div
+                    className={clsx(
+                      'p-3 font-medium border-b focus:outline-none text-black dark:text-white',
+                      selected
+                        ? 'border-emerald-500 font-semibold'
+                        : ' border-transparent cursor-pointer'
+                    )}
+                  >
+                    Enter token manually
+                  </div>
+                )}
+              </Tab>
+            </Tab.List>
+          </Tab.Group>
+        )}
+
+        {authMethod === 'token' &&
           provider?.expectedCredentials
             .filter((credential) => credential !== 'region')
             .map((credential) => (
@@ -201,7 +248,7 @@ export const CreateProviderCredentials = (props: {
               />
             ))}
 
-        {provider?.authScheme === 'token' &&
+        {authMethod === 'token' &&
           provider?.optionalCredentials
             .filter((credential) => credential !== 'region')
             .map((credential) => (
@@ -215,17 +262,17 @@ export const CreateProviderCredentials = (props: {
             ))}
 
         {(provider?.id === 'aws' || provider?.id === 'aws_assume_role') && (
-          <AWSRegionPicker 
-            value={credentials['region']} 
-            onChange={(region) => handleCredentialChange('region', region)} 
+          <AWSRegionPicker
+            value={credentials['region']}
+            onChange={(region) => handleCredentialChange('region', region)}
           />
         )}
 
-        {provider && provider?.authScheme === 'token' && (
+        {provider && authMethod === 'token' && (
           <Input required value={name} setValue={(value) => setName(value)} label="Name" />
         )}
 
-        {provider && provider.authScheme !== 'oauth' && (
+        {authMethod === 'token' && (
           <div className="flex justify-between">
             <Button variant="secondary" type="button" onClick={handleClickBack}>
               Back
@@ -237,7 +284,7 @@ export const CreateProviderCredentials = (props: {
           </div>
         )}
       </form>
-      {provider?.id === 'github' && <SetupGhAuth />}
+      {provider?.id === 'github' && authMethod === 'oauth' && <SetupGhAuth />}
     </>
   )
 }

--- a/frontend/utils/syncing/general.ts
+++ b/frontend/utils/syncing/general.ts
@@ -33,4 +33,4 @@ export const encryptProviderCredentials = async (
 }
 
 export const isCredentialSecret = (credential: string) =>
-  !/(?:addr|host)/i.test(credential.toLowerCase())
+  !/(?:addr|host|url)/i.test(credential.toLowerCase())


### PR DESCRIPTION
## :mag: Overview

Adds the ability to set up GitHub credentials manually by pasting a token, instead of using the OAuth flow. This allows users of GitHub Enterprise Server to set up their credentials to sync secrets from Phase Cloud.

## :framed_picture: Screenshots or Demo

<img width="1207" height="859" alt="image" src="https://github.com/user-attachments/assets/9ddc1c35-53cd-49dc-8ca3-83895d7ae1f6" />

### :dart: Reviewer Focus

Verify that credentials can be set up correctly using:
* Cloud mode
  * GitHub.com OAuth
  * GitHub.com manual setup
  * GitHub Enterprise Server manual setup
* Self hosted mode
  *  GitHub.com OAuth
  * GitHub Enterprise Server OAuth
  * GitHub.com manual setup
  * GitHub Enterprise Server manual setup

Verify that syncs work for repos, environments


### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Update migrations (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [ ] Manually test the changes on different browsers/devices?
