### PR TITLE
fix(sso): Okta OIDC adapter respects org-level config

### DIFF
--- a/backend/ee/authentication/sso/oidc/okta/views.py
+++ b/backend/ee/authentication/sso/oidc/okta/views.py
@@ -26,18 +26,56 @@ class OktaOpenIDConnectProvider(GenericOpenIDConnectProvider):
 class OktaOpenIDConnectAdapter(GenericOpenIDConnectAdapter):
     provider_id = OktaOpenIDConnectProvider.id
 
-    @property
-    def oidc_config_url(self):
+    def _resolve_issuer(self):
+        """Resolve the Okta issuer URL.
+
+        The session key `sso_org_config_id` is the intent signal:
+
+        - When present, the user entered the org-level SSO flow → use that
+          org's stored config. If the config can't be loaded or is missing
+          an `issuer`, FAIL CLOSED — don't silently fall back to the
+          instance-level env, which could route the user to a different IdP
+          than the operator intended.
+        - When absent, the user entered the instance-level flow → use
+          `OKTA_OIDC_ISSUER` from env.
+        """
+        session = getattr(self.request, "session", None) if self.request else None
+        org_config_id = session.get("sso_org_config_id") if session else None
+
+        if org_config_id:
+            try:
+                from api.utils.sso import get_org_sso_config
+
+                _provider, org_config = get_org_sso_config(org_config_id)
+            except Exception as e:
+                logger.error(
+                    f"Failed to load org SSO config {org_config_id}: {e}"
+                )
+                raise ValueError(
+                    f"Org-level Okta SSO config {org_config_id} could not be loaded"
+                )
+
+            issuer = org_config.get("issuer") if org_config else None
+            if not issuer:
+                raise ValueError(
+                    f"Org-level Okta SSO config {org_config_id} is missing 'issuer'"
+                )
+            return issuer.rstrip("/")
+
         issuer = os.getenv("OKTA_OIDC_ISSUER")
         if not issuer:
-            raise ValueError("OKTA_OIDC_ISSUER must be set")
-        return f"{issuer}/.well-known/openid-configuration"
+            raise ValueError(
+                "OKTA_OIDC_ISSUER must be set, or configure org-level Okta SSO"
+            )
+        return issuer.rstrip("/")
+
+    @property
+    def oidc_config_url(self):
+        return f"{self._resolve_issuer()}/.well-known/openid-configuration"
 
     @property
     def default_config(self):
-        issuer = os.getenv("OKTA_OIDC_ISSUER")
-        if not issuer:
-            raise ValueError("OKTA_OIDC_ISSUER must be set")
+        issuer = self._resolve_issuer()
         return {
             "access_token_url": f"{issuer}/v1/token",
             "authorize_url": f"{issuer}/v1/authorize",


### PR DESCRIPTION
## Summary

The Okta OIDC adapter previously read `OKTA_OIDC_ISSUER` from environment unconditionally. As a result, **org-level Okta SSO** (configured per-org via `OrganisationSSOProvider` in the Phase Console) never reached the adapter — `OktaOpenIDConnectAdapter.__init__` raised `ValueError: OKTA_OIDC_ISSUER must be set` even when a valid org config was in the session.

This PR brings the Okta adapter in line with the Entra ID adapter, which already supports this pattern via [`_resolve_expected_tenant_id`](https://github.com/phasehq/console/blob/feat--teams/backend/ee/authentication/sso/oidc/entraid/views.py#L77).

## Change

- New `_resolve_issuer()` helper that uses `session["sso_org_config_id"]` as the **intent signal**:
  - **Present** → load `OrganisationSSOProvider.config` via `get_org_sso_config()` and use its `issuer` field
  - **Absent** → fall back to `OKTA_OIDC_ISSUER` from env (instance-level / legacy)
- **Fail-closed** when org-level was intended but the config is broken (missing row, decrypt error, missing `issuer` field). Does NOT silently fall back to the instance-level env, which could route the user to a different IdP than the operator intended.
- Both `oidc_config_url` and `default_config` route through the same helper so they cannot drift.
- Clearer `ValueError` message that mentions both configuration paths.

## Precedence summary

| Scenario | Behavior |
|---|---|
| Instance-level flow (no `sso_org_config_id`) + env set | env wins — **unchanged** |
| Instance-level flow + env unset | `ValueError` — **unchanged** |
| Org-level flow + valid config + env unset | org config used (**fixes the bug**) |
| Org-level flow + valid config + env *also* set | org config wins; env ignored (**fixes the bug** — session is the intent signal) |
| Org-level flow + broken config + env set | **`ValueError` (fail-closed)** — refuses to silently route to a different IdP |
| Request without a session attribute | env fallback (defensive) |

## Why "fail closed" matters

If an operator configured org-level SSO and the config breaks (e.g. someone deleted the `OrganisationSSOProvider` row, or `client_secret` decryption fails), the previous draft of this fix would have silently fallen through to the instance-level env. That could route an authenticating user to a completely different IdP than the operator intended — a textbook silent-failure → wrong-identity-provider footgun. The Entra ID adapter handles this the same way (returns `None`, causing a clear downstream error rather than silent redirect).

## Why no precedence flip ("instance-level wins, ignore org-level")

That would actively break multi-tenant deployments where some orgs configure their own Okta tenant alongside an instance-level fallback for the default org. The `sso_org_config_id` session key already encodes the user's intent unambiguously — that's the right discriminator.

## Test plan

- [x] Instance-level deployment (only env vars set, no org-level SSO): login flow unaffected.
- [x] Instance-level deployment with env unset: `ValueError` with clear message at adapter init time.
- [x] Org-level deployment (Phase Console → Authentication → Okta OIDC enabled, env vars *unset*): login completes; JWKS lookup hits the right tenant.
- [x] Org-level deployment with env *also* set to a different Okta tenant: org config wins; env tenant is ignored.
- [x] Org-level config row deleted between authorize and callback: adapter raises `Org-level Okta SSO config ... could not be loaded`; user sees an error page rather than being routed elsewhere.