### PR TITLE
fix: misc typography and spacing issues on access pages

### DIFF
--- a/frontend/app/[team]/access/members/[memberId]/page.tsx
+++ b/frontend/app/[team]/access/members/[memberId]/page.tsx
@@ -139,16 +139,16 @@ export default function MemberDetail({ params }: { params: { team: string; membe
 
   return (
     <section className="flex flex-col px-3 sm:px-4 lg:px-6">
-      <div className="pb-4 px-4 md:px-6 pt-4">
+      <div className="pb-4">
         <Link
           href={`/${params.team}/access/members`}
-          className="text-neutral-500 flex items-center gap-2 text-sm hover:text-zinc-800 dark:hover:text-zinc-200 transition ease"
+          className="text-neutral-500 inline-flex items-center gap-2 text-sm hover:text-zinc-800 dark:hover:text-zinc-200 transition ease"
         >
           <FaChevronLeft /> Back to members
         </Link>
       </div>
-      <div className="flex-grow overflow-y-auto px-4 md:px-6 space-y-6 pb-8">
-        <div className="pt-4">
+      <div className="flex-grow overflow-y-auto space-y-6 py-4">
+        <div>
           <div className="flex items-center gap-3">
             <Avatar member={member} size="xl" />
             <div className="flex flex-col gap-0.5">

--- a/frontend/app/[team]/access/service-accounts/[account]/page.tsx
+++ b/frontend/app/[team]/access/service-accounts/[account]/page.tsx
@@ -148,7 +148,7 @@ export default function ServiceAccount({ params }: { params: { team: string; acc
             <div>
               <h3 className="relative group w-full max-w-md">
                 <input
-                  className="custom bg-transparent hover:bg-neutral-500/10 rounded-lg transition ease w-full "
+                  className="custom bg-transparent hover:bg-neutral-500/10 rounded-lg transition ease w-full text-base font-medium"
                   value={name}
                   onChange={(e) => setName(e.target.value)}
                   readOnly={!userCanUpdateSA}

--- a/frontend/app/[team]/access/service-accounts/page.tsx
+++ b/frontend/app/[team]/access/service-accounts/page.tsx
@@ -122,7 +122,7 @@ export default function ServiceAccounts({ params }: { params: { team: string } }
                         <Avatar serviceAccount={account} />
                         <div>
                           <div className="font-medium">{account.name}</div>
-                          <div className="text-sm text-neutral-500">{account.id}</div>
+                          <div className="text-sm text-neutral-500 font-mono">{account.id}</div>
                         </div>
                       </td>
 


### PR DESCRIPTION
## Summary

- Fixed inconsistent horizontal padding on member detail page by removing redundant inner `px-4 md:px-6` (outer section padding already handles this), matching the service account detail layout
- Added explicit `text-base font-medium` to service account name input so it renders at the same size as the member name heading
- Added `font-mono` to service account ID on the list page for consistency with other ID displays

## Screenshots

<img width="1185" height="759" alt="image" src="https://github.com/user-attachments/assets/95c8e421-f9c1-4498-9975-5cb364548967" />

<img width="1185" height="759" alt="image" src="https://github.com/user-attachments/assets/36482a70-e7f9-4899-9aee-e8319f307822" />

<img width="1185" height="759" alt="image" src="https://github.com/user-attachments/assets/87fde945-834a-4b70-8e99-044bac5ad27a" />
