### PR TITLE
fix: `user.socialaccount` might be `None`

### DIFF
--- a/backend/api/emails.py
+++ b/backend/api/emails.py
@@ -26,14 +26,18 @@ def _frontend_url():
 
 
 def get_org_member_name(org_member):
-    social_acc = org_member.user.socialaccount_set.first()
+    user = org_member.user
 
-    member_name = social_acc.extra_data.get("name") if social_acc else None
+    social_acc = user.socialaccount_set.first()
+    if social_acc:
+        name = (social_acc.extra_data or {}).get("name")
+        if name:
+            return name
 
-    if member_name is None:
-        member_name = org_member.user.email
+    if user.full_name:
+        return user.full_name
 
-    return member_name
+    return user.email
 
 
 def send_email(subject, recipient_list, template_name, context):

--- a/backend/api/emails.py
+++ b/backend/api/emails.py
@@ -28,7 +28,7 @@ def _frontend_url():
 def get_org_member_name(org_member):
     social_acc = org_member.user.socialaccount_set.first()
 
-    member_name = social_acc.extra_data.get("name")
+    member_name = social_acc.extra_data.get("name") if social_acc else None
 
     if member_name is None:
         member_name = org_member.user.email


### PR DESCRIPTION
When self hosting phase with just simple password authentication inviting new members per email does not work, because the org member does not have a social account set.

The missing check caused the following error:
```py
ERROR [rq.worker:1216] worker 19 140338981935880 [Job 96bc1351-5992-4e99-a5ae-b4328a96dd7c]: exception raised while executing (api.emails.send_invite_email)
 Traceback (most recent call last):
   File "/env/lib/python3.12/site-packages/rq/worker.py", line 1633, in perform_job
     return_value = job.perform()
                    ^^^^^^^^^^^^^
   File "/env/lib/python3.12/site-packages/rq/job.py", line 1331, in perform
     self._result = self._execute()
                    ^^^^^^^^^^^^^^^
   File "/env/lib/python3.12/site-packages/rq/job.py", line 1365, in _execute
     result = self.func(*self.args, **self.kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/app/api/emails.py", line 89, in send_invite_email
     invited_by_name = get_org_member_name(invite.invited_by)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/app/api/emails.py", line 20, in get_org_member_name
     member_name = social_acc.extra_data.get("name")
                   ^^^^^^^^^^^^^^^^^^^^^
 AttributeError: 'NoneType' object has no attribute 'extra_data'
```

Just checking whether `social_acc` is `None` in `get_org_member_name ` should be enough of a fix without major refactoring. imho an issue for this small change was not needed.
I have searched the codebase for other places, where `socialaccount_set` is not being checked, but this was the only place.