### PR TITLE
fix: create SCIM token dialog closing prematurely

### DIFF
--- a/frontend/app/[team]/access/scim/_components/SCIMTokenDialogs.tsx
+++ b/frontend/app/[team]/access/scim/_components/SCIMTokenDialogs.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import { Fragment, useRef, useState } from 'react'
+import { forwardRef, Fragment, useImperativeHandle, useRef, useState } from 'react'
 import { useMutation } from '@apollo/client'
 import { toast } from 'react-toastify'
 import { RadioGroup } from '@headlessui/react'
-import { FaCheckCircle, FaCircle, FaExclamationTriangle, FaPlus, FaTrash } from 'react-icons/fa'
+import { FaCheckCircle, FaCircle, FaExclamationTriangle, FaTrash } from 'react-icons/fa'
 import { Button } from '@/components/common/Button'
 import CopyButton from '@/components/common/CopyButton'
 import GenericDialog from '@/components/common/GenericDialog'
@@ -16,12 +16,20 @@ import { humanReadableExpiry } from '@/utils/tokens'
 import { getUnixTimeStampinFuture } from '@/utils/time'
 import { EXPIRY_OPTIONS } from './shared'
 
-export function CreateSCIMTokenDialog({ organisationId }: { organisationId: string }) {
+export const CreateSCIMTokenDialog = forwardRef<
+  { openModal: () => void; closeModal: () => void },
+  { organisationId: string }
+>(({ organisationId }, ref) => {
   const [name, setName] = useState('')
   const [expiryDays, setExpiryDays] = useState<number | null>(90)
   const [createdToken, setCreatedToken] = useState<string | null>(null)
 
-  const dialogRef = useRef<{ closeModal: () => void }>(null)
+  const dialogRef = useRef<{ openModal: () => void; closeModal: () => void }>(null)
+
+  useImperativeHandle(ref, () => ({
+    openModal: () => dialogRef.current?.openModal(),
+    closeModal: () => dialogRef.current?.closeModal(),
+  }))
 
   const [createToken, { loading }] = useMutation(CreateSCIMTokenOp, {
     refetchQueries: [{ query: GetSCIMTokens, variables: { organisationId } }],
@@ -54,12 +62,6 @@ export function CreateSCIMTokenDialog({ organisationId }: { organisationId: stri
   return (
     <GenericDialog
       title="Create SCIM token"
-      buttonContent={
-        <>
-          <FaPlus /> Create token
-        </>
-      }
-      buttonVariant="primary"
       ref={dialogRef}
       onClose={handleClose}
       isStatic={!!createdToken}
@@ -150,7 +152,9 @@ export function CreateSCIMTokenDialog({ organisationId }: { organisationId: stri
       </div>
     </GenericDialog>
   )
-}
+})
+
+CreateSCIMTokenDialog.displayName = 'CreateSCIMTokenDialog'
 
 export function DeleteSCIMTokenDialog({
   tokenId,

--- a/frontend/app/[team]/access/scim/page.tsx
+++ b/frontend/app/[team]/access/scim/page.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { useContext } from 'react'
+import { useContext, useRef } from 'react'
 import { useMutation, useQuery } from '@apollo/client'
 import { toast } from 'react-toastify'
 import Link from 'next/link'
-import { FaBan, FaChevronRight, FaKey, FaRegListAlt } from 'react-icons/fa'
+import { FaBan, FaChevronRight, FaKey, FaPlus, FaRegListAlt } from 'react-icons/fa'
+import { Button } from '@/components/common/Button'
 import CopyButton from '@/components/common/CopyButton'
 import { EmptyState } from '@/components/common/EmptyState'
 import Spinner from '@/components/common/Spinner'
@@ -22,6 +23,8 @@ import { SCIMEventsTable } from './_components/SCIMEventsTable'
 
 export default function SCIMPage({ params }: { params: { team: string } }) {
   const { activeOrganisation: organisation } = useContext(organisationContext)
+
+  const createTokenDialogRef = useRef<{ openModal: () => void; closeModal: () => void }>(null)
 
   const userCanManageSCIM = organisation
     ? userHasPermission(organisation.role!.permissions, 'SCIM', 'update')
@@ -164,7 +167,18 @@ export default function SCIMPage({ params }: { params: { team: string } }) {
                 </div>
                 <div className="flex items-center gap-3">
                   {userCanManageSCIM && (
-                    <CreateSCIMTokenDialog organisationId={organisation.id} />
+                    <>
+                      <CreateSCIMTokenDialog
+                        ref={createTokenDialogRef}
+                        organisationId={organisation.id}
+                      />
+                      <Button
+                        variant="primary"
+                        onClick={() => createTokenDialogRef.current?.openModal()}
+                      >
+                        <FaPlus /> Create token
+                      </Button>
+                    </>
                   )}
                 </div>
               </div>
@@ -183,8 +197,15 @@ export default function SCIMPage({ params }: { params: { team: string } }) {
                     </div>
                   }
                 >
-                  {userCanManageSCIM && (
-                    <CreateSCIMTokenDialog organisationId={organisation.id} />
+                  {userCanManageSCIM ? (
+                    <Button
+                      variant="primary"
+                      onClick={() => createTokenDialogRef.current?.openModal()}
+                    >
+                      <FaPlus /> Create token
+                    </Button>
+                  ) : (
+                    <></>
                   )}
                 </EmptyState>
               ) : (


### PR DESCRIPTION
## Summary

Fixes a bug where creating the first SCIM token caused the create-token dialog to close instantly, hiding the token before the user could copy it.

## Root cause

`SCIMPage` rendered two separate `CreateSCIMTokenDialog` instances — one in the section header (shown when tokens exist), and a duplicate inside the `EmptyState` (shown only when `tokens.length === 0`). Creating the first token triggered a refetch that flipped the count from 0 → 1, unmounting the `EmptyState` branch and tearing down the open dialog along with its `createdToken` state. On the second attempt, the persistent header dialog was used, so the token displayed correctly.

## Fix

- Convert `CreateSCIMTokenDialog` to a `forwardRef` component exposing `openModal`/`closeModal` via `useImperativeHandle`, with no built-in trigger button.
- Mount a single dialog instance at the page level, owned by `createTokenDialogRef`.
- Render trigger buttons in both the header and the empty state; both call `createTokenDialogRef.current?.openModal()` on the same persistent dialog.

The dialog now survives the 0 → 1 token transition, so the newly created token stays visible and copyable.

## Preview

### Before

https://github.com/user-attachments/assets/42c222bd-09a9-4568-9bfb-1cfdb6ac8778

### After

https://github.com/user-attachments/assets/e6de805a-19d6-4bf7-89de-9cdcfcd6d4c1


## Review Focus

- [x] With zero SCIM tokens, click the empty-state "Create token" button → dialog opens.
- [x] Submit the form → token is created, dialog stays open and shows the token with a copy button.
- [x] Click "Done" → dialog closes, token appears in the credentials table.
- [x] With one or more tokens, click the header "Create token" button → dialog still works end-to-end.
- [x] Verify the empty-state button is hidden for users without `SCIM:update` permission.
