### PR TITLE
chore(deps): bump posthog-js from 1.335.3 to 1.341.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,7 @@
     "next": "^14.2.35",
     "next-auth": "^4.24.13",
     "nextjs-toploader": "^3.8.16",
-    "posthog-js": "^1.335.3",
+    "posthog-js": "^1.341.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.5.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2032,17 +2032,17 @@
     tiny-glob "^0.2.9"
     tslib "^2.4.0"
 
-"@posthog/core@1.14.0":
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/@posthog/core/-/core-1.14.0.tgz#9efbfb24c2b672db17b3ac29c483cab6a7f72890"
-  integrity sha512-havjGYHwL8Gy6LXIR911h+M/sYlJLQbepxP/cc1M7Cp3v8F92bzpqkbuvUIUyb7/izkxfGwc9wMqKAo0QxMTrg==
+"@posthog/core@1.20.0":
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/@posthog/core/-/core-1.20.0.tgz#b529cf017c23037e6202eecb7fa1ac554d731fb8"
+  integrity sha512-e/F20we0t6bPMuDOVOe53f908s23vuKEpFKNXmZcx4bSYsPkjRN49akIIHU621HBJdcsFx537vhJYKZxu8uS9w==
   dependencies:
     cross-spawn "^7.0.6"
 
-"@posthog/types@1.335.3":
-  version "1.335.3"
-  resolved "https://registry.yarnpkg.com/@posthog/types/-/types-1.335.3.tgz#e90099a646a450ef4753edf0d02d939ba1579260"
-  integrity sha512-mReFmfI+ep5sH3cnFhjvWfOcl3j6olKpN5lHFbOomLGxYTHMXcyMUBE3/o8WfrAgR1qxKQUsWMNcv6BhLr/GKA==
+"@posthog/types@1.341.0":
+  version "1.341.0"
+  resolved "https://registry.yarnpkg.com/@posthog/types/-/types-1.341.0.tgz#6feb4557c1cefdf334155c56a00acc411b87c7a2"
+  integrity sha512-lIQzaPzfxdhonj2nXI2Nh3z45wyfb/e48cyy/+GawNDeRnkzqyhifpyAimVafBJIP7RR1lQqEnM8Xk55H7SRgQ==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -7264,22 +7264,22 @@ postcss@^8.4.23, postcss@^8.4.33:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
-posthog-js@^1.335.3:
-  version "1.335.3"
-  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.335.3.tgz#3b17d4075fc522984f82a1f568187c0ff8308978"
-  integrity sha512-ZQg3ozgsPom+SZtAxMN97Zx9Vqkdsv1D4TZU/OqbAZdm27PswV6+ShBurm3nKm9jrlUU1cGHMRn2ZJZf249znQ==
+posthog-js@^1.341.0:
+  version "1.341.0"
+  resolved "https://registry.yarnpkg.com/posthog-js/-/posthog-js-1.341.0.tgz#41d8c62332c7b6ca3dee54c259a5dcc7ecd191d7"
+  integrity sha512-sWa/84yi93ar/SJrG0do5QshCGWqUH39cNLrngN/GqC8kA5JLxyUEBmFaK65aAxrSKJ1muGP11ofIKDCwQn98Q==
   dependencies:
     "@opentelemetry/api" "^1.9.0"
     "@opentelemetry/api-logs" "^0.208.0"
     "@opentelemetry/exporter-logs-otlp-http" "^0.208.0"
     "@opentelemetry/resources" "^2.2.0"
     "@opentelemetry/sdk-logs" "^0.208.0"
-    "@posthog/core" "1.14.0"
-    "@posthog/types" "1.335.3"
+    "@posthog/core" "1.20.0"
+    "@posthog/types" "1.341.0"
     core-js "^3.38.1"
     dompurify "^3.3.1"
     fflate "^0.4.8"
-    preact "^10.28.0"
+    preact "^10.28.2"
     query-selector-shadow-dom "^1.0.1"
     web-vitals "^5.1.0"
 
@@ -7289,10 +7289,10 @@ preact-render-to-string@^5.1.19:
   dependencies:
     pretty-format "^3.8.0"
 
-preact@^10.28.0:
-  version "10.28.2"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.28.2.tgz#4b668383afa4b4a2546bbe4bd1747e02e2360138"
-  integrity sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==
+preact@^10.28.2:
+  version "10.28.3"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.28.3.tgz#3c2171526b3e29628ad1a6c56a9e3ca867bbdee8"
+  integrity sha512-tCmoRkPQLpBeWzpmbhryairGnhW9tKV6c6gr/w+RhoRoKEJwsjzipwp//1oCpGPOchvSLaAPlpcJi9MwMmoPyA==
 
 preact@^10.6.3:
   version "10.13.2"


### PR DESCRIPTION
## Summary
- Bumps `posthog-js` from 1.335.3 to 1.341.0 in the frontend

## Test plan
- [x] Verify the app builds successfully
- [x] Confirm PostHog analytics events are tracked correctly in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)