### PR TITLE
fix: restore fallback chain in get_client_ip to prevent None IP 

### DIFF
--- a/backend/api/utils/access/ip.py
+++ b/backend/api/utils/access/ip.py
@@ -1,9 +1,23 @@
 from ipaddress import ip_address
 
 
+def _validate_ip(raw_ip):
+    """Validate and return a cleaned IP string, or None if invalid."""
+    raw_ip = (raw_ip or "").strip()
+    if not raw_ip:
+        return None
+    try:
+        ip_address(raw_ip)
+        return raw_ip
+    except ValueError:
+        return None
+
+
 def get_client_ip(request):
     """
     Get the client IP address as a single string.
+
+    Checks headers in order: X-Real-IP, X-Forwarded-For (first IP), REMOTE_ADDR.
 
     Args:
         request: Django request object
@@ -11,11 +25,18 @@ def get_client_ip(request):
     Returns:
         str | None: The client IP address (IPv4 or IPv6)
     """
-    raw_ip = (request.META.get("HTTP_X_REAL_IP") or "").strip()
-    if not raw_ip:
-        return None
-    try:
-        ip_address(raw_ip)
-    except ValueError:
-        return None
-    return raw_ip
+    # Prefer X-Real-IP (set by nginx)
+    ip = _validate_ip(request.META.get("HTTP_X_REAL_IP"))
+    if ip:
+        return ip
+
+    # Fall back to X-Forwarded-For (first entry is the original client)
+    x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR", "")
+    if x_forwarded_for:
+        first_ip = x_forwarded_for.split(",")[0]
+        ip = _validate_ip(first_ip)
+        if ip:
+            return ip
+
+    # Fall back to REMOTE_ADDR (always set by WSGI)
+    return _validate_ip(request.META.get("REMOTE_ADDR"))

--- a/backend/tests/api/utils/access/test_ip.py
+++ b/backend/tests/api/utils/access/test_ip.py
@@ -1,0 +1,91 @@
+import pytest
+from unittest.mock import MagicMock
+from api.utils.access.ip import get_client_ip, _validate_ip
+
+
+class TestValidateIp:
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("1.2.3.4", "1.2.3.4"),
+            ("  1.2.3.4  ", "1.2.3.4"),
+            ("::1", "::1"),
+            ("2001:db8::1", "2001:db8::1"),
+            ("", None),
+            ("   ", None),
+            (None, None),
+            ("not-an-ip", None),
+            ("999.999.999.999", None),
+            ("1.2.3.4/24", None),
+        ],
+    )
+    def test_validate_ip(self, raw, expected):
+        assert _validate_ip(raw) == expected
+
+
+def _make_request(**meta):
+    req = MagicMock()
+    req.META = meta
+    return req
+
+
+class TestGetClientIp:
+    def test_x_real_ip_preferred(self):
+        req = _make_request(
+            HTTP_X_REAL_IP="10.0.0.1",
+            HTTP_X_FORWARDED_FOR="10.0.0.2, 10.0.0.3",
+            REMOTE_ADDR="10.0.0.4",
+        )
+        assert get_client_ip(req) == "10.0.0.1"
+
+    def test_falls_back_to_x_forwarded_for(self):
+        req = _make_request(
+            HTTP_X_FORWARDED_FOR="203.0.113.50, 70.41.3.18",
+            REMOTE_ADDR="127.0.0.1",
+        )
+        assert get_client_ip(req) == "203.0.113.50"
+
+    def test_x_forwarded_for_single_entry(self):
+        req = _make_request(HTTP_X_FORWARDED_FOR="203.0.113.50")
+        assert get_client_ip(req) == "203.0.113.50"
+
+    def test_falls_back_to_remote_addr(self):
+        req = _make_request(REMOTE_ADDR="192.168.1.1")
+        assert get_client_ip(req) == "192.168.1.1"
+
+    def test_no_headers_returns_none(self):
+        req = _make_request()
+        assert get_client_ip(req) is None
+
+    def test_invalid_x_real_ip_falls_through(self):
+        req = _make_request(
+            HTTP_X_REAL_IP="garbage",
+            REMOTE_ADDR="10.0.0.1",
+        )
+        assert get_client_ip(req) == "10.0.0.1"
+
+    def test_invalid_x_forwarded_for_falls_through(self):
+        req = _make_request(
+            HTTP_X_FORWARDED_FOR="garbage, 10.0.0.2",
+            REMOTE_ADDR="10.0.0.1",
+        )
+        # First entry is invalid, so falls through to REMOTE_ADDR
+        assert get_client_ip(req) == "10.0.0.1"
+
+    def test_ipv6_x_real_ip(self):
+        req = _make_request(HTTP_X_REAL_IP="2001:db8::1")
+        assert get_client_ip(req) == "2001:db8::1"
+
+    def test_empty_x_real_ip_falls_through(self):
+        req = _make_request(
+            HTTP_X_REAL_IP="",
+            REMOTE_ADDR="10.0.0.1",
+        )
+        assert get_client_ip(req) == "10.0.0.1"
+
+    def test_whitespace_only_x_real_ip_falls_through(self):
+        req = _make_request(
+            HTTP_X_REAL_IP="   ",
+            HTTP_X_FORWARDED_FOR="203.0.113.50",
+        )
+        assert get_client_ip(req) == "203.0.113.50"


### PR DESCRIPTION
## Summary
- Login alert emails display `None` as the IP address in production because `get_client_ip` only checks the `X-Real-IP` header with no fallback
- The fallback headers (`X-Forwarded-For`, `REMOTE_ADDR`) were removed in #687 — they were in fact necessary
- Restores a proper fallback chain: `X-Real-IP` → `X-Forwarded-For` (first entry) → `REMOTE_ADDR`, with `ipaddress` module validation on each candidate

## Root cause

In #687, commit `7ca1e304` removed all fallback headers from `get_client_ip`, and follow-up `b5fe1d39` only restored null safety (`or ""`) but not the fallback chain itself. Any deployment where `X-Real-IP` isn't set by the reverse proxy results in `None`.

## Test plan
- [x] Deploy to staging and verify login alert emails show the correct client IP
- [x] Verify IP is correct when behind Cloudflare (`CF-Connecting-IP` → nginx `X-Real-IP`)
- [x] Verify IP is present when accessing directly (falls back to `REMOTE_ADDR`)
- [x] Verify `NetworkAccessPolicy` / IP allowlist middleware still works (also uses `get_client_ip`)
