### PR TITLE
fix: service account token creation bug

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -530,7 +530,7 @@ class ServiceTokenManager(models.Manager):
             raise ValueError("Cannot add more service tokens to this app.")
         return super().create(*args, **kwargs)
 
-
+# Deprecated Legacy App-linked Service Tokens
 class ServiceToken(models.Model):
     id = models.TextField(default=uuid4, primary_key=True, editable=False)
     app = models.ForeignKey(App, on_delete=models.CASCADE)
@@ -569,7 +569,7 @@ class ServiceAccountToken(models.Model):
     created_at = models.DateTimeField(auto_now_add=True, blank=True, null=True)
     updated_at = models.DateTimeField(auto_now=True)
     deleted_at = models.DateTimeField(blank=True, null=True)
-    expires_at = models.DateTimeField(null=True)
+    expires_at = models.DateTimeField(null=True, blank=True)
 
     def clean(self):
         # Ensure only one of created_by or created_by_service_account is set


### PR DESCRIPTION
## :mag: Overview

Fixed the `ApolloError: {'expires_at': ['This field cannot be blank.']}` when creating Service Account Tokens that do not expire.

## :bulb: Proposed Changes

- Updated the expires_at field in the ServiceAccountToken model to allow blank values, enhancing flexibility in token management.
- Added a deprecation comment for legacy app-linked service tokens in the ServiceToken model.

### :test_tube: Testing

- Create a Service Account Token with no expiry - verify that creation is successful and a valid token is minted
- Create a Service Account Token with expiry - verify that creation succeeds and a valid token is minted

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Permits non-expiring service account tokens by allowing blank expires_at and adds a deprecation note to legacy app-linked service tokens.
> 
> - **Backend/models**:
>   - `ServiceAccountToken`: set `expires_at` to `blank=True` to support non-expiring tokens.
>   - `ServiceToken`: add deprecation comment indicating legacy app-linked tokens.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f6eec58652b560ca547bc98db182edcaab29cad5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->