### PR TITLE
feat: improve secret lookup and creation flow

### DIFF
--- a/frontend/app/[team]/apps/[app]/_components/AppSecrets.tsx
+++ b/frontend/app/[team]/apps/[app]/_components/AppSecrets.tsx
@@ -36,6 +36,7 @@ import {
   getUserKxPublicKey,
   arraysEqual,
 } from '@/utils/crypto'
+import { escapeRegExp } from 'lodash'
 import { EmptyState } from '@/components/common/EmptyState'
 import { toast } from 'react-toastify'
 import { EnvSyncStatus } from '@/components/syncing/EnvSyncStatus'
@@ -46,7 +47,7 @@ import { SecretInfoLegend } from './SecretInfoLegend'
 import { formatTitle } from '@/utils/meta'
 import MultiEnvImportDialog from '@/components/environments/secrets/import/MultiEnvImportDialog'
 import { TbDownload } from 'react-icons/tb'
-import { duplicateKeysExist } from '@/utils/secrets'
+import { duplicateKeysExist, normalizeKey } from '@/utils/secrets'
 import { useWarnIfUnsavedChanges } from '@/hooks/warnUnsavedChanges'
 import { AppDynamicSecretRow } from '@/ee/components/secrets/dynamic/AppDynamicSecretRow'
 import { AppFolderRow } from './AppFolderRow'
@@ -149,7 +150,7 @@ export const AppSecrets = ({ team, app }: { team: string; app: string }) => {
 
   const filteredFolders = useMemo(() => {
     if (searchQuery === '') return appFolders
-    const re = new RegExp(searchQuery, 'i')
+    const re = new RegExp(escapeRegExp(searchQuery), 'i')
     return appFolders.filter((folder) => re.test(folder.name))
   }, [appFolders, searchQuery])
 
@@ -199,7 +200,7 @@ export const AppSecrets = ({ team, app }: { team: string; app: string }) => {
     searchQuery === ''
       ? clientAppSecrets
       : clientAppSecrets.filter((secret) => {
-          const searchRegex = new RegExp(searchQuery, 'i')
+          const searchRegex = new RegExp(escapeRegExp(searchQuery), 'i')
           const valueMatch = secret.envs.some(
             (env) => env.secret && searchRegex.test(env.secret.value)
           )
@@ -210,7 +211,7 @@ export const AppSecrets = ({ team, app }: { team: string; app: string }) => {
     searchQuery === ''
       ? appDynamicSecrets
       : appDynamicSecrets.filter((secret) => {
-          const searchRegex = new RegExp(searchQuery, 'i')
+          const searchRegex = new RegExp(escapeRegExp(searchQuery), 'i')
           return searchRegex.test(secret.name)
         })
 
@@ -381,16 +382,8 @@ export const AppSecrets = ({ team, app }: { team: string; app: string }) => {
     toast.success('Changes successfully deployed.')
   }
 
-  const normalizeKey = (key: string) => {
-    return key
-      .trim()
-      .toUpperCase()
-      .replace(/[\s-]/g, '_')
-      .replace(/[^A-Z0-9_]/g, '')
-  }
-
-  const handleAddNewClientSecret = (initialKey?: string | any) => {
-    const keyToUse = typeof initialKey === 'string' ? initialKey : ''
+  const handleAddNewClientSecret = (initialKey?: string) => {
+    const keyToUse = initialKey ?? ''
     const envs: EnvironmentType[] = appEnvironments
 
     setClientAppSecrets([
@@ -797,7 +790,7 @@ export const AppSecrets = ({ team, app }: { team: string; app: string }) => {
               <TbDownload /> Import secrets
             </Button>
             {userCanCreateSecrets && (
-              <Button variant="primary" onClick={handleAddNewClientSecret}>
+              <Button variant="primary" onClick={() => handleAddNewClientSecret()}>
                 <FaPlus /> New Secret
               </Button>
             )}
@@ -956,7 +949,7 @@ export const AppSecrets = ({ team, app }: { team: string; app: string }) => {
               <Button variant="outline" onClick={() => importDialogRef.current?.openModal()}>
                 <TbDownload /> Import secrets
               </Button>
-              <Button variant="primary" onClick={handleAddNewClientSecret}>
+              <Button variant="primary" onClick={() => handleAddNewClientSecret()}>
                 <FaPlus /> New Secret
               </Button>
             </div>

--- a/frontend/utils/secrets.ts
+++ b/frontend/utils/secrets.ts
@@ -200,7 +200,7 @@ export const processEnvFile = (
       key: key.toUpperCase(),
       value: withValues ? valueStr : '',
       tags: [],
-      comment: withComments ? (lastComment || inlineComment || '') : '',
+      comment: withComments ? lastComment || inlineComment || '' : '',
       path,
       environment,
     })
@@ -212,12 +212,10 @@ export const processEnvFile = (
   return newSecrets
 }
 
-
 export const duplicateKeysExist = (
   secrets: SecretType[] | AppSecret[],
   dynamicSecrets: DynamicSecretType[] = []
 ): boolean => {
-
   const keySet = new Set<string>()
 
   // Check regular secrets
@@ -244,7 +242,6 @@ export const duplicateKeysExist = (
   return false // No duplicates
 }
 
-
 export const envFilePlaceholder = `# Paste your .env here
 
 # Comments before a key-value pair will be parsed
@@ -269,3 +266,23 @@ export const sortEnvs = (
   envs
     .filter((e): e is Partial<EnvironmentType> => !!e && typeof e.index === 'number')
     .sort((a, b) => a.index! - b.index!)
+
+/**
+ * Normalizes a string into a valid environment variable key.
+ *
+ * This function performs the following operations:
+ * 1. Trims whitespace from both ends.
+ * 2. Converts the string to uppercase.
+ * 3. Replaces spaces and hyphens with underscores.
+ * 4. Removes any characters that are not uppercase letters, numbers, or underscores.
+ *
+ * @param {string} key - The raw key string to normalize.
+ * @returns {string} - The normalized key.
+ */
+export const normalizeKey = (key: string) => {
+  return key
+    .trim()
+    .toUpperCase()
+    .replace(/[\s-]/g, '_')
+    .replace(/[^A-Z0-9_]/g, '')
+}


### PR DESCRIPTION
## :mag: Overview

This PR introduces a quick and easy way to create a secret directly from a search query when no results are found. This is particularly useful for users who search for a secret, realize it's missing, and want to create it immediately without manually re-typing the key.

## :bulb: Proposed Changes

- **In-place Secret Creation from Search:** Added a "Create" button to the empty search results state in both the App-wide Secrets view and individual Environment views.
- **Key Normalization:** Implemented a normalization helper that automatically formats the search query into a standard secret key format (uppercase, underscores instead of spaces/hyphens, special characters removed).
- **Search-to-Draft Flow:** Clicking the create button pre-fills a new secret draft with the normalized key and clears the search query, allowing for an immediate "search-to-edit" transition.
- **Improved Empty State Logic:** Fixed a bug in the App Home view where searching while having zero secrets would incorrectly trigger the generic "No Secrets" state instead of the search results state.

## :framed_picture: Screenshots or Demo

<img width="2219" height="1363" alt="image" src="https://github.com/user-attachments/assets/0b750e66-6ecf-4b04-bf40-42ef6a81fdc6" />

## :memo: Release Notes

Users can now quickly create secrets from their search queries. When a search returns no results, a button appears to create a new secret with the key automatically pre-filled and normalized (e.g., searching for "api-key" will offer to create "API_KEY").

## :question: Open Questions

None at this time.

### :test_tube: Testing

- **Manual Testing:**
    - Verified search-to-create flow in the App Home view (across all environments).
    - Verified search-to-create flow within a specific Environment view.
    - Confirmed normalization works for spaces (`my key` -> `MY_KEY`), hyphens (`my-key` -> `MY_KEY`), and special characters (`my key!` -> `MY_KEY`).
    - Verified the fix for the "zero secrets + search" edge case.
- **Permissions:** Confirmed the button only appears for users with `Secrets:create` permissions.

### :dart: Reviewer Focus

- `frontend/app/[team]/apps/[app]/_components/AppSecrets.tsx`: Focus on the state logic change that ensures search results take precedence over the generic empty state.
- `frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx`: Focus on the conditional rendering of the create button within the `EmptyState`.

### :heavy_plus_sign: Additional Context

This improvement reduces friction in the secret management workflow, especially during initial setup or when expanding existing configurations.

## :sparkles: How to Test the Changes Locally

1. Navigate to any App Secrets home screen.
2. Search for a key that doesn't exist (e.g., `TEST_NEW_SECRET`).
3. Click the **Create "TEST_NEW_SECRET"** button.
4. Verify that a new row is added with the key pre-filled and the search box is cleared.
5. Repeat the process within a specific environment (e.g., Development).

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
- [ ] Update dependencies and lockfiles (if required)
- [ ] Update migrations (if required)
- [ ] Regenerate graphql schema and types (if required)
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a search-to-create workflow and improves search/filtering for secrets.
> 
> - Adds a “Create "<normalized>"” action in empty search states (app-wide and environment views) gated by `Secrets:create`; creates a new draft with a normalized key and clears the query
> - Implements `normalizeKey` helper and updates add-secret functions to accept an initial key
> - Expands search to match secret values (not just keys) and updates input placeholders to “Search keys or values”
> - Adjusts empty state conditions so search results take precedence and the create action appears when no matches are found
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 38bfc912b4d802075993ed607ccee23631bc1c13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->