### PR TITLE
fix: validate identity_key against member's keyring, not org owner's

### DIFF
--- a/backend/backend/graphene/mutations/organisation.py
+++ b/backend/backend/graphene/mutations/organisation.py
@@ -92,16 +92,18 @@ class CreateOrganisationMutation(graphene.Mutation):
 
 
 class UpdateUserWrappedSecretsMutation(graphene.Mutation):
-    """Re-wrap THIS org's keyring after the caller proves they hold the
+    """Re-wrap this member's keyring after the caller proves they hold the
     recovery mnemonic. Used by SSO recovery (where there's no login
     password to verify against, so identity is proven via the mnemonic
     alone).
 
-    Requires identity_key matching the org's stored identity_key — proves
-    the caller derived the keyring from the right mnemonic. Without this
-    proof, an authenticated user (or session-cookie holder) could
-    overwrite their own wrapped_keyring with arbitrary garbage and lock
-    themselves out of the org permanently.
+    Requires identity_key matching the member's stored identity_key —
+    proves the caller derived the keyring from the same mnemonic they
+    registered with. Without this, an authenticated session could
+    overwrite the wrapped_keyring with a foreign identity and lock the
+    member out of the org permanently. Every Phase user has their own
+    independently-derived keyring, so this check must be against the
+    member's identity_key, not the org's (which is the owner's).
     """
 
     class Arguments:
@@ -119,15 +121,15 @@ class UpdateUserWrappedSecretsMutation(graphene.Mutation):
         except Organisation.DoesNotExist:
             raise GraphQLError("Organisation not found.")
 
-        if org.identity_key != identity_key:
-            raise GraphQLError("Invalid recovery proof.")
-
         try:
             org_member = OrganisationMember.objects.get(
                 organisation=org, user=info.context.user, deleted_at=None
             )
         except OrganisationMember.DoesNotExist:
             raise GraphQLError("Not a member of this organisation.")
+
+        if org_member.identity_key != identity_key:
+            raise GraphQLError("Invalid recovery proof.")
 
         org_member.wrapped_keyring = wrapped_keyring
         org_member.wrapped_recovery = wrapped_recovery
@@ -137,14 +139,17 @@ class UpdateUserWrappedSecretsMutation(graphene.Mutation):
 
 
 class RecoverAccountKeyringMutation(graphene.Mutation):
-    """Rewrap THIS org's keyring with a deviceKey derived from the user's
-    account password. Used by the recovery flow when the local keyring
-    has been lost (cleared cache, new device) but the user still
+    """Rewrap this member's keyring with a deviceKey derived from the
+    user's account password. Used by the recovery flow when the local
+    keyring has been lost (cleared cache, new device) but the user still
     remembers their password.
 
     Two server-side proofs are required:
-      1. identity_key matches the org's stored identity_key — proves the
-         caller derived the keyring from the right mnemonic.
+      1. identity_key matches the member's stored identity_key — proves
+         the caller derived the keyring from the same mnemonic they
+         registered with. Every Phase user has their own keyring, so
+         this is checked against the member's identity_key, not the
+         org's (which is the owner's).
       2. auth_hash matches user.password — proves the password the user
          is wrapping the keyring with is also their account login auth.
 
@@ -191,15 +196,15 @@ class RecoverAccountKeyringMutation(graphene.Mutation):
         except Organisation.DoesNotExist:
             raise GraphQLError("Organisation not found.")
 
-        if org.identity_key != identity_key:
-            raise GraphQLError("Invalid recovery proof.")
-
         try:
             org_member = OrganisationMember.objects.get(
                 user=user, organisation=org, deleted_at=None
             )
         except OrganisationMember.DoesNotExist:
             raise GraphQLError("Not a member of this organisation.")
+
+        if org_member.identity_key != identity_key:
+            raise GraphQLError("Invalid recovery proof.")
 
         if not user.check_password(auth_hash):
             raise GraphQLError(
@@ -234,8 +239,11 @@ class ChangeAccountPasswordMutation(graphene.Mutation):
     Three server-side proofs are required:
       1. current_auth_hash matches user.password — proves the caller
          knows the current login password.
-      2. identity_key matches the org's stored identity_key — proves the
-         caller derived the keyring from the right mnemonic.
+      2. identity_key matches the member's stored identity_key — proves
+         the caller derived the keyring from the same mnemonic they
+         registered with. Every Phase user has their own keyring, so
+         this is checked against the member's identity_key, not the
+         org's (which is the owner's).
       3. user is a member of the org.
 
     On success: user.password is set to new_auth_hash, the org's
@@ -289,15 +297,15 @@ class ChangeAccountPasswordMutation(graphene.Mutation):
         except Organisation.DoesNotExist:
             raise GraphQLError("Organisation not found.")
 
-        if org.identity_key != identity_key:
-            raise GraphQLError("Invalid recovery proof.")
-
         try:
             org_member = OrganisationMember.objects.get(
                 user=user, organisation=org, deleted_at=None
             )
         except OrganisationMember.DoesNotExist:
             raise GraphQLError("Not a member of this organisation.")
+
+        if org_member.identity_key != identity_key:
+            raise GraphQLError("Invalid recovery proof.")
 
         with transaction.atomic():
             user.set_password(new_auth_hash)

--- a/backend/tests/test_auth_password.py
+++ b/backend/tests/test_auth_password.py
@@ -981,10 +981,10 @@ class PasswordChangeFlowTest(_ThrottleClearMixin, unittest.TestCase):
         user.check_password.return_value = True
 
         org = MagicMock()
-        org.identity_key = "matching_key"
         mock_org.objects.get.return_value = org
 
         org_member = MagicMock()
+        org_member.identity_key = "matching_key"
         mock_om.objects.get.return_value = org_member
 
         result = ChangeAccountPasswordMutation.mutate(
@@ -1033,8 +1033,8 @@ class PasswordChangeFlowTest(_ThrottleClearMixin, unittest.TestCase):
     @patch("backend.graphene.mutations.organisation.OrganisationMember")
     @patch("backend.graphene.mutations.organisation.Organisation")
     def test_password_change_rejects_wrong_identity_key(self, mock_org, mock_om):
-        """Mnemonic must match the org's stored identity_key — proves the
-        user has the keyring material and isn't just guessing UUIDs."""
+        """Mnemonic must match the member's stored identity_key — proves
+        the user has the keyring material and isn't just guessing UUIDs."""
         from graphql import GraphQLError
         from backend.graphene.mutations.organisation import (
             ChangeAccountPasswordMutation,
@@ -1044,8 +1044,11 @@ class PasswordChangeFlowTest(_ThrottleClearMixin, unittest.TestCase):
         user.check_password.return_value = True
 
         org = MagicMock()
-        org.identity_key = "real_key"
         mock_org.objects.get.return_value = org
+
+        org_member = MagicMock()
+        org_member.identity_key = "real_key"
+        mock_om.objects.get.return_value = org_member
 
         with self.assertRaises(GraphQLError):
             ChangeAccountPasswordMutation.mutate(
@@ -1059,7 +1062,6 @@ class PasswordChangeFlowTest(_ThrottleClearMixin, unittest.TestCase):
                 wrapped_recovery="wr_a",
             )
         user.set_password.assert_not_called()
-        mock_om.objects.get.assert_not_called()
 
     def test_sso_user_cannot_change_password(self):
         """SSO users (unusable password) are blocked."""
@@ -1116,10 +1118,10 @@ class RecoveryFlowTest(_ThrottleClearMixin, unittest.TestCase):
         user.check_password.return_value = True  # supplied authHash matches
 
         org = MagicMock()
-        org.identity_key = "matching_key"
         mock_org.objects.get.return_value = org
 
         org_member = MagicMock()
+        org_member.identity_key = "matching_key"
         mock_om.objects.get.return_value = org_member
 
         result = RecoverAccountKeyringMutation.mutate(
@@ -1155,9 +1157,11 @@ class RecoveryFlowTest(_ThrottleClearMixin, unittest.TestCase):
         user.check_password.return_value = False  # supplied hash != stored
 
         org = MagicMock()
-        org.identity_key = "matching_key"
         mock_org.objects.get.return_value = org
-        mock_om.objects.get.return_value = MagicMock()
+
+        org_member = MagicMock()
+        org_member.identity_key = "matching_key"
+        mock_om.objects.get.return_value = org_member
 
         with self.assertRaises(GraphQLError):
             RecoverAccountKeyringMutation.mutate(
@@ -1171,8 +1175,9 @@ class RecoveryFlowTest(_ThrottleClearMixin, unittest.TestCase):
             )
         user.set_password.assert_not_called()
 
+    @patch("backend.graphene.mutations.organisation.OrganisationMember")
     @patch("backend.graphene.mutations.organisation.Organisation")
-    def test_recovery_rejects_wrong_identity_key(self, mock_org):
+    def test_recovery_rejects_wrong_identity_key(self, mock_org, mock_om):
         """Wrong identity key is rejected before any keyring write."""
         from graphql import GraphQLError
         from backend.graphene.mutations.organisation import (
@@ -1182,8 +1187,11 @@ class RecoveryFlowTest(_ThrottleClearMixin, unittest.TestCase):
         user.has_usable_password.return_value = True
 
         org = MagicMock()
-        org.identity_key = "real_key"
         mock_org.objects.get.return_value = org
+
+        org_member = MagicMock()
+        org_member.identity_key = "real_key"
+        mock_om.objects.get.return_value = org_member
 
         with self.assertRaises(GraphQLError):
             RecoverAccountKeyringMutation.mutate(
@@ -1233,8 +1241,11 @@ class RecoveryFlowTest(_ThrottleClearMixin, unittest.TestCase):
         user = MagicMock()
 
         org = MagicMock()
-        org.identity_key = "real_key"
         mock_org.objects.get.return_value = org
+
+        org_member = MagicMock()
+        org_member.identity_key = "real_key"
+        mock_om.objects.get.return_value = org_member
 
         with self.assertRaises(GraphQLError):
             UpdateUserWrappedSecretsMutation.mutate(
@@ -1245,7 +1256,7 @@ class RecoveryFlowTest(_ThrottleClearMixin, unittest.TestCase):
                 wrapped_keyring="garbage",
                 wrapped_recovery="garbage",
             )
-        mock_om.objects.get.assert_not_called()
+        org_member.save.assert_not_called()
 
     @patch("backend.graphene.mutations.organisation.OrganisationMember")
     @patch("backend.graphene.mutations.organisation.Organisation")
@@ -1259,10 +1270,10 @@ class RecoveryFlowTest(_ThrottleClearMixin, unittest.TestCase):
         user = MagicMock()
 
         org = MagicMock()
-        org.identity_key = "matching_key"
         mock_org.objects.get.return_value = org
 
         org_member = MagicMock()
+        org_member.identity_key = "matching_key"
         mock_om.objects.get.return_value = org_member
 
         result = UpdateUserWrappedSecretsMutation.mutate(


### PR DESCRIPTION
## Summary

Three mutations introduced by the auth refactor (#849) — `UpdateUserWrappedSecretsMutation`, `RecoverAccountKeyringMutation`, and `ChangeAccountPasswordMutation` — compared the user-supplied `identity_key` against `org.identity_key`. That column is the **org owner's** identity_key, set once at org creation. Every Phase user derives their own keyring from their own mnemonic, so for any non-owner member the supplied `identity_key` won't match `org.identity_key` and the mutation rejects the call as \"Invalid recovery proof.\"

This breaks production for non-owner members:
- SSO recovery via \`/recovery\` (calls `UpdateUserWrappedSecretsMutation`)
- Password recovery via \`/recovery\` (calls `RecoverAccountKeyringMutation`)
- In-session password change via the change-password dialog (calls `ChangeAccountPasswordMutation`)

The intent of the check is *"the new identity_key must match the one this member registered with"*, which is `org_member.identity_key`. Owner-only orgs happen to work because the owner's `org_member.identity_key == org.identity_key`.

## Changes

- `backend/backend/graphene/mutations/organisation.py`: in all three mutations, move the `OrganisationMember.objects.get(...)` lookup ahead of the validation and compare against `org_member.identity_key`. Update docstrings.
- `backend/tests/test_auth_password.py`: tests had been mocking `org.identity_key` to drive the (incorrect) check. Switch the mocks to `org_member.identity_key` and update the assert-not-called assertions affected by the lookup-order change.

## Test plan

- [x] `pytest backend/tests/test_auth_password.py` passes (54/54)
- [x] Manual: with a non-owner member account, run \`/recovery\` → mnemonic accepted, keyring rewrapped (currently rejected as \"Invalid recovery proof\")
- [x] Manual: change-password dialog as a non-owner → succeeds (currently rejected)