### PR TITLE
fix: prevent secret action menu being hidden behind table header

### DIFF
--- a/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
+++ b/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
@@ -127,14 +127,14 @@ export default function EnvironmentPath({
 
   // Cross-env replicate flow: ?createRotation=<sourceRotatingSecretId>
   const replicateSourceId = searchParams?.get('createRotation') ?? null
-  const [rotationPrefill, setRotationPrefill] =
-    useState<CreateRotatingSecretInitialState | null>(null)
+  const [rotationPrefill, setRotationPrefill] = useState<CreateRotatingSecretInitialState | null>(
+    null
+  )
   const [fetchRotationCloneSpec] = useLazyQuery(GetRotationCloneSpec)
 
   // Cross-env replicate flow: ?createDynamic=<sourceDynamicSecretId>
   const replicateDynamicSourceId = searchParams?.get('createDynamic') ?? null
-  const [dynamicPrefill, setDynamicPrefill] =
-    useState<CreateDynamicSecretInitialState | null>(null)
+  const [dynamicPrefill, setDynamicPrefill] = useState<CreateDynamicSecretInitialState | null>(null)
   const [fetchDynamicCloneSpec] = useLazyQuery(GetDynamicSecretCloneSpec)
 
   const [envKeys, setEnvKeys] = useState<EnvKeyring | null>(null)
@@ -1203,7 +1203,10 @@ export default function EnvironmentPath({
               {!allowDynamicSecrets && <PlanLabel plan={ApiOrganisationPlanChoices.En} />}
             </Button>
 
-            <Button variant="secondary" onClick={() => handleAddSecret(true, '', ApiSecretTypeChoices.Secret, '${')}>
+            <Button
+              variant="secondary"
+              onClick={() => handleAddSecret(true, '', ApiSecretTypeChoices.Secret, '${')}
+            >
               <div className="flex items-center gap-2">
                 <FaLink /> Reference a secret
               </div>
@@ -1316,7 +1319,6 @@ export default function EnvironmentPath({
                           </Menu.Items>
                         </Transition>
                       </>
-
                     )}
                   </Menu>
                 ) : (
@@ -1447,7 +1449,6 @@ export default function EnvironmentPath({
               )}
             </div>
 
-            {/* No overflow-hidden: the topmost row's hover action menus rise above the list to overlap the header, and clipping would hide them. First/last rows are corner-rounded directly so their backgrounds still match the card's rounded-md corners (border-radius clips an element's own bg, but not its absolutely-positioned menu). */}
             <div className="flex flex-col gap-0 divide-y divide-neutral-500/20 bg-zinc-100 dark:bg-zinc-800 rounded-md shadow-md [&>*:first-child]:rounded-t-md [&>*:last-child]:rounded-b-md">
               <NewFolderMenu />
               <CreateDynamicSecretDialog

--- a/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
+++ b/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
@@ -1447,7 +1447,8 @@ export default function EnvironmentPath({
               )}
             </div>
 
-            <div className="flex flex-col gap-0 divide-y divide-neutral-500/20 bg-zinc-100 dark:bg-zinc-800 rounded-md shadow-md overflow-hidden">
+            {/* No overflow-hidden: the topmost row's hover action menus rise above the list to overlap the header, and clipping would hide them. First/last rows are corner-rounded directly so their backgrounds still match the card's rounded-md corners (border-radius clips an element's own bg, but not its absolutely-positioned menu). */}
+            <div className="flex flex-col gap-0 divide-y divide-neutral-500/20 bg-zinc-100 dark:bg-zinc-800 rounded-md shadow-md [&>*:first-child]:rounded-t-md [&>*:last-child]:rounded-b-md">
               <NewFolderMenu />
               <CreateDynamicSecretDialog
                 environment={environment}


### PR DESCRIPTION
## :mag: Overview

Fixes #926 

## :framed_picture: Screenshots or Demo

<img width="1526" height="508" alt="image" src="https://github.com/user-attachments/assets/407d8ec3-5611-4707-84b7-e92d5d3adf5f" />

## :sparkles: How to Test the Changes Locally

Verify that the action menu for the first secret in a list shows correctly, and is not hidden behind the table header

