### PR TITLE
fix: filter out deleted accounts from apps.service_accounts

### DIFF
--- a/backend/backend/graphene/types.py
+++ b/backend/backend/graphene/types.py
@@ -627,6 +627,7 @@ class EnvironmentType(DjangoObjectType):
 class AppType(DjangoObjectType):
     environments = graphene.NonNull(graphene.List(EnvironmentType))
     members = graphene.NonNull(graphene.List(OrganisationMemberType))
+    service_accounts = graphene.NonNull(graphene.List(lambda: ServiceAccountType))
 
     class Meta:
         model = App
@@ -683,6 +684,9 @@ class AppType(DjangoObjectType):
 
     def resolve_members(self, info):
         return self.members.filter(deleted_at=None)
+
+    def resolve_service_accounts(self, info):
+        return self.service_accounts.filter(deleted_at=None)
 
 
 class AppMembershipType(DjangoObjectType):


### PR DESCRIPTION
## :mag: Overview

Fixes the apps.service_accounts field resolver to filter out deleted accounts

## :sparkles: How to Test the Changes Locally

* Add a service account to an app
* Verify that it appears on the apps list page as an app account (`<org>/apps`)
* Delete the service account from the org
* Verify that the account is no longer shown on the apps list page

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
~~- [ ] Update dependencies and lockfiles (if required)~~
~~- [ ] Update migrations (if required)~~
~~- [ ] Regenerate graphql schema and types (if required)~~
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
