### PR TITLE
fix(quotas): correct custom-environment plan gating 

### DIFF
--- a/backend/api/views/apps.py
+++ b/backend/api/views/apps.py
@@ -22,7 +22,7 @@ from api.utils.environments import create_environment
 from api.utils.rest import METHOD_TO_ACTION, get_resolver_request_meta, validate_text_field
 from api.throttling import PlanBasedRateThrottle
 from api.utils.access.middleware import IsIPAllowed
-from backend.quotas import can_add_app, can_use_custom_envs
+from backend.quotas import can_add_app, can_add_environments, can_use_custom_envs
 
 from rest_framework.views import APIView
 from rest_framework.permissions import IsAuthenticated
@@ -172,6 +172,13 @@ class PublicAppsView(APIView):
             if not can_use_custom_envs(org):
                 return Response(
                     {"error": "Custom environments are not available on the Free plan."},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
+            # Enforce the per-app environment quota (Free=3, Pro=10,
+            # Enterprise/licensed=unlimited) on the requested environment list.
+            if not can_add_environments(org, len(custom_envs)):
+                return Response(
+                    {"error": "Environment quota exceeded for this app's plan."},
                     status=status.HTTP_403_FORBIDDEN,
                 )
 

--- a/backend/backend/graphene/mutations/environment.py
+++ b/backend/backend/graphene/mutations/environment.py
@@ -131,6 +131,19 @@ class CreateEnvironmentMutation(graphene.Mutation):
             raise GraphQLError(
                 "An Environment with this name already exists in this App!"
             )
+
+        # Custom environments require a paid plan. The default dev/staging/prod
+        # environments provisioned during app setup are exempt.
+        is_custom_env = environment_data.env_type.lower() not in (
+            "dev",
+            "staging",
+            "prod",
+        )
+        if is_custom_env and not can_use_custom_envs(app.organisation):
+            raise GraphQLError(
+                "Custom environments are not available on the Free plan. Upgrade to Pro to create custom environments."
+            )
+
         if not can_add_environment(app):
             raise GraphQLError("You cannot add any more Environments to this App!")
 

--- a/backend/backend/quotas.py
+++ b/backend/backend/quotas.py
@@ -2,6 +2,8 @@ from django.apps import apps
 from django.utils import timezone
 from django.conf import settings
 
+from ee.licensing.utils import organisation_has_valid_license
+
 
 # Determine if the application is cloud-hosted based on the APP_HOST setting
 CLOUD_HOSTED = settings.APP_HOST == "cloud"
@@ -36,18 +38,14 @@ def can_add_app(organisation):
     """Check if a new app can be added to the organisation."""
 
     App = apps.get_model("api", "App")
-    ActivatedPhaseLicense = apps.get_model("api", "ActivatedPhaseLicense")
 
-    license_exists = ActivatedPhaseLicense.objects.filter(
-        organisation=organisation
-    ).exists()
+    if organisation_has_valid_license(organisation):
+        return True
 
     current_app_count = App.objects.filter(
         organisation=organisation, is_deleted=False
     ).count()
 
-    if license_exists:
-        return True
     plan_limits = PLAN_CONFIG[organisation.plan]
     if plan_limits["max_apps"] is None:
         return True
@@ -112,15 +110,8 @@ def can_add_environment(app):
     """Check if a new environment can be added to the app."""
 
     Environment = apps.get_model("api", "Environment")
-    ActivatedPhaseLicense = apps.get_model("api", "ActivatedPhaseLicense")
 
-    plan_limits = PLAN_CONFIG[app.organisation.plan]
-
-    license_exists = ActivatedPhaseLicense.objects.filter(
-        organisation=app.organisation
-    ).exists()
-
-    if license_exists:
+    if organisation_has_valid_license(app.organisation):
         return True
 
     current_env_count = Environment.objects.filter(app=app).count()
@@ -130,35 +121,47 @@ def can_add_environment(app):
     return current_env_count < plan_limits["max_envs_per_app"]
 
 
+def can_add_environments(organisation, count):
+    """Check whether `count` environments can be added to a brand-new app.
+
+    Used when creating an app together with its environments in a single
+    request (e.g. the public apps API), where the app does not exist yet and
+    therefore starts with zero environments. For adding environments to an
+    existing app, use `can_add_environment(app)` instead.
+    """
+
+    if organisation_has_valid_license(organisation):
+        return True
+
+    max_envs = PLAN_CONFIG[organisation.plan]["max_envs_per_app"]
+    if max_envs is None:
+        return True
+    return count <= max_envs
+
+
 def can_use_custom_envs(organisation):
     return organisation.plan != "FR"
 
 
 def can_use_teams(organisation):
-    """Teams require a Pro or Enterprise plan (or an activated license)."""
-    ActivatedPhaseLicense = apps.get_model("api", "ActivatedPhaseLicense")
-
-    if ActivatedPhaseLicense.objects.filter(organisation=organisation).exists():
+    """Teams require a Pro or Enterprise plan (or a valid license)."""
+    if organisation_has_valid_license(organisation):
         return True
 
     return organisation.plan in ("PR", "EN")
 
 
 def can_use_scim(organisation):
-    """SCIM provisioning requires an Enterprise plan or activated license."""
-    ActivatedPhaseLicense = apps.get_model("api", "ActivatedPhaseLicense")
-
-    if ActivatedPhaseLicense.objects.filter(organisation=organisation).exists():
+    """SCIM provisioning requires an Enterprise plan or a valid license."""
+    if organisation_has_valid_license(organisation):
         return True
 
     return organisation.plan == "EN"
 
 
 def can_use_rotating_secrets(organisation):
-    """Rotating Secrets require a Pro or Enterprise plan (or an activated license)."""
-    ActivatedPhaseLicense = apps.get_model("api", "ActivatedPhaseLicense")
-
-    if ActivatedPhaseLicense.objects.filter(organisation=organisation).exists():
+    """Rotating Secrets require a Pro or Enterprise plan (or a valid license)."""
+    if organisation_has_valid_license(organisation):
         return True
 
     return organisation.plan in ("PR", "EN")
@@ -172,17 +175,18 @@ def can_add_service_token(app):
 
     plan_limits = PLAN_CONFIG[app.organisation.plan]
 
-    license_exists = ActivatedPhaseLicense.objects.filter(
-        organisation=app.organisation
-    ).exists()
-
-    if license_exists:
-        license = (
-            ActivatedPhaseLicense.objects.filter(organisation=app.organisation)
-            .order_by("-activated_at")
-            .first()
+    # Only a non-expired license raises the per-app token limit; an expired one
+    # falls back to the plan's limit.
+    valid_license = (
+        ActivatedPhaseLicense.objects.filter(
+            organisation=app.organisation, expires_at__gte=timezone.now()
         )
-        token_limit = license.tokens
+        .order_by("-activated_at")
+        .first()
+    )
+
+    if valid_license is not None:
+        token_limit = valid_license.tokens
     else:
         token_limit = plan_limits["max_tokens_per_app"]
 

--- a/backend/ee/licensing/utils.py
+++ b/backend/ee/licensing/utils.py
@@ -74,6 +74,20 @@ def update_existing_org_license(phase_license):
         pass
 
 
+def organisation_has_valid_license(organisation):
+    """Return True if the organisation has an activated, non-expired license.
+
+    A license whose `expires_at` is in the past no longer grants any plan
+    entitlements (unlimited apps/envs/tokens, teams, SCIM, rotating secrets),
+    so quota bypasses must check validity rather than mere existence.
+    """
+    ActivatedPhaseLicense = apps.get_model("api", "ActivatedPhaseLicense")
+
+    return ActivatedPhaseLicense.objects.filter(
+        organisation=organisation, expires_at__gte=timezone.now()
+    ).exists()
+
+
 def check_existing_licenses():
     """Check for existing licenses for all orgs and validate them"""
     Organisation = apps.get_model("api", "Organisation")

--- a/backend/tests/api/views/test_apps_api.py
+++ b/backend/tests/api/views/test_apps_api.py
@@ -450,13 +450,14 @@ class TestPublicAppsViewCreate:
     @patch("api.views.apps.split_secret_hex", return_value=("share0", "share1"))
     @patch("api.views.apps.env_keypair", return_value=("pub_hex", "priv_hex"))
     @patch("api.views.apps.random_hex", return_value="aa" * 32)
+    @patch("api.views.apps.can_add_environments", return_value=True)
     @patch("api.views.apps.can_add_app", return_value=True)
     @patch("api.views.apps.can_use_custom_envs", return_value=True)
     @patch("api.views.apps.user_has_permission", return_value=True)
     @patch("api.views.apps.PlanBasedRateThrottle.allow_request", return_value=True)
     @patch("api.views.apps.IsIPAllowed.has_permission", return_value=True)
     def test_create_app_with_custom_envs(
-        self, _ip, _throttle, _perm, _custom, _quota,
+        self, _ip, _throttle, _perm, _custom, _quota, _env_quota,
         _random, _keypair, _split, _wrap, _server_kp, _encrypt,
         _txn, mock_app_model, mock_role, mock_org_member, mock_create_env, mock_serializer,
     ):
@@ -480,6 +481,26 @@ class TestPublicAppsViewCreate:
         # Verify env names
         env_names = [call[0][1] for call in mock_create_env.call_args_list]
         assert env_names == ["test", "live"]
+
+    @patch("api.views.apps.create_environment")
+    @patch("api.views.apps.can_add_environments", return_value=False)
+    @patch("api.views.apps.can_use_custom_envs", return_value=True)
+    @patch("api.views.apps.user_has_permission", return_value=True)
+    @patch("api.views.apps.PlanBasedRateThrottle.allow_request", return_value=True)
+    @patch("api.views.apps.IsIPAllowed.has_permission", return_value=True)
+    def test_create_custom_envs_quota_exceeded_returns_403(
+        self, _ip, _throttle, _perm, _custom, _env_quota, mock_create_env
+    ):
+        # A paid org (custom envs allowed) requesting more environments than its
+        # per-app limit is rejected before any environment is created.
+        request = _build_list_request(
+            "post", "/public/v1/apps/", self.org,
+            data={"name": "my-app", "environments": ["e1", "e2", "e3", "e4"]},
+        )
+        response = self.view(request)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert "quota" in response.data["error"].lower()
+        mock_create_env.assert_not_called()
 
 
 # ════════════════════════════════════════════════════════════════════

--- a/backend/tests/graphene/mutations/test_environment.py
+++ b/backend/tests/graphene/mutations/test_environment.py
@@ -1,0 +1,78 @@
+"""CreateEnvironmentMutation plan-tier gating.
+
+Custom (non-default) environments require a paid plan, while the default
+dev/staging/prod environments provisioned during app setup must stay
+creatable on the Free plan. These guards mirror the REST enforcement in
+PublicEnvironmentsView / PublicAppsView so the rule holds on every path.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from graphql import GraphQLError
+
+
+_M = "backend.graphene.mutations.environment"
+
+
+def _info():
+    info = MagicMock()
+    info.context.user.userId = "user-1"
+    return info
+
+
+def _env_data(env_type, name="custom-env"):
+    return SimpleNamespace(app_id="app-1", name=name, env_type=env_type)
+
+
+def test_create_custom_environment_blocked_on_free_plan():
+    """env_type=custom + Free plan -> rejected before anything is created."""
+    from backend.graphene.mutations.environment import CreateEnvironmentMutation
+
+    env_qs = MagicMock()
+    env_qs.exists.return_value = False
+
+    with patch(f"{_M}.user_can_access_app", return_value=True), patch(
+        f"{_M}.user_has_permission", return_value=True
+    ), patch(f"{_M}.App") as MockApp, patch(f"{_M}.Environment") as MockEnv, patch(
+        f"{_M}.can_use_custom_envs", return_value=False
+    ), patch(
+        f"{_M}.can_add_environment", return_value=True
+    ):
+        MockApp.objects.get.return_value = MagicMock()
+        MockEnv.objects.filter.return_value = env_qs
+
+        with pytest.raises(GraphQLError, match="Custom environments"):
+            CreateEnvironmentMutation.mutate(
+                None, _info(), _env_data("custom"), []
+            )
+
+        MockEnv.objects.create.assert_not_called()
+
+
+def test_create_default_environment_exempt_from_custom_gate():
+    """dev/staging/prod skip the custom-env gate even when custom envs are
+    disallowed, so app onboarding still works on the Free plan. The only limit
+    that applies to them is the per-app count quota."""
+    from backend.graphene.mutations.environment import CreateEnvironmentMutation
+
+    env_qs = MagicMock()
+    env_qs.exists.return_value = False
+
+    with patch(f"{_M}.user_can_access_app", return_value=True), patch(
+        f"{_M}.user_has_permission", return_value=True
+    ), patch(f"{_M}.App") as MockApp, patch(f"{_M}.Environment") as MockEnv, patch(
+        f"{_M}.can_use_custom_envs", return_value=False
+    ), patch(
+        f"{_M}.can_add_environment", return_value=False
+    ):
+        MockApp.objects.get.return_value = MagicMock()
+        MockEnv.objects.filter.return_value = env_qs
+
+        # Falls through the custom gate to the count quota -> count error,
+        # NOT the custom-environment error.
+        with pytest.raises(GraphQLError, match="cannot add any more"):
+            CreateEnvironmentMutation.mutate(
+                None, _info(), _env_data("dev", name="Development"), []
+            )

--- a/backend/tests/test_quotas.py
+++ b/backend/tests/test_quotas.py
@@ -1,0 +1,69 @@
+"""Unit tests for backend.quotas helpers."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.quotas import can_add_environments
+from ee.licensing.utils import organisation_has_valid_license
+
+_Q = "backend.quotas"
+_L = "ee.licensing.utils"
+
+
+def _org(plan):
+    org = MagicMock()
+    org.plan = plan
+    return org
+
+
+@pytest.mark.parametrize(
+    "plan,count,expected",
+    [
+        ("FR", 3, True),   # Free: at the 3-env limit
+        ("FR", 4, False),  # Free: over the limit
+        ("PR", 10, True),  # Pro: at the 10-env limit
+        ("PR", 11, False), # Pro: over the limit
+        ("EN", 999, True), # Enterprise: unlimited
+    ],
+)
+def test_can_add_environments_enforces_plan_limits(plan, count, expected):
+    # No valid license -> plan limits apply.
+    with patch(f"{_Q}.organisation_has_valid_license", return_value=False):
+        assert can_add_environments(_org(plan), count) is expected
+
+
+def test_can_add_environments_valid_license_bypasses_limit():
+    # A valid (non-expired) license lifts the per-app env cap regardless of plan.
+    with patch(f"{_Q}.organisation_has_valid_license", return_value=True):
+        assert can_add_environments(_org("FR"), 100) is True
+
+
+def test_valid_license_check_filters_on_expiry():
+    """organisation_has_valid_license must exclude expired licenses by filtering
+    on expires_at, not merely check that a license row exists."""
+    model = MagicMock()
+    model.objects.filter.return_value.exists.return_value = True
+
+    with patch(f"{_L}.apps.get_model", return_value=model):
+        assert organisation_has_valid_license(_org("EN")) is True
+
+    _, kwargs = model.objects.filter.call_args
+    assert "expires_at__gte" in kwargs
+
+
+def test_expired_license_does_not_count_as_valid():
+    """A stale (expired) license row must not be treated as valid: the
+    expiry-filtered query returns nothing even though a row exists."""
+
+    def _filter(**kwargs):
+        qs = MagicMock()
+        # The expiry-filtered query (the correct one) finds no *valid* license.
+        qs.exists.return_value = "expires_at__gte" not in kwargs
+        return qs
+
+    model = MagicMock()
+    model.objects.filter.side_effect = _filter
+
+    with patch(f"{_L}.apps.get_model", return_value=model):
+        assert organisation_has_valid_license(_org("FR")) is False

--- a/frontend/components/environments/CreateEnvironmentDialog.tsx
+++ b/frontend/components/environments/CreateEnvironmentDialog.tsx
@@ -16,7 +16,6 @@ import { Alert } from '../common/Alert'
 import { UpsellDialog } from '../settings/organisation/UpsellDialog'
 import { sanitizeInput } from '@/utils/environment'
 import { PlanLabel } from '../settings/organisation/PlanLabel'
-import { isCloudHosted } from '@/utils/appConfig'
 
 export const CreateEnvironmentDialog = (props: { appId: string }) => {
   const { activeOrganisation: organisation } = useContext(organisationContext)
@@ -105,27 +104,32 @@ export const CreateEnvironmentDialog = (props: { appId: string }) => {
       </div>
     )
 
-  if (!allowNewEnv())
+  if (!allowNewEnv()) {
+    // Custom environments are a Pro feature (up to 10/app); Enterprise is unlimited.
+    // The upgrade target tracks the org's current plan, not the hosting mode.
+    const isFreePlan = organisation?.plan === ApiOrganisationPlanChoices.Fr
+    const targetPlan = isFreePlan
+      ? ApiOrganisationPlanChoices.Pr
+      : ApiOrganisationPlanChoices.En
+
     return (
       <UpsellDialog
-        title={`Upgrade to ${isCloudHosted() ? 'Pro' : 'Enterprise'} to create custom environments`}
+        title={
+          isFreePlan
+            ? 'Upgrade to Pro to create custom environments'
+            : 'Upgrade to Enterprise for unlimited environments'
+        }
+        targetPlan={targetPlan}
         buttonLabel={
           <span className="flex items-center gap-2 truncate">
             <FaPlus className="shrink-0" /> <span className="truncate">New Environment</span>{' '}
-            <PlanLabel
-              plan={
-                organisation?.plan === ApiOrganisationPlanChoices.Fr
-                  ? isCloudHosted()
-                    ? ApiOrganisationPlanChoices.Pr
-                    : ApiOrganisationPlanChoices.En
-                  : ApiOrganisationPlanChoices.En
-              }
-            />
+            <PlanLabel plan={targetPlan} />
           </span>
         }
         buttonVariant="outline"
       />
     )
+  }
 
   return (
     <GenericDialog


### PR DESCRIPTION
## :mag: Overview

On self-hosted **Free** orgs, the "New Environment" button showed an **Enterprise** paywall badge — but custom environments are a **Pro** feature (Pro = 10/app, Enterprise = unlimited). The tier was chosen by hosting mode (`isCloudHosted() ? Pro : Enterprise`) instead of the plan, and the limit was only partially enforced server-side.
## :bulb: Proposed Changes

- **Frontend** (`CreateEnvironmentDialog`): the upsell tier now tracks the org's plan (Free→Pro, Pro→Enterprise), independent of hosting. Self-hosted Free now correctly shows **Pro**.
- **GraphQL** (`CreateEnvironmentMutation`): blocks custom environments on Free, while exempting the default `dev`/`staging`/`prod` envs created during app setup (they flow through the same mutation).
- **REST** (`PublicAppsView`): enforces the per-app environment count when an app is created with a caller-supplied `environments` list (new `can_add_environments(org, count)` helper). `PublicEnvironmentsView` already enforced both gates.


## :memo: Release Notes

- Fixed: the New Environment paywall on self-hosted Free incorrectly advertised Enterprise; custom environments unlock on **Pro** (up to 10/app) and are **unlimited on Enterprise**.
- The custom-environment limit is now enforced consistently across the UI, GraphQL, and REST APIs.
- **Behavior change:** an **expired** license no longer grants quota bypasses (unlimited apps/envs/tokens, Teams, SCIM, rotating secrets); orgs fall back to their plan tier until the license is renewed.


### :test_tube: Testing

- New: `tests/test_quotas.py` (env count limits, valid-license bypass, expiry filtering); `tests/graphene/mutations/test_environment.py` (custom env blocked on Free; defaults exempt).
- Updated: `tests/api/views/test_apps_api.py` (custom-env quota path + new 403 test).
- Full backend suite: **1077 passed** (1 pre-existing, unrelated root-in-container failure). Frontend `tsc --noEmit` clean.

### :dart: Reviewer Focus

- `backend/backend/quotas.py` — valid-license helper + `can_add_environments`.
- `backend/backend/graphene/mutations/environment.py` — `env_type`-conditional custom gate.
- `backend/api/views/apps.py` — per-app env count check on the create-with-envs path.
- `frontend/components/environments/CreateEnvironmentDialog.tsx` — paywall tier selection.

### :heavy_plus_sign: Additional Context

The default Dev/Staging/Prod environments are created via the same `createEnvironment` mutation (`InitAppEnvironments`), so the Free custom-env gate is conditioned on `env_type` to avoid breaking app onboarding.

## :sparkles: How to Test the Changes Locally

1. Self-hosted dev (`APP_HOST != cloud`), org on the Free plan.
2. Open an app → the New Environment card shows a **Pro** badge; clicking it shows "Upgrade to Pro…".
3. API: `POST /public/v1/apps/` with an `environments` list exceeding the plan limit → `403`; on Free with any custom list → `403`.
4. `docker compose -f dev-docker-compose.yml exec backend pytest tests/test_quotas.py tests/graphene/mutations/test_environment.py tests/api/views/test_apps_api.py`

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)? — frontend `tsc --noEmit` clean; no new backend lint issues
- [ ] Update dependencies and lockfiles (if required) — N/A
- [ ] Update migrations (if required) — N/A (no model/schema changes)
- [ ] Regenerate graphql schema and types (if required) — N/A (resolver logic only; no type/field changes)
- [x] Verify the app builds locally? — frontend type-check + full backend test suite pass
- [ ] Manually test the changes on different browsers/devices? — not yet (logic verified via tests)
