### PR TITLE
fix: serve all routes at both / and /service/ via middleware

### DIFF
--- a/backend/backend/middleware.py
+++ b/backend/backend/middleware.py
@@ -1,0 +1,19 @@
+class ServicePrefixMiddleware:
+    """Strip the ``/service`` URL prefix before routing.
+
+    Cloud ALB forwards ``console.phase.dev/service/*`` to the backend verbatim.
+    Stripping it here lets every route — current and future — resolve at both
+    ``/<path>`` and ``/service/<path>`` without per-route registration.
+    """
+
+    PREFIX = "/service"
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.path_info == self.PREFIX or request.path_info.startswith(
+            self.PREFIX + "/"
+        ):
+            request.path_info = request.path_info[len(self.PREFIX) :] or "/"
+        return self.get_response(request)

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -217,6 +217,9 @@ SITE_ID = 1
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
+    # Strip /service prefix so cloud (ALB forwards /service/* verbatim) and
+    # self-hosted (nginx strips /service/) hit the same routes.
+    "backend.middleware.ServicePrefixMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -64,20 +64,20 @@ urlpatterns = [
     path("lockbox/<box_id>", LockboxView.as_view()),
 ]
 
-# Public API URLs
+# Public API routes — defined without a prefix so the same list mounts in two places.
 public_urls = [
-    path("public/", root_endpoint),
-    path("public/v1/secrets/", PublicSecretsView.as_view()),
-    path(
-        "public/v1/secrets/dynamic/",
-        include("ee.integrations.secrets.dynamic.rest.urls"),
-    ),
-    path("public/identities/external/v1/aws/iam/auth/", aws_iam_auth),
-    path("public/identities/external/v1/azure/entra/auth/", azure_entra_auth),
+    path("", root_endpoint),
+    path("v1/secrets/", PublicSecretsView.as_view()),
+    path("v1/secrets/dynamic/", include("ee.integrations.secrets.dynamic.rest.urls")),
+    path("identities/external/v1/aws/iam/auth/", aws_iam_auth),
+    path("identities/external/v1/azure/entra/auth/", azure_entra_auth),
 ]
 
-# Add public URLs to main urlpatterns
-urlpatterns.extend(public_urls)
+# Mount at root first (cloud: api.phase.dev/v1/...) so reverse() returns the
+# canonical form, then at /public/ for legacy clients and self-hosted nginx
+# (which forwards /service/public/... after stripping /service/).
+urlpatterns.append(path("", include(public_urls)))
+urlpatterns.append(path("public/", include(public_urls)))
 
 # Cloud-hosted specific URLs
 if CLOUD_HOSTED:

--- a/backend/tests/test_url_routing.py
+++ b/backend/tests/test_url_routing.py
@@ -1,0 +1,151 @@
+"""Tests for /service prefix routing.
+
+Two layers covered:
+- ``ServicePrefixMiddleware`` — strips ``/service`` from ``request.path_info`` so
+  the rest of the stack sees a single canonical path. No-op for everything else.
+- URL resolution — ``public_urls`` is mounted at both root and ``/public/`` so
+  cloud (``api.phase.dev/v1/...``) and legacy / self-hosted nginx
+  (``/public/v1/...``) topologies converge on the same views.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from django.urls import Resolver404, resolve
+
+from backend.middleware import ServicePrefixMiddleware
+
+
+class ServicePrefixMiddlewareTest(unittest.TestCase):
+    """Middleware strips /service; everything else passes through untouched."""
+
+    def _strip(self, path):
+        request = MagicMock()
+        request.path_info = path
+        ServicePrefixMiddleware(get_response=MagicMock())(request)
+        return request.path_info
+
+    # --- /service prefix is stripped ---
+
+    def test_strips_prefix_from_nested_path(self):
+        self.assertEqual(self._strip("/service/auth/me/"), "/auth/me/")
+
+    def test_strips_prefix_from_v1_secrets(self):
+        self.assertEqual(self._strip("/service/v1/secrets/"), "/v1/secrets/")
+
+    def test_strips_prefix_when_legacy_public_path_under_service(self):
+        self.assertEqual(self._strip("/service/public/v1/secrets/"), "/public/v1/secrets/")
+
+    def test_strips_prefix_with_only_trailing_slash(self):
+        self.assertEqual(self._strip("/service/"), "/")
+
+    def test_strips_prefix_with_no_trailing_slash(self):
+        # Cloud ALB may forward `/service` without a trailing slash; treat the
+        # same as `/service/` — empty residual becomes "/".
+        self.assertEqual(self._strip("/service"), "/")
+
+    # --- lookalike paths must NOT be stripped ---
+
+    def test_leaves_root_alone(self):
+        self.assertEqual(self._strip("/"), "/")
+
+    def test_leaves_unrelated_path_alone(self):
+        self.assertEqual(self._strip("/auth/me/"), "/auth/me/")
+
+    def test_leaves_services_plural_alone(self):
+        # /services/* must not match the /service prefix.
+        self.assertEqual(self._strip("/services/foo"), "/services/foo")
+
+    def test_leaves_service_substring_alone(self):
+        self.assertEqual(self._strip("/serviceabc"), "/serviceabc")
+
+    def test_leaves_v1_secrets_alone(self):
+        self.assertEqual(self._strip("/v1/secrets/"), "/v1/secrets/")
+
+    # --- middleware contract: response chain is invoked ---
+
+    def test_calls_get_response_with_modified_request(self):
+        request = MagicMock()
+        request.path_info = "/service/health/"
+        get_response = MagicMock(return_value="response")
+        result = ServicePrefixMiddleware(get_response)(request)
+        get_response.assert_called_once_with(request)
+        self.assertEqual(result, "response")
+        self.assertEqual(request.path_info, "/health/")
+
+    def test_passthrough_calls_get_response_with_unmodified_request(self):
+        request = MagicMock()
+        request.path_info = "/v1/secrets/"
+        get_response = MagicMock(return_value="response")
+        ServicePrefixMiddleware(get_response)(request)
+        get_response.assert_called_once_with(request)
+        self.assertEqual(request.path_info, "/v1/secrets/")
+
+
+class URLRoutingTest(unittest.TestCase):
+    """Routes resolve at the post-strip paths the middleware forwards.
+
+    These resolve calls don't go through middleware — they assert that *given*
+    the path the middleware would forward, the URL resolver finds a route.
+    Together with the middleware tests above, this covers the full chain.
+    """
+
+    def assertResolves(self, path):
+        try:
+            resolve(path)
+        except Resolver404:
+            self.fail(f"path did not resolve: {path}")
+
+    def assertNotResolves(self, path):
+        with self.assertRaises(Resolver404):
+            resolve(path)
+
+    # --- top-level routes (post-strip from /service/<route>) ---
+
+    def test_health_at_root(self):
+        self.assertResolves("/health/")
+
+    def test_graphql_at_root(self):
+        self.assertResolves("/graphql/")
+
+    def test_auth_me_at_root(self):
+        self.assertResolves("/auth/me/")
+
+    def test_logout_at_root(self):
+        self.assertResolves("/logout/")
+
+    def test_lockbox_at_root(self):
+        self.assertResolves("/lockbox/some-box-id")
+
+    # --- public_urls mounted at root (cloud canonical: api.phase.dev/v1/...) ---
+
+    def test_root_endpoint_at_root(self):
+        self.assertResolves("/")
+
+    def test_v1_secrets_at_root(self):
+        self.assertResolves("/v1/secrets/")
+
+    def test_aws_iam_auth_at_root(self):
+        self.assertResolves("/identities/external/v1/aws/iam/auth/")
+
+    def test_azure_entra_auth_at_root(self):
+        self.assertResolves("/identities/external/v1/azure/entra/auth/")
+
+    # --- public_urls also at /public/ (legacy form / nginx-stripped self-hosted) ---
+
+    def test_root_endpoint_at_public(self):
+        self.assertResolves("/public/")
+
+    def test_v1_secrets_at_public(self):
+        self.assertResolves("/public/v1/secrets/")
+
+    def test_aws_iam_auth_at_public(self):
+        self.assertResolves("/public/identities/external/v1/aws/iam/auth/")
+
+    # --- non-routes still 404 (sanity: we didn't accidentally match-all) ---
+
+    def test_unknown_path_does_not_resolve(self):
+        self.assertNotResolves("/no/such/endpoint/")
+
+    def test_lookalike_services_does_not_resolve(self):
+        self.assertNotResolves("/services/")

--- a/backend/tests/test_url_routing.py
+++ b/backend/tests/test_url_routing.py
@@ -149,3 +149,34 @@ class URLRoutingTest(unittest.TestCase):
 
     def test_lookalike_services_does_not_resolve(self):
         self.assertNotResolves("/services/")
+
+
+class AppendSlashUnderServicePrefixTest(unittest.TestCase):
+    """CommonMiddleware's APPEND_SLASH 301 must preserve the /service/ prefix.
+
+    The middleware mutates ``request.path_info`` but Django snapshots the
+    original PATH_INFO into ``request.path`` before any middleware runs, and
+    ``get_full_path()`` uses ``request.path``. Lock this in: a missing-slash
+    request under ``/service/`` redirects to the *prefixed* slashed path, not
+    to the bare path (which the cloud ALB would not route to the backend).
+    """
+
+    def setUp(self):
+        from django.test import Client
+        self.client = Client()
+
+    def test_append_slash_under_service_preserves_prefix(self):
+        response = self.client.get("/service/secrets", follow=False)
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response["Location"], "/service/secrets/")
+
+    def test_append_slash_under_service_preserves_prefix_for_auth(self):
+        response = self.client.get("/service/auth/me", follow=False)
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response["Location"], "/service/auth/me/")
+
+    def test_append_slash_at_root_unaffected(self):
+        # Baseline: same redirect without the /service/ prefix still works.
+        response = self.client.get("/secrets", follow=False)
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response["Location"], "/secrets/")


### PR DESCRIPTION
## Summary

Adds a small middleware that strips a `/service` URL prefix before URL resolution, so every backend route resolves at both `/<path>` and `/service/<path>` with no per-route registration.

Refactors `public_urls` to be defined without a prefix and mounts it at root first (so `reverse()` returns the canonical form) and at `/public/` for backwards compatibility with existing self-hosted topologies.

Supersedes #820. CI changes from that PR landed separately in #868.

## Test plan

- [x] Manually verified locally that routes resolve at both prefixes
- [x] Existing self-hosted topology (nginx strips `/service/` before proxying to backend) continues to work unchanged
- [x] Unit tests for the routing behavior