### PR TITLE
fix: sync client-side secret value visiblity to the type toggle state

### DIFF
--- a/frontend/app/[team]/apps/[app]/_components/AppSecretRow.tsx
+++ b/frontend/app/[team]/apps/[app]/_components/AppSecretRow.tsx
@@ -701,6 +701,7 @@ const AppSecretRowComponent = ({
 }
 
 const areAppSecretRowEqual = (prev: AppSecretRowProps, next: AppSecretRowProps) => {
+  if (prev.index !== next.index) return false
   if (prev.isExpanded !== next.isExpanded) return false
   if (prev.stagedForDelete !== next.stagedForDelete) return false
   if (prev.revealOnHover !== next.revealOnHover) return false

--- a/frontend/app/[team]/apps/[app]/_components/AppSecretRow.tsx
+++ b/frontend/app/[team]/apps/[app]/_components/AppSecretRow.tsx
@@ -158,6 +158,18 @@ const EnvSecretComponent = ({
     if (isBoolean) setShowValue(true)
   }, [isBoolean])
 
+  // Sync visibility when the type is toggled: config → revealed, secret/sealed → masked
+  const secretType = clientEnvSecret.secret?.type
+  const prevTypeRef = useRef(secretType)
+  useEffect(() => {
+    const prevType = prevTypeRef.current
+    prevTypeRef.current = secretType
+    if (!prevType || !secretType || prevType === secretType) return
+    if (isSealedAndSaved) return
+    if (secretType === ApiSecretTypeChoices.Config) setShowValue(true)
+    else if (!isBoolean) setShowValue(false)
+  }, [secretType, isSealedAndSaved, isBoolean])
+
   const handleHideSecret = () => {
     if (isSealedAndSaved) return
     setShowValue(false)
@@ -360,7 +372,9 @@ const areEnvSecretEqual = (
     (p?.type ?? null) === (n?.type ?? null) &&
     (p?.stagedForDelete ?? false) === (n?.stagedForDelete ?? false) &&
     (p?.rotatingSecretId ?? null) === (n?.rotatingSecretId ?? null) &&
-    prev.serverEnvSecret?.secret?.value === next.serverEnvSecret?.secret?.value
+    prev.serverEnvSecret?.secret?.value === next.serverEnvSecret?.secret?.value &&
+    (prev.serverEnvSecret?.secret?.id ?? null) === (next.serverEnvSecret?.secret?.id ?? null) &&
+    (prev.serverEnvSecret?.secret?.type ?? null) === (next.serverEnvSecret?.secret?.type ?? null)
   )
 }
 
@@ -704,6 +718,20 @@ const areAppSecretRowEqual = (prev: AppSecretRowProps, next: AppSecretRowProps) 
     if ((p?.type ?? null) !== (n?.type ?? null)) return false
     if ((p?.stagedForDelete ?? false) !== (n?.stagedForDelete ?? false)) return false
     if ((p?.rotatingSecretId ?? null) !== (n?.rotatingSecretId ?? null)) return false
+  }
+
+  // Server state drives isSealedAndSaved and the modified highlight — compare it too
+  if ((prev.serverAppSecret?.id ?? null) !== (next.serverAppSecret?.id ?? null)) return false
+  if ((prev.serverAppSecret?.key ?? null) !== (next.serverAppSecret?.key ?? null)) return false
+  const prevServerEnvs = prev.serverAppSecret?.envs ?? []
+  const nextServerEnvs = next.serverAppSecret?.envs ?? []
+  if (prevServerEnvs.length !== nextServerEnvs.length) return false
+  for (let i = 0; i < prevServerEnvs.length; i++) {
+    const p = prevServerEnvs[i].secret
+    const n = nextServerEnvs[i].secret
+    if ((p?.id ?? null) !== (n?.id ?? null)) return false
+    if ((p?.value ?? '') !== (n?.value ?? '')) return false
+    if ((p?.type ?? null) !== (n?.type ?? null)) return false
   }
   return true
 }

--- a/frontend/app/[team]/apps/[app]/_components/AppSecrets.tsx
+++ b/frontend/app/[team]/apps/[app]/_components/AppSecrets.tsx
@@ -578,9 +578,9 @@ export const AppSecrets = ({ team, app }: { team: string; app: string }) => {
         setAppSecretsToDelete([])
       }
 
+      // The appSecrets sync effect picks up the refetched data once decryption
+      // completes — setting state here would write the stale pre-deploy snapshot
       await refetch()
-      setServerAppSecrets(appSecrets)
-      setClientAppSecrets(appSecrets)
     }
   }
 


### PR DESCRIPTION
## :mag: Overview

On the single-env secrets editor, toggling a secret's type immediately updates value visibility — `config` → revealed, `secret` → masked, `sealed` → locked "Sealed" state. On the cross-env editor, the toggle had no visible effect: the change only appeared after deploying **and** doing a full page refresh.

## :bulb: Proposed Changes

Two client-side fixes in `AppSecretRow.tsx`:

- **React to type toggles:** `EnvSecretComponent` initialized its reveal state once on mount and never updated it. A new effect syncs visibility when the type changes (config → revealed, secret/sealed → masked), mirroring the single-env `SecretRow` behavior. It's a change-detector keyed on the previous type, so mount rules (new/empty values start revealed, "Add value" reveals) and boolean secrets are unaffected.
- **Compare server-side state in memo comparators:** `areAppSecretRowEqual` ignored `serverAppSecret` entirely and `areEnvSecretEqual` only compared the server value. After a deploy + refetch, only the server copy changes (the client copy already matched), so re-renders were memo-blocked — `isSealedAndSaved` never activated and rows kept stale state until refresh. Both comparators now also compare server secret id/key/value/type. This also un-sticks the amber "modified" highlight after deploying a type-only change.

## :memo: Release Notes

- Fixed: on the cross-env secrets view, changing a secret's type now immediately updates value visibility, and sealed secrets show their locked state right after deploying — no page refresh needed.

## :sparkles: How to Test the Changes Locally

1. Open an app's overview (cross-env) view and expand a secret row.
2. Toggle the type via the type selector in the key cell: `config` reveals the value in every environment, `secret` masks them again — instantly, before deploying.
3. Set a secret to `sealed` and hit Deploy: rows switch to the disabled "Sealed" state immediately, without a refresh.

### :green_heart: Did You...

- [ ] Ensure linting passes (code style checks)?
- [x] Verify the app builds locally? (`tsc --noEmit` clean)
- [ ] Manually test the changes on different browsers/devices?
