### PR TITLE
fix: accurate empty state copy for add members/service accounts dialogs

### DIFF
--- a/frontend/app/[team]/apps/[app]/access/members/_components/AddMemberDialog.tsx
+++ b/frontend/app/[team]/apps/[app]/access/members/_components/AddMemberDialog.tsx
@@ -376,8 +376,9 @@ export const AddMemberDialog = ({ appId }: { appId: string }) => {
             <Alert variant="info" icon={true}>
               <div className="flex flex-col gap-2">
                 <p>
-                  All organisation members are added to this App. You can invite more users from the
-                  organisation members page.
+                  {orgMembersData?.organisationMembers?.length <= 1
+                    ? 'There are no other members in this organisation to add. You can invite more users from the organisation members page.'
+                    : 'All organisation members are added to this App. You can invite more users from the organisation members page.'}
                 </p>
                 <Link href={`/${organisation?.name}/access/members`}>
                   <Button variant="secondary">

--- a/frontend/app/[team]/apps/[app]/access/service-accounts/_components/AddAccountDialog.tsx
+++ b/frontend/app/[team]/apps/[app]/access/service-accounts/_components/AddAccountDialog.tsx
@@ -373,8 +373,9 @@ export const AddAccountDialog = ({ appId }: { appId: string }) => {
             <Alert variant="info" icon={true}>
               <div className="flex flex-col gap-2">
                 <p>
-                  All organisation service accounts are added to this App. You can create more
-                  service accounts from the organisation access page.
+                  {serviceAccountsData?.serviceAccounts?.length === 0
+                    ? 'No service accounts exist in this organisation. You can create service accounts from the organisation access page.'
+                    : 'All organisation service accounts are added to this App. You can create more service accounts from the organisation access page.'}
                 </p>
                 <Link href={`/${organisation?.name}/access/service-accounts`}>
                   <Button variant="secondary">


### PR DESCRIPTION
## Summary
- **Service Accounts dialog**: When no service accounts exist in the org, now shows "No service accounts exist in this organisation" instead of the misleading "All organisation service accounts are added to this App"
- **Members dialog**: When no other org members are available (e.g. single-member org), now shows "There are no other members in this organisation to add" instead of the misleading "All organisation members are added to this App"

## Test plan
- [ ] Open an app's service accounts tab with no org-level service accounts created — verify the new copy appears
- [ ] Open an app's service accounts tab with all org service accounts already added — verify the existing copy still appears
- [ ] Open an app's members tab as the only org member — verify the new copy appears
- [ ] Open an app's members tab with all org members already added — verify the existing copy still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)