### PR TITLE
fix: raise gunicorn --timeout and --graceful-timeout

### DIFF
--- a/backend/scripts/start.sh
+++ b/backend/scripts/start.sh
@@ -44,4 +44,4 @@ fi
 # Start gunicorn server.
 echo "Detected $CORES system cores. Starting $WORKERS gunicorn workers."
 # Listen for connections on IPv4 and IPv6 - Dualstack
-exec gunicorn -b '[::]:8000' --workers "$WORKERS" backend.wsgi:application
+exec gunicorn -b '[::]:8000' --workers "$WORKERS" --timeout 120 --graceful-timeout 90 backend.wsgi:application


### PR DESCRIPTION
## Summary

Raises gunicorn's per-request timeout from 30s to 120s and shutdown drain
from 30s to 90s. Defaults were chopping the largest legitimate requests
and truncating in-flight requests during rolling deploys.