### PR TITLE
fix: set up an integration link to docs

### DIFF
--- a/frontend/components/dashboard/GetStarted.tsx
+++ b/frontend/components/dashboard/GetStarted.tsx
@@ -483,7 +483,7 @@ export const GetStarted = (props: { organisation: OrganisationType }) => {
                       <Button variant="primary">Go to Integrations</Button>
                     </Link>
                     <Link
-                      href="https://docs.phase.dev/console/users#add-users-to-an-organisation"
+                      href="https://docs.phase.dev/integrations/platforms/docker"
                       target="_blank"
                     >
                       <Button variant="secondary">View Docs</Button>


### PR DESCRIPTION
## Summary
- Fixes the "View Docs" button in the "Set up an Integration" section on the home page
- Was incorrectly linking to the members docs URL (`/console/users#add-users-to-an-organisation`)
- Now correctly links to `https://docs.phase.dev/integrations/platforms/docker`

🤖 Generated with [Claude Code](https://claude.com/claude-code)