### PR TITLE
feat(webauth): honor a CLI-requested token lifetime

### DIFF
--- a/frontend/app/webauth/[requestCode]/page.tsx
+++ b/frontend/app/webauth/[requestCode]/page.tsx
@@ -22,6 +22,8 @@ import {
 } from '@/utils/crypto'
 
 import { getDevicePassword } from '@/utils/localStorage'
+import { humanReadableExpiryTimestamp } from '@/utils/tokens'
+import { WebAuthRequestParams, parseWebAuthRequest, expiryFromLifetime } from '@/utils/webAuth'
 import { useMutation } from '@apollo/client'
 import { Disclosure, Transition } from '@headlessui/react'
 import axios from 'axios'
@@ -33,28 +35,11 @@ import { FaChevronRight, FaExclamationTriangle, FaCheckCircle, FaShieldAlt } fro
 import { SiGithub, SiGnometerminal, SiSlack } from 'react-icons/si'
 import { toast } from 'react-toastify'
 
-interface WebAuthRequestParams {
-  port: number
-  publicKey: string
-  requestedTokenName: string
-}
-
 const handleCopy = (val: string) => {
   copyToClipBoard(val)
   toast.info('Copied', {
     autoClose: 2000,
   })
-}
-
-const getWebAuthRequestParams = (hash: string): WebAuthRequestParams => {
-  const delimiter = '-'
-  const params = hash.split(delimiter)
-
-  return {
-    port: Number(params[0]),
-    publicKey: params[1],
-    requestedTokenName: params[2],
-  }
 }
 
 export default function WebAuth({ params }: { params: { requestCode: string } }) {
@@ -71,7 +56,12 @@ export default function WebAuth({ params }: { params: { requestCode: string } })
 
   const { data: session } = useSession()
 
-  const handleCreatePat = (name: string, organisationId: string, keyring: OrganisationKeyring) => {
+  const handleCreatePat = (
+    name: string,
+    organisationId: string,
+    keyring: OrganisationKeyring,
+    expiry: number | null
+  ) => {
     return new Promise<string>(async (resolve, reject) => {
       if (keyring) {
         const userKxKeys = {
@@ -83,7 +73,7 @@ export default function WebAuth({ params }: { params: { requestCode: string } })
           organisationId,
           userKxKeys,
           name,
-          null
+          expiry
         )
 
         const { data } = await createUserToken({
@@ -115,11 +105,14 @@ export default function WebAuth({ params }: { params: { requestCode: string } })
       throw new Error('Incorrect sudo password')
     }
 
+    const expiry = expiryFromLifetime(requestParams.requestedTokenLifetime)
+
     try {
       const pssUser = await handleCreatePat(
         requestParams.requestedTokenName,
         organisation.id,
-        keyring
+        keyring,
+        expiry
       )
       setUserToken(pssUser)
 
@@ -150,7 +143,7 @@ export default function WebAuth({ params }: { params: { requestCode: string } })
     const validateWebAuthRequest = async () => {
       try {
         const decodedWebAuthReq = await decodeb64string(decodeURIComponent(params.requestCode))
-        const authRequestParams = getWebAuthRequestParams(decodedWebAuthReq)
+        const authRequestParams = parseWebAuthRequest(decodedWebAuthReq)
 
         if (!authRequestParams.publicKey || !authRequestParams.requestedTokenName) {
           setStatus('invalid')
@@ -308,6 +301,13 @@ export default function WebAuth({ params }: { params: { requestCode: string } })
             <p className="text-neutral-500 text-lg">
               Choose an account below to authenticate with the Phase CLI
             </p>
+            {requestParams && (
+              <p className="text-neutral-500 text-sm pt-1">
+                {humanReadableExpiryTimestamp(
+                  expiryFromLifetime(requestParams.requestedTokenLifetime)
+                )}
+              </p>
+            )}
           </div>
           <div className="flex flex-col gap-4 w-ful max-w-2xl">
             {organisations?.map((organisation, index) => (

--- a/frontend/tests/utils/tokens.test.ts
+++ b/frontend/tests/utils/tokens.test.ts
@@ -1,0 +1,14 @@
+import { humanReadableExpiryTimestamp } from '@/utils/tokens'
+
+describe('humanReadableExpiryTimestamp', () => {
+  it('describes a null expiry as never expiring', () => {
+    expect(humanReadableExpiryTimestamp(null)).toBe('This token will never expire.')
+  })
+
+  it('describes a timestamp as a localized expiry date', () => {
+    const expiry = 1700000000000
+    expect(humanReadableExpiryTimestamp(expiry)).toBe(
+      `This token will expire on ${new Date(expiry).toLocaleDateString()}.`
+    )
+  })
+})

--- a/frontend/tests/utils/webAuth.test.ts
+++ b/frontend/tests/utils/webAuth.test.ts
@@ -1,0 +1,94 @@
+import { expiryFromLifetime, parseWebAuthRequest } from '@/utils/webAuth'
+
+describe('parseWebAuthRequest', () => {
+  describe('JSON payload (new CLI)', () => {
+    it('parses a JSON payload with a requested lifetime', () => {
+      const decoded = JSON.stringify({
+        port: 8002,
+        publicKey: 'abc123',
+        name: 'john@laptop',
+        lifetime: 604800,
+      })
+
+      expect(parseWebAuthRequest(decoded)).toEqual({
+        port: 8002,
+        publicKey: 'abc123',
+        requestedTokenName: 'john@laptop',
+        requestedTokenLifetime: 604800,
+      })
+    })
+
+    it('treats a missing lifetime as never-expiring', () => {
+      const decoded = JSON.stringify({ port: 8002, publicKey: 'abc123', name: 'john@laptop' })
+
+      expect(parseWebAuthRequest(decoded).requestedTokenLifetime).toBeNull()
+    })
+
+    it('treats a non-positive lifetime as never-expiring', () => {
+      const decoded = JSON.stringify({
+        port: 8002,
+        publicKey: 'abc123',
+        name: 'john@laptop',
+        lifetime: 0,
+      })
+
+      expect(parseWebAuthRequest(decoded).requestedTokenLifetime).toBeNull()
+    })
+
+    it('preserves a token name containing hyphens', () => {
+      const decoded = JSON.stringify({
+        port: 8002,
+        publicKey: 'abc123',
+        name: 'john@my-dev-laptop',
+        lifetime: 3600,
+      })
+
+      expect(parseWebAuthRequest(decoded).requestedTokenName).toBe('john@my-dev-laptop')
+    })
+  })
+
+  describe('legacy hyphen-joined payload (old CLI)', () => {
+    it('parses the legacy `port-pubKeyHex-patName` format with no lifetime', () => {
+      expect(parseWebAuthRequest('8002-abc123-john@laptop')).toEqual({
+        port: 8002,
+        publicKey: 'abc123',
+        requestedTokenName: 'john@laptop',
+        requestedTokenLifetime: null,
+      })
+    })
+
+    it('keeps a token name that itself contains hyphens', () => {
+      expect(parseWebAuthRequest('8002-abc123-john@my-dev-laptop').requestedTokenName).toBe(
+        'john@my-dev-laptop'
+      )
+    })
+
+    it('falls back to the legacy parse when the payload is valid JSON but not an object', () => {
+      // `8002` parses as a JSON number; the non-object guard must reject it and use the legacy path.
+      expect(parseWebAuthRequest('8002')).toEqual({
+        port: 8002,
+        publicKey: '',
+        requestedTokenName: '',
+        requestedTokenLifetime: null,
+      })
+    })
+  })
+})
+
+describe('expiryFromLifetime', () => {
+  it('returns null for a null lifetime', () => {
+    expect(expiryFromLifetime(null)).toBeNull()
+  })
+
+  it('returns null for a zero lifetime', () => {
+    expect(expiryFromLifetime(0)).toBeNull()
+  })
+
+  it('returns an absolute ms timestamp lifetime seconds in the future', () => {
+    const now = Date.now()
+    const expiry = expiryFromLifetime(604800)
+
+    expect(expiry).not.toBeNull()
+    expect(expiry!).toBeGreaterThanOrEqual(now + 604800 * 1000)
+  })
+})

--- a/frontend/utils/tokens.ts
+++ b/frontend/utils/tokens.ts
@@ -33,6 +33,11 @@ export const humanReadableExpiry = (expiryOption: ExpiryOptionT) =>
     ? 'This token will never expire.'
     : `This token will expire on ${new Date(expiryOption.getExpiry()!).toLocaleDateString()}.`
 
+export const humanReadableExpiryTimestamp = (expiry: number | null) =>
+  expiry === null
+    ? 'This token will never expire.'
+    : `This token will expire on ${new Date(expiry).toLocaleDateString()}.`
+
 export const compareExpiryOptions = (a: ExpiryOptionT, b: ExpiryOptionT) => {
   return a.getExpiry() === b.getExpiry()
 }

--- a/frontend/utils/webAuth.ts
+++ b/frontend/utils/webAuth.ts
@@ -1,0 +1,61 @@
+export interface WebAuthRequestParams {
+  port: number
+  publicKey: string
+  requestedTokenName: string
+  // The token lifetime requested by the CLI, in seconds. null = never expires.
+  requestedTokenLifetime: number | null
+}
+
+/**
+ * Parse a decoded webauth request payload sent by the Phase CLI.
+ *
+ * New CLIs send a base64-encoded JSON object:
+ *   { port: number, publicKey: string, name: string, lifetime?: number }
+ * where `lifetime` is the requested token lifetime in seconds (omitted, null or
+ * non-positive = never expires).
+ *
+ * Older CLIs send a hyphen-joined string `port-pubKeyHex-patName`. The token name
+ * itself can contain hyphens, so everything after the second hyphen is the name.
+ *
+ * @param {string} decoded - the base64-decoded payload string.
+ * @returns {WebAuthRequestParams}
+ */
+export const parseWebAuthRequest = (decoded: string): WebAuthRequestParams => {
+  try {
+    const payload = JSON.parse(decoded)
+
+    if (payload && typeof payload === 'object' && !Array.isArray(payload)) {
+      const lifetime =
+        typeof payload.lifetime === 'number' && payload.lifetime > 0 ? payload.lifetime : null
+
+      return {
+        port: Number(payload.port),
+        publicKey: typeof payload.publicKey === 'string' ? payload.publicKey : '',
+        requestedTokenName: typeof payload.name === 'string' ? payload.name : '',
+        requestedTokenLifetime: lifetime,
+      }
+    }
+  } catch {
+    // Not JSON - fall through to the legacy hyphen-joined format.
+  }
+
+  const delimiter = '-'
+  const params = decoded.split(delimiter)
+
+  return {
+    port: Number(params[0]),
+    publicKey: params[1] ?? '',
+    requestedTokenName: params.slice(2).join(delimiter),
+    requestedTokenLifetime: null,
+  }
+}
+
+/**
+ * Convert a requested token lifetime (in seconds) into an absolute Unix expiry
+ * timestamp in milliseconds, as expected by `generateUserToken`/`CreateUserTokenMutation`.
+ *
+ * @param {number | null} lifetime - the requested lifetime in seconds, or null.
+ * @returns {number | null} the absolute expiry timestamp in ms, or null for never-expiring.
+ */
+export const expiryFromLifetime = (lifetime: number | null): number | null =>
+  lifetime ? Date.now() + lifetime * 1000 : null


### PR DESCRIPTION
## Overview

PATs minted through the CLI `webauth` login flow always had infinite lifetime. The approval page hardcoded the token expiry to `null` when calling `generateUserToken(...)`, even though per-token expiry is supported everywhere else:

- `CreateUserTokenMutation` accepts `expiry: BigInt` (`backend/backend/graphene/mutations/environment.py`)
- `UserToken.expires_at` exists and is nullable (`backend/api/models.py`)
- Expiry is enforced on auth (`backend/api/utils/rest.py`, `token_is_expired_or_deleted`)
- The normal "Create token" dialog already lets users pick an expiry

The webauth path was the only token-creation flow that could not set an expiry. Fixing it requires reworking the webauth request payload to be parse-safe, which is the same migration two CLI flags depend on (`--token-lifetime` and `--token-name`). This PR is the Console half; the CLI side is phasehq/cli#302 and phasehq/cli#303.

## Proposed Changes

Rework the webauth payload parsing to a parse-safe format and honor a CLI-requested token lifetime. No backend change is needed.

- **New `frontend/utils/webAuth.ts`:**
  - `parseWebAuthRequest(decoded)` accepts a base64(JSON) payload `{ port, publicKey, name, lifetime? }`:
    - `name` is the requested token name, parsed as a string so arbitrary, user-supplied names (hyphens, spaces, etc.) survive intact - this is the format dependency for the CLI `--token-name` flag (cli#303).
    - `lifetime` is the requested lifetime in **seconds** (omitted / null / non-positive = never expires) - drives the CLI `--token-lifetime` flag (cli#302).
    - Falls back to the legacy `port-pubKeyHex-patName` format for older CLIs. The legacy parse now keeps everything after the second hyphen as the name (`params.slice(2).join('-')`) instead of `params[2]`, which fixes the truncation bug (#937).
  - `expiryFromLifetime(lifetime)` converts the requested lifetime (seconds) into an absolute millisecond expiry timestamp, as expected by `generateUserToken` / `CreateUserTokenMutation`.
- **`frontend/utils/tokens.ts`:** add `humanReadableExpiryTimestamp(expiry)` to render an absolute-timestamp expiry, mirroring the existing `humanReadableExpiry`.
- **`frontend/app/webauth/[requestCode]/page.tsx`:** use `parseWebAuthRequest`; compute the expiry at mint time and pass it to `generateUserToken` instead of hardcoded `null`; show the resulting expiry on the approval screen. Removed the inline `WebAuthRequestParams` interface and `getWebAuthRequestParams` helper (moved to the util).

No requested lifetime preserves the current never-expires behavior; no requested name preserves the CLI's `username@hostname` default.

Cross-repo contract: the base64(JSON) payload shape documented in `webAuth.ts` is what the CLI side (cli#302, cli#303) must emit. Adding this one format migration unblocks both CLI flags.

## Screenshots or Demo

Visible change: on the CLI authentication ("in progress") screen, a line now shows the resulting token expiry, e.g. "This token will expire on 7/5/2026." or "This token will never expire." when no lifetime was requested.

## Release Notes

The CLI login flow (`phase auth` webauth) can now request a token lifetime, and the Console honors it - the minted personal access token expires accordingly instead of always living forever. Logins that do not request a lifetime are unchanged (non-expiring). The webauth payload is also now parse-safe, which fixes PAT names being truncated at the first hyphen and lets the CLI send a custom token name. Requires a CLI version that sends the new payload (phasehq/cli#302, phasehq/cli#303); older CLIs keep working unchanged.

## Open Questions

- Payload format contract: I went with base64(JSON) + legacy-string fallback; `lifetime` in seconds (Console computes the absolute expiry) and `name` as a free-form string. This needs to match phasehq/cli#302 and phasehq/cli#303. Happy to adjust field names/units if preferred.

### Testing

- `frontend/tests/utils/webAuth.test.ts` (new): `parseWebAuthRequest` across JSON and legacy payloads, lifetime present/absent/non-positive, hyphenated token names (the #937 case), and the non-object-JSON fallback guard; plus `expiryFromLifetime` (null, zero, future timestamp).
- `frontend/tests/utils/tokens.test.ts` (new): `humanReadableExpiryTimestamp` null and timestamp branches.
- 12 tests passing (`yarn test tests/utils/webAuth.test.ts tests/utils/tokens.test.ts`). Lint and `tsc --noEmit` clean for the changed files, and `next build` succeeds (`/webauth/[requestCode]` compiles).
- Smoke test against a local dev stack: `GET /webauth/<base64(JSON)>` serves and redirects unauthenticated users to `/login` with the payload preserved intact.
- Gap: the `page.tsx` wiring is not unit-tested - this repo has no page/component test pattern (`jest.config.js` roots to `tests/`, which holds pure-util tests), so the logic was extracted into testable utils instead. Full end-to-end verification (login -> approve -> mint) needs a running CLI + Console.

### Reviewer Focus

Start at `frontend/utils/webAuth.ts` - `parseWebAuthRequest` (the payload contract, legacy fallback, and arbitrary-name handling) is the core of the change and the cross-repo interface shared by both CLI flags. Then `frontend/app/webauth/[requestCode]/page.tsx` for how the expiry is computed and passed to `generateUserToken`.

### Additional Context

- Closes #928 (honor a CLI-requested token lifetime)
- Fixes #937 (webauth PAT names truncated at the first hyphen)
- Coordinated CLI changes: phasehq/cli#302 (`--token-lifetime`) and phasehq/cli#303 (`--token-name`), which share this payload-format migration

## How to Test the Changes Locally

1. Run the dev stack (`docker compose --env-file .env.dev -f dev-docker-compose.yml up -d`) and sign in.
2. With a CLI build from phasehq/cli#302, run `phase auth --token-lifetime 7d` and complete the webauth flow; confirm the approval screen shows the expiry and the created PAT carries `expires_at`.
3. With a CLI build from phasehq/cli#303, run `phase auth --token-name "ci-prod-api"` and confirm the PAT is created with that exact name (including hyphens).
4. Without those CLI builds (legacy payload), run a normal `phase auth` webauth login and confirm the token is still created, never-expiring, and its `username@hostname` name is no longer truncated at the first hyphen.
5. Manual payload check without the CLI: base64-encode `{"port":8002,"publicKey":"<hex>","name":"user@my-host","lifetime":604800}` and open `/webauth/<b64>`; verify the full name is used and the expiry line renders.

### Did You...

- [x] Ensure linting passes (code style checks)?
- [x] Update dependencies and lockfiles (if required) - N/A (no dependency or lockfile change)
- [x] Update migrations (if required) - N/A (no backend change)
- [x] Regenerate graphql schema and types (if required) - N/A (no backend GraphQL change)
- [x] Verify the app builds locally? - `next build` succeeds; `/webauth/[requestCode]` compiles
- [x] Manually test the changes on different browsers/devices? - route smoke-tested (serves, redirects to login with payload intact); parsing/expiry logic covered by unit tests
