### PR TITLE
Fix GitHub OAuth issuer validation

### DIFF
--- a/frontend/ee/authentication/sso/oidc/util/githubEnterpriseProvider.ts
+++ b/frontend/ee/authentication/sso/oidc/util/githubEnterpriseProvider.ts
@@ -17,6 +17,7 @@ export default function GitHubEnterpriseProvider<P extends GithubProfile>(
     id: 'github-enterprise',
     name: 'GitHub Enterprise',
     type: 'oauth',
+    issuer: `${baseUrl}/login/oauth`,
     authorization: {
       url: `${baseUrl}/login/oauth/authorize`,
       params: { scope: 'read:user user:email' },

--- a/frontend/pages/api/auth/[...nextauth].ts
+++ b/frontend/pages/api/auth/[...nextauth].ts
@@ -48,6 +48,7 @@ export const authOptions: NextAuthOptionsCallback = (_req, res) => {
         GitHubProvider({
           clientId: process.env.GITHUB_CLIENT_ID,
           clientSecret: clientSecret,
+          issuer: 'https://github.com/login/oauth',
         })
       )
     }


### PR DESCRIPTION
## Summary
- set the issuer for the standard GitHub NextAuth provider
- set the issuer for the GitHub Enterprise NextAuth provider
