### PR TITLE
fix: replace full_clean with clean in ServiceAccountToken save method

### DIFF
--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -584,7 +584,7 @@ class ServiceAccountToken(models.Model):
             )
 
     def save(self, *args, **kwargs):
-        self.full_clean()  # This calls clean() and field validation
+        self.clean()
         super().save(*args, **kwargs)
 
     def get_creator_account(self):


### PR DESCRIPTION
## :mag: Overview

Fixed the ApolloError: {'expires_at': ['This field cannot be blank.']} when creating Service Account Tokens that do not expire.

## :bulb: Proposed Changes

Replace the unnecessary `full_clean()` call with just `clean()` on model `save()` to run our custom validation logic


### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Update migrations (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace full_clean() with clean() in ServiceAccountToken.save to run custom validation only.
> 
> - **Backend – Models (`backend/api/models.py`)**:
>   - Update `ServiceAccountToken.save` to call `clean()` instead of `full_clean()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c53c971fcd1dacc0c363ebd8334510fef4d28521. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->