### PR TITLE
fix: bypass host validation for /health/ ALB probes

### DIFF
--- a/backend/backend/middleware.py
+++ b/backend/backend/middleware.py
@@ -1,7 +1,3 @@
-from django.conf import settings
-from django.http import JsonResponse
-
-
 class ServicePrefixMiddleware:
     """Strip the ``/service`` URL prefix before routing.
 
@@ -32,17 +28,25 @@ class HealthCheckMiddleware:
     ``ALLOWED_HOSTS`` is set to specific domains, so handling the endpoint
     here lets the setting stay tight without breaking ALB.
 
-    Mirrors the ``api.views.auth.health_check`` view's response shape.
+    Delegates to ``api.views.auth.health_check`` so the response shape and
+    GET-only enforcement (via DRF's ``@api_view(["GET"])``) stay in lockstep
+    with the canonical view — non-GET requests get the same 405 they would
+    have gotten without this middleware.
+
     Place after ``ServicePrefixMiddleware`` so the canonical post-strip path
-    is the only one to match.
+    is the only one to match, and before any middleware that calls
+    ``request.get_host()`` (notably ``CommonMiddleware``).
     """
 
     PATH = "/health/"
 
     def __init__(self, get_response):
+        from api.views.auth import health_check
+
         self.get_response = get_response
+        self._view = health_check
 
     def __call__(self, request):
         if request.path_info == self.PATH:
-            return JsonResponse({"status": "alive", "version": settings.VERSION})
+            return self._view(request)
         return self.get_response(request)

--- a/backend/backend/middleware.py
+++ b/backend/backend/middleware.py
@@ -1,3 +1,7 @@
+from django.conf import settings
+from django.http import JsonResponse
+
+
 class ServicePrefixMiddleware:
     """Strip the ``/service`` URL prefix before routing.
 
@@ -16,4 +20,29 @@ class ServicePrefixMiddleware:
             self.PREFIX + "/"
         ):
             request.path_info = request.path_info[len(self.PREFIX) :] or "/"
+        return self.get_response(request)
+
+
+class HealthCheckMiddleware:
+    """Short-circuit ``/health/`` before host validation runs.
+
+    ALB target group health checks send ``Host: <task-ip>:<port>`` (the ALB
+    has no setting for a custom Host header on health checks). Django's
+    ``CommonMiddleware`` rejects that with ``DisallowedHost`` when
+    ``ALLOWED_HOSTS`` is set to specific domains, so handling the endpoint
+    here lets the setting stay tight without breaking ALB.
+
+    Mirrors the ``api.views.auth.health_check`` view's response shape.
+    Place after ``ServicePrefixMiddleware`` so the canonical post-strip path
+    is the only one to match.
+    """
+
+    PATH = "/health/"
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.path_info == self.PATH:
+            return JsonResponse({"status": "alive", "version": settings.VERSION})
         return self.get_response(request)

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -220,6 +220,9 @@ MIDDLEWARE = [
     # Strip /service prefix so cloud (ALB forwards /service/* verbatim) and
     # self-hosted (nginx strips /service/) hit the same routes.
     "backend.middleware.ServicePrefixMiddleware",
+    # Short-circuit /health/ before CommonMiddleware so ALB health checks
+    # (Host: <task-ip>:<port>) don't fail strict ALLOWED_HOSTS validation.
+    "backend.middleware.HealthCheckMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",

--- a/backend/tests/test_url_routing.py
+++ b/backend/tests/test_url_routing.py
@@ -8,9 +8,11 @@ Two layers covered:
   (``/public/v1/...``) topologies converge on the same views.
 """
 
+import json
 import unittest
 from unittest.mock import MagicMock
 
+from django.test import RequestFactory
 from django.urls import Resolver404, resolve
 
 from backend.middleware import HealthCheckMiddleware, ServicePrefixMiddleware
@@ -21,25 +23,37 @@ class HealthCheckMiddlewareTest(unittest.TestCase):
 
     The point of this middleware is to bypass Django's host validation so
     ALB health checks (Host: <task-ip>:<port>) don't fail under strict
-    ALLOWED_HOSTS. Tests verify the short-circuit path and that unrelated
-    paths are untouched.
+    ALLOWED_HOSTS. The middleware delegates to the canonical view, so the
+    response shape (200 + payload) and method enforcement (405 for non-GET)
+    come from the view itself — these tests pin both behaviors so future
+    drift in the view is caught here too.
     """
 
-    def test_health_path_returns_alive_without_calling_get_response(self):
-        request = MagicMock()
-        request.path_info = "/health/"
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_get_health_returns_alive_without_calling_get_response(self):
+        request = self.factory.get("/health/")
         get_response = MagicMock()
 
         response = HealthCheckMiddleware(get_response)(request)
 
         get_response.assert_not_called()
         self.assertEqual(response.status_code, 200)
-        # Response shape mirrors the api.views.auth.health_check view.
-        import json
-
         body = json.loads(response.content)
         self.assertEqual(body["status"], "alive")
         self.assertIn("version", body)
+
+    def test_non_get_health_returns_405_without_calling_get_response(self):
+        # View is GET-only via @api_view(["GET"]); non-GET must surface as
+        # 405, not slip through the chain (where it'd hit host validation).
+        request = self.factory.post("/health/")
+        get_response = MagicMock()
+
+        response = HealthCheckMiddleware(get_response)(request)
+
+        get_response.assert_not_called()
+        self.assertEqual(response.status_code, 405)
 
     def test_non_health_path_calls_get_response(self):
         request = MagicMock()

--- a/backend/tests/test_url_routing.py
+++ b/backend/tests/test_url_routing.py
@@ -13,7 +13,55 @@ from unittest.mock import MagicMock
 
 from django.urls import Resolver404, resolve
 
-from backend.middleware import ServicePrefixMiddleware
+from backend.middleware import HealthCheckMiddleware, ServicePrefixMiddleware
+
+
+class HealthCheckMiddlewareTest(unittest.TestCase):
+    """Middleware short-circuits /health/; everything else passes through.
+
+    The point of this middleware is to bypass Django's host validation so
+    ALB health checks (Host: <task-ip>:<port>) don't fail under strict
+    ALLOWED_HOSTS. Tests verify the short-circuit path and that unrelated
+    paths are untouched.
+    """
+
+    def test_health_path_returns_alive_without_calling_get_response(self):
+        request = MagicMock()
+        request.path_info = "/health/"
+        get_response = MagicMock()
+
+        response = HealthCheckMiddleware(get_response)(request)
+
+        get_response.assert_not_called()
+        self.assertEqual(response.status_code, 200)
+        # Response shape mirrors the api.views.auth.health_check view.
+        import json
+
+        body = json.loads(response.content)
+        self.assertEqual(body["status"], "alive")
+        self.assertIn("version", body)
+
+    def test_non_health_path_calls_get_response(self):
+        request = MagicMock()
+        request.path_info = "/v1/secrets/"
+        get_response = MagicMock(return_value="response")
+
+        result = HealthCheckMiddleware(get_response)(request)
+
+        get_response.assert_called_once_with(request)
+        self.assertEqual(result, "response")
+
+    def test_health_lookalike_paths_are_not_intercepted(self):
+        # /healthz, /health (no slash), /health/foo must go through the chain.
+        for path in ("/healthz/", "/health", "/health/foo", "/api/health/"):
+            with self.subTest(path=path):
+                request = MagicMock()
+                request.path_info = path
+                get_response = MagicMock(return_value="response")
+
+                HealthCheckMiddleware(get_response)(request)
+
+                get_response.assert_called_once_with(request)
 
 
 class ServicePrefixMiddlewareTest(unittest.TestCase):


### PR DESCRIPTION
Adds `HealthCheckMiddleware` so `/health/` returns 200 regardless of the
incoming `Host` header. Lets deployments behind an ALB keep `ALLOWED_HOSTS`
strict.