### PR TITLE
ci: native arm64 runners for PR builds (replace QEMU emulation)

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -11,8 +11,10 @@ on:
         type: string
 
 jobs:
-  build_and_push:
+  test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -34,6 +36,124 @@ jobs:
           cd backend
           pytest tests/ -v
 
+  build:
+    if: inputs.is_pr == 'true'
+    needs: test
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./backend
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,"name=phasehq/backend-staging,ghcr.io/${{ github.repository }}/backend-staging",push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=backend-${{ matrix.arch }}
+          cache-to: type=gha,scope=backend-${{ matrix.arch }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    if: inputs.is_pr == 'true'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: backend-digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifest (DockerHub)
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            -t phasehq/backend-staging:${{ inputs.version }} \
+            $(printf 'phasehq/backend-staging@sha256:%s ' *)
+
+      - name: Create multi-arch manifest (GHCR)
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            -t ghcr.io/${{ github.repository }}/backend-staging:${{ inputs.version }} \
+            $(printf 'ghcr.io/${{ github.repository }}/backend-staging@sha256:%s ' *)
+
+  # --- Release path: existing buildx flow (unchanged) ---
+
+  build_and_push:
+    if: inputs.is_pr != 'true'
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -53,22 +173,15 @@ jobs:
       - name: Generate tags
         id: meta
         run: |
-          if [[ "${{ inputs.is_pr }}" == "true" ]]; then
-            # PR build - staging image with commit hash as version tag
-            echo "DOCKER_TAGS=phasehq/backend-staging:${{ inputs.version }}" >> $GITHUB_ENV
-            echo "GHCR_TAGS=ghcr.io/${{ github.repository }}/backend-staging:${{ inputs.version }}" >> $GITHUB_ENV
-          else
-            # Release build - production image with version (vX.XX.XX) and :latest tags
-            echo "DOCKER_TAGS=phasehq/backend:${{ inputs.version }},phasehq/backend:latest" >> $GITHUB_ENV
-            echo "GHCR_TAGS=ghcr.io/${{ github.repository }}/backend:${{ inputs.version }},ghcr.io/${{ github.repository }}/backend:latest" >> $GITHUB_ENV
-          fi
+          echo "DOCKER_TAGS=phasehq/backend:${{ inputs.version }},phasehq/backend:latest" >> $GITHUB_ENV
+          echo "GHCR_TAGS=ghcr.io/${{ github.repository }}/backend:${{ inputs.version }},ghcr.io/${{ github.repository }}/backend:latest" >> $GITHUB_ENV
 
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
           context: ./backend
           push: true
-          platforms: ${{ inputs.is_pr == 'true' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.DOCKER_TAGS }}
             ${{ env.GHCR_TAGS }}

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -11,8 +11,10 @@ on:
         type: string
 
 jobs:
-  build_and_push:
+  test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -31,6 +33,122 @@ jobs:
         run: |
           cd frontend
           yarn test
+
+  build:
+    if: inputs.is_pr == 'true'
+    needs: test
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ./frontend
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,"name=phasehq/frontend-staging,ghcr.io/${{ github.repository }}/frontend-staging",push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=frontend-${{ matrix.arch }}
+          cache-to: type=gha,scope=frontend-${{ matrix.arch }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p ${{ runner.temp }}/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    if: inputs.is_pr == 'true'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: frontend-digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifest (DockerHub)
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            -t phasehq/frontend-staging:${{ inputs.version }} \
+            $(printf 'phasehq/frontend-staging@sha256:%s ' *)
+
+      - name: Create multi-arch manifest (GHCR)
+        working-directory: ${{ runner.temp }}/digests
+        run: |
+          docker buildx imagetools create \
+            -t ghcr.io/${{ github.repository }}/frontend-staging:${{ inputs.version }} \
+            $(printf 'ghcr.io/${{ github.repository }}/frontend-staging@sha256:%s ' *)
+
+  build_and_push:
+    if: inputs.is_pr != 'true'
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -51,22 +169,15 @@ jobs:
       - name: Generate tags
         id: meta
         run: |
-          if [[ "${{ inputs.is_pr }}" == "true" ]]; then
-            # PR build - staging image with commit hash as version tag
-            echo "DOCKER_TAGS=phasehq/frontend-staging:${{ inputs.version }}" >> $GITHUB_ENV
-            echo "GHCR_TAGS=ghcr.io/${{ github.repository }}/frontend-staging:${{ inputs.version }}" >> $GITHUB_ENV
-          else
-            # Release build - production image with version (vX.XX.XX) and :latest tags
-            echo "DOCKER_TAGS=phasehq/frontend:${{ inputs.version }},phasehq/frontend:latest" >> $GITHUB_ENV
-            echo "GHCR_TAGS=ghcr.io/${{ github.repository }}/frontend:${{ inputs.version }},ghcr.io/${{ github.repository }}/frontend:latest" >> $GITHUB_ENV
-          fi
+          echo "DOCKER_TAGS=phasehq/frontend:${{ inputs.version }},phasehq/frontend:latest" >> $GITHUB_ENV
+          echo "GHCR_TAGS=ghcr.io/${{ github.repository }}/frontend:${{ inputs.version }},ghcr.io/${{ github.repository }}/frontend:latest" >> $GITHUB_ENV
 
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
           context: ./frontend
           push: true
-          platforms: ${{ inputs.is_pr == 'true' && 'linux/amd64' || 'linux/amd64,linux/arm64' }}
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ env.DOCKER_TAGS }}
             ${{ env.GHCR_TAGS }}


### PR DESCRIPTION
## Summary

Splits the staging/PR Docker build off the legacy single-runner buildx flow onto a matrix that uses native runners per architecture, then merges them into a single multi-arch manifest by digest. Release builds (the `:version` + `:latest` push to `phasehq/backend` and `phasehq/frontend`) are intentionally left on the existing flow — this PR only touches the staging path.

Cherry-picked from #820 (workflow changes only — the URL routing changes from that PR are not included here).

### What changed

- `test` job is now a separate job that both build paths depend on.
- New `build` job (PR/staging only): matrix over `ubuntu-latest` (amd64) and `ubuntu-24.04-arm` (arm64), each builds + pushes by digest to DockerHub and GHCR.
- New `merge` job (PR/staging only): downloads digest artifacts and assembles a multi-arch manifest with `docker buildx imagetools create`.
- Existing `build_and_push` job kept for release path (`is_pr != 'true'`), unchanged in substance.
- Per-arch GHA cache scopes (`scope=backend-amd64` / `scope=backend-arm64`) so the two arches don't fight over a shared cache key.
- Explicit `permissions:` blocks on every job to satisfy CodeQL.

### Why

ARM64 staging builds were going through QEMU on an AMD64 runner — typically ~10–20 minutes per arch, serialized inside one buildx invocation. Native arm64 runners build in their own architecture and run in parallel with amd64, so wall-clock drops substantially.

### Not in scope (follow-up)

Release builds (`:version` + `:latest`) still use the old single-runner cross-compile flow. Migrating those should be a follow-up once we've validated the staging matrix in CI.

## Test plan

- [x] PR build kicks off `test` → `build (amd64)` + `build (arm64)` in parallel → `merge`
- [x] `phasehq/backend-staging:<sha>` and `ghcr.io/phasehq/console/backend-staging:<sha>` resolve as multi-arch manifests
- [x] `phasehq/frontend-staging:<sha>` and `ghcr.io/phasehq/console/frontend-staging:<sha>` resolve as multi-arch manifests
- [x] `docker manifest inspect` on each shows both `linux/amd64` and `linux/arm64` entries
- [x] Release build path (`is_pr != 'true'`) still produces multi-arch `phasehq/backend:<version>` / `:latest` and the frontend equivalents