### PR TITLE
fix: validate cross-app secret refs against empty target envs

### DIFF
--- a/frontend/components/secrets/BrokenReferencesDialog.tsx
+++ b/frontend/components/secrets/BrokenReferencesDialog.tsx
@@ -35,10 +35,10 @@ export const BrokenReferencesDialog = forwardRef<
               className="p-1.5 rounded bg-zinc-100 dark:bg-zinc-800/50 border border-zinc-200 dark:border-zinc-700"
             >
               <div className="text-2xs 2xl:text-xs">
-                <span className="font-mono font-medium text-zinc-900 dark:text-zinc-100">{err.secretKey}</span>
+                <span className="font-mono font-medium text-zinc-900 dark:text-zinc-100 ph-no-capture">{err.secretKey}</span>
                 <span className="text-neutral-500"> in {err.envName}</span>
               </div>
-              <div className="text-2xs 2xl:text-xs text-neutral-600 dark:text-neutral-400">
+              <div className="text-2xs 2xl:text-xs text-neutral-600 dark:text-neutral-400 ph-no-capture">
                 <span className="font-mono"><SecretReferenceHighlight value={err.reference} /></span>: {err.error}
               </div>
             </li>

--- a/frontend/hooks/useOrgSecretKeys.ts
+++ b/frontend/hooks/useOrgSecretKeys.ts
@@ -104,8 +104,8 @@ export function useOrgSecretKeys(): { orgApps: OrgApp[]; loading: boolean } {
 
               envSecretKeys[env.name.toLowerCase()] = keys
             } catch {
-              // Skip environments we can't unwrap (no access)
-              envSecretKeys[env.name.toLowerCase()] = []
+              // No decrypt access — leave undefined so validation can distinguish
+              // "no visibility" (skip) from "empty env" (strict check)
             }
           }
 

--- a/frontend/tests/utils/secretReferences.test.ts
+++ b/frontend/tests/utils/secretReferences.test.ts
@@ -975,6 +975,53 @@ describe('validateSecretReferences', () => {
     expect(errors[0].error).toContain('does not exist in "OtherApp"')
   })
 
+  test('flags any key reference when target cross-app env has zero secrets', () => {
+    const ctxEmptyEnv = makeContext({
+      orgApps: [
+        {
+          id: 'app-2',
+          name: 'OtherApp',
+          envNames: ['Development'],
+          envIds: { development: 'other-env-dev' },
+          envSecretKeys: { development: [] },
+          envRootKeys: { development: [] },
+          folderKeys: {},
+          envFolderKeys: {},
+          secretIdLookup: {},
+        },
+      ],
+    })
+    const secrets = makeSecrets([
+      { key: 'REF', envName: 'Development', value: '${OtherApp::development.ANYTHING}' },
+    ])
+    const errors = validateSecretReferences(secrets, ctxEmptyEnv)
+    expect(errors).toHaveLength(1)
+    expect(errors[0].error).toContain('does not exist in "OtherApp"')
+  })
+
+  test('skips cross-app key validation when user has no decrypt access to target env', () => {
+    const ctxNoAccess = makeContext({
+      orgApps: [
+        {
+          id: 'app-2',
+          name: 'OtherApp',
+          envNames: ['Development'],
+          envIds: { development: 'other-env-dev' },
+          envSecretKeys: {}, // env exists but no entry = no decrypt access
+          envRootKeys: {},
+          folderKeys: {},
+          envFolderKeys: {},
+          secretIdLookup: {},
+        },
+      ],
+    })
+    const secrets = makeSecrets([
+      { key: 'REF', envName: 'Development', value: '${OtherApp::development.UNKNOWN}' },
+    ])
+    const errors = validateSecretReferences(secrets, ctxNoAccess)
+    expect(errors).toHaveLength(0)
+  })
+
   test('skips secrets staged for delete', () => {
     const secrets = [
       {

--- a/frontend/utils/secretReferences.ts
+++ b/frontend/utils/secretReferences.ts
@@ -909,8 +909,9 @@ export function validateSecretReferences(
                   })
                 } else {
                   const { key } = decomposePathAndKey(ref.pathAndKey)
-                  const crossAppEnvKeys = crossApp.envSecretKeys[ref.env!.toLowerCase()] ?? []
-                  if (crossAppEnvKeys.length > 0 && !crossAppEnvKeys.includes(key)) {
+                  const crossAppEnvKeys = crossApp.envSecretKeys[ref.env!.toLowerCase()]
+                  // undefined = no decrypt access, skip; defined (incl. []) = strict check
+                  if (crossAppEnvKeys !== undefined && !crossAppEnvKeys.includes(key)) {
                     errors.push({
                       secretKey: secret.key,
                       envName,


### PR DESCRIPTION
## Summary

Fixes a false negative in `validateSecretReferences` where cross-app references like `${app::env.MISSING_KEY}` were not flagged as broken when the target env's decrypted key list was empty.

## Root cause

The cross-app key check was guarded by `crossAppEnvKeys.length > 0 &&`, which silently skipped validation whenever the target env's key list was `[]`. That conflated two distinct cases:

- **No decrypt access** — `useOrgSecretKeys` set the entry to `[]` as a fallback when env-key unwrap threw.
- **Env genuinely has zero secrets** — list is legitimately `[]`.

The second case meant any `${app::env.X}` ref against an empty env passed validation, even though the key clearly doesn't exist.

## Fix

- `frontend/hooks/useOrgSecretKeys.ts`: on unwrap failure, leave `envSecretKeys[env]` undefined instead of `[]`. This lets validation distinguish "no visibility" from "empty env".
- `frontend/utils/secretReferences.ts`: cross-app key check now uses `crossAppEnvKeys !== undefined` instead of `length > 0`. Undefined → skip (we can't see the keys); defined (including `[]`) → strict check.

## Test plan

- [x] Existing `validateSecretReferences` tests still pass (82 → 84 with new cases)
- [x] New regression test: empty target env flags any cross-app key ref as broken
- [x] New regression test: no-access target env skips cross-app key validation
- [x] `tsc --noEmit` clean
- [x] Manual: write `${OtherApp::env.NONEXISTENT}` against an env with secrets and confirm warning fires
- [x] Manual: confirm cross-app refs to envs you can't decrypt still don't false-positive
