### PR TITLE
feat: tailscale sidecar docker compose self-hosting setup

### DIFF
--- a/tailscale-docker-compose.yml
+++ b/tailscale-docker-compose.yml
@@ -1,0 +1,162 @@
+# Phase Console + Tailscale sidecar.
+# Docs: https://docs.phase.dev/self-hosting/tailscale
+#
+# Runs the Phase Console as a machine on your Tailscale network (tailnet):
+#   - Inbound:  the Console is reachable at https://phase.<your-tailnet>.ts.net
+#               with a valid TLS certificate via Tailscale Serve. No Tailscale
+#               installation is required on the Docker host.
+#   - Outbound: the backend and worker can reach other machines on your tailnet
+#               directly, so integrations can talk to private services.
+#
+# The nginx, backend and worker services share the tailscale service's network
+# namespace (network_mode: service:tailscale), similar to a Kubernetes pod.
+# Inside that namespace, port 443 belongs to Tailscale Serve (TLS for the
+# tailnet) and nginx terminates TLS for the Docker host on port 8443, which is
+# published as the host's port 443. The frontend, postgres and redis services
+# stay on the internal compose network and are not exposed to the tailnet.
+
+services:
+  tailscale:
+    container_name: phase-tailscale
+    image: tailscale/tailscale:latest
+    hostname: phase # tailnet machine name -> https://phase.<your-tailnet>.ts.net
+    restart: unless-stopped
+    environment:
+      TS_AUTHKEY: "${TS_AUTHKEY}"
+      TS_STATE_DIR: /var/lib/tailscale
+      TS_USERSPACE: "false" # kernel-mode networking: gives backend/worker transparent tailnet access
+      TS_ACCEPT_DNS: "true" # MagicDNS: resolve tailnet hostnames from backend/worker
+      TS_SERVE_CONFIG: /config/serve.json
+    volumes:
+      - phase-tailscale-state:/var/lib/tailscale
+      - ./tailscale/serve.json:/config/serve.json:ro
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    cap_add:
+      - NET_ADMIN
+    ports:
+      # nginx shares this network namespace, so its ports are published here.
+      # Remove this section for tailnet-only access (no ports on the host).
+      - 80:80
+      - 443:8443
+    networks:
+      phase-net:
+        aliases:
+          # This keeps http://backend:8000 resolvable for the frontend.
+          - backend
+
+  nginx:
+    container_name: phase-nginx
+    build:
+      context: ./nginx
+      dockerfile: Dockerfile
+    restart: always
+    network_mode: service:tailscale
+    volumes:
+      - ./tailscale/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - tailscale
+      - frontend
+      - backend
+
+  frontend:
+    container_name: phase-frontend
+    restart: unless-stopped
+    depends_on:
+      - backend
+    image: phasehq/frontend:latest
+    env_file: .env
+    environment:
+      NEXTAUTH_URL: "${HTTP_PROTOCOL}${HOST}"
+      BACKEND_API_BASE: "http://backend:8000"
+      NEXT_PUBLIC_BACKEND_API_BASE: "/service"
+    networks:
+      - phase-net
+
+  migrations:
+    container_name: phase-migrations
+    image: phasehq/backend:latest
+    command: python manage.py migrate
+    env_file: .env
+    environment:
+      OAUTH_REDIRECT_URI: "${HTTP_PROTOCOL}${HOST}"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    networks:
+      - phase-net
+
+  backend:
+    container_name: phase-backend
+    restart: unless-stopped
+    network_mode: service:tailscale
+    depends_on:
+      tailscale:
+        condition: service_started
+      migrations:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    image: phasehq/backend:latest
+    env_file: .env
+    environment:
+      OAUTH_REDIRECT_URI: "${HTTP_PROTOCOL}${HOST}"
+      EXTERNAL_MIGRATION: "true"
+
+  worker:
+    container_name: phase-worker
+    restart: unless-stopped
+    network_mode: service:tailscale
+    depends_on:
+      tailscale:
+        condition: service_started
+      migrations:
+        condition: service_completed_successfully
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    image: phasehq/backend:latest
+    command: python manage.py rqworker default
+    env_file: .env
+
+  postgres:
+    container_name: phase-postgres
+    image: postgres:15.4-alpine3.17
+    restart: always
+    env_file:
+      - .env
+    environment:
+      POSTGRES_DB: ${DATABASE_NAME}
+      POSTGRES_USER: ${DATABASE_USER}
+      POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
+      POSTGRES_HOST_AUTH_METHOD: "trust"
+    volumes:
+      - phase-postgres-data:/var/lib/postgresql/data
+    networks:
+      - phase-net
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DATABASE_USER} -d ${DATABASE_NAME}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    container_name: phase-redis
+    image: redis:alpine3.19
+    restart: always
+    networks:
+      - phase-net
+
+volumes:
+  phase-postgres-data:
+    driver: local
+  phase-tailscale-state:
+    driver: local
+
+networks:
+  phase-net:

--- a/tailscale/nginx.conf
+++ b/tailscale/nginx.conf
@@ -1,0 +1,69 @@
+# --- Cloudflare IP header forwarding ---
+# map $http_cf_connecting_ip $client_real_ip {
+#     default $remote_addr;
+#     "~." $http_cf_connecting_ip;
+# }
+
+server {
+    listen 80;
+    # TLS on 8443 instead of 443: inside the shared Tailscale network namespace,
+    # port 443 belongs to `tailscale serve` (which terminates TLS for the tailnet with a valid certificate).
+    listen 8443 ssl;
+    http2 on;
+    # Remove Nginx version from response headers
+    server_tokens off;
+
+    # TLS config
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers EECDH+AESGCM:EECDH+CHACHA20; # Enforce strong ciphers, might break older clients. Adjust as needed.
+    ssl_prefer_server_ciphers on;
+
+    # TLS certificates
+    # Self-signed. Adjust as needed.
+    ssl_certificate /etc/nginx/ssl/nginx.crt;
+    ssl_certificate_key /etc/nginx/ssl/nginx.key;
+    
+    # Route API traffic to backend - https://example.com/service/ -> http://backend:8000/
+    location /service/ {
+        rewrite ^/service/(.*) /$1 break;
+
+        # If using Cloudflare - use this to forward the real client IP
+        # proxy_set_header X-Real-IP $client_real_ip;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-NginX-Proxy true;
+
+        proxy_pass http://backend:8000;
+        proxy_redirect off;
+
+        proxy_cookie_path / "/; HttpOnly; SameSite=strict";
+
+        proxy_buffers 16 32k;
+        proxy_buffer_size 64k;
+        proxy_busy_buffers_size 128k;
+    }
+    
+    location / {
+        include /etc/nginx/mime.types;
+
+        # If using Cloudflare - use this to forward the real client IP
+        # proxy_set_header X-Real-IP $client_real_ip;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+
+        proxy_set_header Host $http_host;
+        proxy_set_header X-NginX-Proxy true;
+
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        proxy_pass http://frontend:3000;
+        proxy_redirect off;
+
+        proxy_buffers 16 32k;
+        proxy_buffer_size 64k;
+        proxy_busy_buffers_size 128k;
+    }
+}

--- a/tailscale/serve.json
+++ b/tailscale/serve.json
@@ -1,0 +1,16 @@
+{
+  "TCP": {
+    "443": {
+      "HTTPS": true
+    }
+  },
+  "Web": {
+    "${TS_CERT_DOMAIN}:443": {
+      "Handlers": {
+        "/": {
+          "Proxy": "http://127.0.0.1:80"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a Docker Compose template for running the Phase Console as a machine on a Tailscale network (tailnet), alongside the existing self-hosting templates:

- `tailscale-docker-compose.yml` — standard Phase Compose stack plus a `tailscale` sidecar. The `nginx`, `backend` and `worker` services share the sidecar's network namespace (`network_mode: service:tailscale`):
  - **Ingress**: the Console joins the tailnet as one machine and is served at `https://phase.<tailnet>.ts.net` with a valid TLS certificate via Tailscale Serve (Funnel optionally exposes it publicly). No Tailscale installation needed on the Docker host.
  - **Egress**: the backend and worker get transparent access to other tailnet machines (with MagicDNS), so integrations can reach private services.
- `tailscale/serve.json` — declarative Tailscale Serve config: TLS on `:443`, proxied to nginx on `:80`.
- `tailscale/nginx.conf` — nginx config with the self-signed TLS listener moved from `:443` to `:8443` (published as host port `443`), since `:443` inside the shared namespace belongs to Tailscale Serve.

The frontend uses a relative `NEXT_PUBLIC_BACKEND_API_BASE=/service` so browser→API calls stay same-origin (CSP `connect-src 'self'`) on every hostname the Console is reachable on.

Docs: phasehq/docs#236 (depends on this PR — it downloads these files from `main`).