### PR TITLE
fix: apply rate limiting to /secrets/tokens/ endpoint

### DIFF
--- a/backend/api/views/auth.py
+++ b/backend/api/views/auth.py
@@ -26,7 +26,8 @@ from django.http import JsonResponse
 from api.authentication.adapters.gitlab import CustomGitLabOAuth2Adapter
 from api.authentication.adapters.google import CustomGoogleOAuth2Adapter
 from api.authentication.adapters.github import CustomGitHubOAuth2Adapter
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import api_view, permission_classes, throttle_classes
+from api.throttling import PlanBasedRateThrottle
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework import status
@@ -188,6 +189,7 @@ def service_token_kms(request):
         AllowAny,
     ]
 )
+@throttle_classes([PlanBasedRateThrottle])
 def secrets_tokens(request):
     auth_token = request.headers["authorization"]
 


### PR DESCRIPTION
## Summary

- Adds `PlanBasedRateThrottle` to the `/secrets/tokens/` REST API endpoint, which was previously unthrottled while all other secrets-related endpoints already enforced plan-based rate limiting.

## Test plan

- [x] Verify `/secrets/tokens/` returns `429 Too Many Requests` when rate limit is exceeded
- [x] Verify normal requests still succeed under the limit