### PR TITLE
fix: service account handler eligibility for manager role

### DIFF
--- a/backend/backend/graphene/queries/service_accounts.py
+++ b/backend/backend/graphene/queries/service_accounts.py
@@ -4,6 +4,7 @@ from api.utils.access.permissions import (
     user_has_permission,
     user_is_org_member,
 )
+from api.utils.access.roles import default_roles
 from api.models import App, Organisation, OrganisationMember, Role, ServiceAccount, TeamMembership
 from .access import resolve_organisation_global_access_users
 from django.db.models import Q
@@ -75,21 +76,34 @@ def resolve_service_account_handlers(root, info, org_id):
     if not user_is_org_member(info.context.user.userId, org_id):
         raise GraphQLError("You don't have access to this organisation")
 
-    service_account_handler_roles = Role.objects.filter(
-        Q(organisation_id=org_id)
-        & (
-            Q(name__iexact="owner")
-            | Q(name__iexact="admin")
-            | Q(permissions__global_access=True)  # Check for global access roles
-            | Q(permissions__permissions__ServiceAccounts__gt=0)
-        ),
-    )
+    # Default roles store an empty permissions JSON in the DB — resolve from the template
+    def role_permissions(role):
+        if role.is_default:
+            return default_roles.get(role.name.capitalize(), {})
+        return role.permissions or {}
 
+    def role_is_handler_eligible(role):
+        if role_has_global_access(role):
+            return True
+        # The default Service role is for machine accounts, not key custody
+        if role.is_default and role.name.lower() == "service":
+            return False
+        return bool(
+            role_permissions(role).get("permissions", {}).get("ServiceAccounts", [])
+        )
+
+    handler_role_ids = [
+        role.id
+        for role in Role.objects.filter(organisation_id=org_id)
+        if role_is_handler_eligible(role)
+    ]
+
+    # Exclude members pending their key ceremony — no public key to wrap to
     members = OrganisationMember.objects.filter(
         organisation_id=org_id,
-        role__in=service_account_handler_roles,
+        role_id__in=handler_role_ids,
         deleted_at=None,
-    )
+    ).exclude(Q(identity_key__isnull=True) | Q(identity_key=""))
 
     return members
 

--- a/backend/tests/graphene/queries/test_service_accounts.py
+++ b/backend/tests/graphene/queries/test_service_accounts.py
@@ -1,0 +1,134 @@
+"""resolve_service_account_handlers role eligibility.
+
+Default roles store an empty permissions JSON in the DB; their permissions
+live in the default_roles template. The old JSON-query filter silently
+excluded every default role except Owner/Admin, so default-role Managers
+were never provisioned as SA handlers. Eligibility must be resolved from
+the template for default roles and from the stored JSON for custom roles.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+_M = "backend.graphene.queries.service_accounts"
+
+
+def _info(user=None):
+    info = MagicMock()
+    user = user or MagicMock()
+    user.userId = "u1"
+    info.context.user = user
+    return info
+
+
+def _default_role(name):
+    return SimpleNamespace(id=f"role-{name.lower()}", name=name, is_default=True, permissions={})
+
+
+def _custom_role(role_id, permissions):
+    return SimpleNamespace(id=role_id, name=role_id, is_default=False, permissions=permissions)
+
+
+def _resolve_with_roles(roles):
+    """Run the resolver with mocked ORM; return the eligible role ids."""
+    from backend.graphene.queries.service_accounts import (
+        resolve_service_account_handlers,
+    )
+
+    with patch(f"{_M}.user_is_org_member", return_value=True), patch(
+        f"{_M}.Role"
+    ) as mock_role_cls, patch(f"{_M}.OrganisationMember") as mock_member_cls:
+        mock_role_cls.objects.filter.return_value = roles
+        resolve_service_account_handlers(None, _info(), org_id="org1")
+        _args, kwargs = mock_member_cls.objects.filter.call_args
+        return set(kwargs["role_id__in"])
+
+
+def test_default_manager_role_is_handler_eligible():
+    """The regression: Manager's permissions only exist in the template."""
+    eligible = _resolve_with_roles([_default_role("Manager")])
+    assert eligible == {"role-manager"}
+
+
+def test_default_owner_and_admin_roles_are_handler_eligible():
+    eligible = _resolve_with_roles([_default_role("Owner"), _default_role("Admin")])
+    assert eligible == {"role-owner", "role-admin"}
+
+
+def test_default_developer_role_is_not_handler_eligible():
+    eligible = _resolve_with_roles([_default_role("Developer")])
+    assert eligible == set()
+
+
+def test_default_service_role_is_not_handler_eligible():
+    """Machine-account role — excluded despite ServiceAccounts:["read"]."""
+    eligible = _resolve_with_roles([_default_role("Service")])
+    assert eligible == set()
+
+
+def test_custom_role_with_service_account_permissions_is_eligible():
+    role = _custom_role(
+        "custom-sa",
+        {"permissions": {"ServiceAccounts": ["read"]}, "global_access": False},
+    )
+    assert _resolve_with_roles([role]) == {"custom-sa"}
+
+
+def test_custom_role_named_service_is_still_eligible():
+    """Only the default Service role is excluded, not custom roles by name."""
+    role = SimpleNamespace(
+        id="custom-service",
+        name="service",
+        is_default=False,
+        permissions={"permissions": {"ServiceAccounts": ["update"]}, "global_access": False},
+    )
+    assert _resolve_with_roles([role]) == {"custom-service"}
+
+
+def test_custom_role_with_global_access_is_eligible():
+    role = _custom_role(
+        "custom-global",
+        {"permissions": {"ServiceAccounts": []}, "global_access": True},
+    )
+    assert _resolve_with_roles([role]) == {"custom-global"}
+
+
+def test_custom_role_with_empty_service_account_permissions_is_not_eligible():
+    role = _custom_role(
+        "custom-empty",
+        {"permissions": {"ServiceAccounts": []}, "global_access": False},
+    )
+    assert _resolve_with_roles([role]) == set()
+
+
+def test_members_without_identity_keys_are_excluded():
+    """No public key to wrap SA keys to — must not be returned as handlers."""
+    from django.db.models import Q
+    from backend.graphene.queries.service_accounts import (
+        resolve_service_account_handlers,
+    )
+
+    with patch(f"{_M}.user_is_org_member", return_value=True), patch(
+        f"{_M}.Role"
+    ) as mock_role_cls, patch(f"{_M}.OrganisationMember") as mock_member_cls:
+        mock_role_cls.objects.filter.return_value = [_default_role("Owner")]
+        resolve_service_account_handlers(None, _info(), org_id="org1")
+
+        exclude_mock = mock_member_cls.objects.filter.return_value.exclude
+        exclude_mock.assert_called_once()
+        (exclude_arg,), _kwargs = exclude_mock.call_args
+        assert str(exclude_arg) == str(Q(identity_key__isnull=True) | Q(identity_key=""))
+
+
+def test_non_org_members_are_rejected():
+    from graphql import GraphQLError
+    from backend.graphene.queries.service_accounts import (
+        resolve_service_account_handlers,
+    )
+
+    with patch(f"{_M}.user_is_org_member", return_value=False):
+        with pytest.raises(GraphQLError):
+            resolve_service_account_handlers(None, _info(), org_id="org1")


### PR DESCRIPTION
## :mag: Overview

Members with the default **Manager** role were never provisioned as Service Account handlers, so they held no copy of SA keyrings and couldn't perform any operation requiring them — generating tokens for client-side-KMS SAs (*"Cannot create token: you are not a handler..."*) or enabling server-side key management (*"You do not have handler access to this service account"*). Since escaping the first error requires the second operation, Managers were fully locked out of client-side SAs. SSK-enabled and team-owned SAs were unaffected.

Root cause: default roles store an empty `permissions` JSON in the DB (their permissions resolve at runtime from the `default_roles` template), but `resolve_service_account_handlers` — the query deciding who gets SA keys wrapped for them — filtered on the stored JSON. Every default role except Owner/Admin (rescued by name) was silently excluded, while the UI resolved permissions from the template and advertised the operations as permitted.

## :bulb: Proposed Changes

- Resolve handler eligibility in Python — from the `default_roles` template for default roles, stored JSON for custom roles. Custom-role semantics unchanged; net change to the eligible set is exactly **+ default Manager**.
- Explicitly exclude the default **Service** role (machine-account role; humans holding it must not receive key custody).
- Exclude members without an `identity_key` (key ceremony incomplete) — wrapping for them is impossible and throws client-side.

## :framed_picture: Screenshots or Demo

N/A — backend-only.

## :memo: Release Notes

Fixed: default-role Managers are now provisioned with Service Account handler keys, enabling token generation and key-management operations. Applies to newly created SAs immediately; pre-existing SAs are healed the next time an Owner/Admin changes a member's role to one with Service Account permissions (triggers an org-wide re-wrap).

### :test_tube: Testing

- New: `backend/tests/graphene/queries/test_service_accounts.py` (10 tests) pins the eligibility contract per role type.
- Full backend suite: 1087 passed; 1 pre-existing environmental failure (`test_file_read_permission_error`, container runs as root), unrelated.

### :dart: Reviewer Focus

The eligibility predicate in `backend/backend/graphene/queries/service_accounts.py`. Key invariant: the new eligible set is a strict superset of the old — `UpdateServiceAccountHandlersMutation` delete-and-recreates handler rows from this list, so a shrunken set would revoke existing key custody.

## :sparkles: How to Test the Changes Locally

1. As an Owner, create a client-side-KMS Service Account; add a member with the default Manager role.
2. As the Manager, create a token or switch the SA to server-side KMS — both fail before this fix, succeed after (for SAs created post-fix; for older SAs, first trigger a re-wrap by changing any member's role as Owner/Admin).

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)? *(no backend lint step in CI)*
- [ ] Update dependencies and lockfiles (if required) — N/A
- [ ] Update migrations (if required) — N/A
- [ ] Regenerate graphql schema and types (if required) — N/A
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices? *(bug repro confirmed on dev; fix covered by unit tests)*
