### PR TITLE
feat(frontend): mobile bottom navigation bar (with org switcher + modal z-index fix)

### DIFF
--- a/frontend/app/[team]/layout.tsx
+++ b/frontend/app/[team]/layout.tsx
@@ -105,8 +105,8 @@ export default function RootLayout({
   return (
     <div
       className={clsx(
-        'w-full h-screen overflow-hidden grid  divide-x divide-neutral-300 dark:divide-neutral-800',
-        showNav && 'grid-cols-[max-content_1fr]'
+        'w-full h-screen overflow-hidden grid divide-neutral-300 dark:divide-neutral-800',
+        showNav && 'md:divide-x md:grid-cols-[max-content_1fr]'
       )}
     >
       {showUnlockDialog && <UnlockKeyringDialog organisation={activeOrganisation} />}
@@ -114,7 +114,7 @@ export default function RootLayout({
       {showNav && <Sidebar />}
       <div className="grid h-screen">
         <div></div>
-        <div className={clsx('overflow-auto', showNav && 'mt-12 min-h-[calc(100vh-48px)]')}>
+        <div className={clsx('overflow-auto', showNav && 'mt-12 min-h-[calc(100vh-48px)] pb-14 md:pb-0')}>
           {children}
         </div>
       </div>

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -224,6 +224,77 @@ const Sidebar = () => {
     )
   }
 
+  // Compact organisation switcher for the mobile bottom nav. Reuses the same
+  // switching logic as the desktop OrgsMenu but renders as a single icon that
+  // opens a menu upward. Only shown when the user belongs to multiple orgs.
+  const MobileOrgSwitcher = () => (
+    <Menu as="div" className="relative flex-1 h-full">
+      {({ open }) => (
+        <>
+          <Menu.Button
+            title={activeOrganisation?.name ? `Organisation: ${activeOrganisation.name}` : 'Switch organisation'}
+            aria-label="Switch organisation"
+            className={clsx(
+              'flex items-center justify-center w-full h-full transition-colors',
+              open ? 'text-zinc-900 dark:text-zinc-100' : 'text-zinc-500 dark:text-zinc-400'
+            )}
+          >
+            <span className="flex items-center justify-center w-7 h-7 rounded-full bg-neutral-500/20 ring-1 ring-inset ring-neutral-400/20 text-sm font-bold uppercase">
+              {activeOrganisation?.name?.[0]?.toUpperCase() ?? <FaExchangeAlt className="text-base" />}
+            </span>
+          </Menu.Button>
+          <Transition
+            as={Fragment}
+            enter="transition ease-out duration-100"
+            enterFrom="transform opacity-0 scale-95"
+            enterTo="transform opacity-100 scale-100"
+            leave="transition ease-in duration-75"
+            leaveFrom="transform opacity-100 scale-100"
+            leaveTo="transform opacity-0 scale-95"
+          >
+            <Menu.Items className="absolute bottom-full right-2 mb-2 w-56 origin-bottom-right z-20 shadow-2xl divide-y divide-neutral-500/40 rounded-md bg-neutral-200 dark:bg-neutral-800 ring-1 ring-inset ring-neutral-500/40 focus:outline-none">
+              <div className="px-1 py-1">
+                {organisations?.map((org: OrganisationType) => (
+                  <Menu.Item key={org.id}>
+                    {({ active }) => (
+                      <Link href={`/${org.name}`}>
+                        <div
+                          title={`Switch to ${org.name}`}
+                          className={`${
+                            active
+                              ? 'hover:text-zinc-900 dark:hover:text-zinc-100 hover:bg-neutral-100 dark:hover:bg-neutral-700'
+                              : 'text-zinc-700 dark:text-zinc-300 dark:hover:text-emerald-500'
+                          } group flex w-full gap-2 items-center justify-between px-2 py-2 border-b border-neutral-500/20`}
+                        >
+                          <div className="flex flex-col gap-0.5 min-w-0 flex-grow">
+                            <div>
+                              <PlanLabel plan={org?.plan!} />
+                            </div>
+                            <span className="truncate text-left font-medium text-sm">{org.name}</span>
+                          </div>
+                          <FaExchangeAlt className="flex-shrink-0" />
+                        </div>
+                      </Link>
+                    )}
+                  </Menu.Item>
+                ))}
+              </div>
+              {!isOwner && (
+                <div className="py-3 px-1 flex justify-center">
+                  <Link href="/onboard">
+                    <Button variant="secondary">
+                      <FaPlus /> Create New Organisation
+                    </Button>
+                  </Link>
+                </div>
+              )}
+            </Menu.Items>
+          </Transition>
+        </>
+      )}
+    </Menu>
+  )
+
   const links: SidebarLinkT[] = [
     {
       name: 'Home',
@@ -264,46 +335,82 @@ const Sidebar = () => {
   ]
 
   return (
-    <div
-      className={clsx(
-        'h-screen flex flex-col pt-12 transition-all duration-300',
-        collapsed ? 'w-16' : 'w-64'
-      )}
-    >
-      <nav className="flex flex-col divide-y divide-neutral-300 dark:divide-neutral-800 items-start justify-between h-full bg-neutral-100/70 dark:bg-neutral-800/20 text-black dark:text-white">
-        {/* Main navigation area */}
-        <div className="gap-3 p-3 grid grid-cols-1 w-full">
-          <div className={clsx(collapsed ? 'mb-2' : '')}>
-            <OrgsMenu />
+    <>
+      {/* Desktop / tablet sidebar (md and up) */}
+      <div
+        className={clsx(
+          'h-screen hidden md:flex flex-col pt-12 transition-all duration-300',
+          collapsed ? 'w-16' : 'w-64'
+        )}
+      >
+        <nav className="flex flex-col divide-y divide-neutral-300 dark:divide-neutral-800 items-start justify-between h-full bg-neutral-100/70 dark:bg-neutral-800/20 text-black dark:text-white">
+          {/* Main navigation area */}
+          <div className="gap-3 p-3 grid grid-cols-1 w-full">
+            <div className={clsx(collapsed ? 'mb-2' : '')}>
+              <OrgsMenu />
+            </div>
+            {links.map((link) => (
+              <SidebarLink
+                key={link.name}
+                name={link.name}
+                href={link.href}
+                icon={link.icon}
+                active={link.active}
+                collapsed={collapsed}
+              />
+            ))}
           </div>
-          {links.map((link) => (
-            <SidebarLink
-              key={link.name}
-              name={link.name}
-              href={link.href}
-              icon={link.icon}
-              active={link.active}
-              collapsed={collapsed}
-            />
-          ))}
-        </div>
 
-        {/* Bottom section with collapse/expand button */}
-        <div className="p-2 w-full">
-          <button
-            onClick={() => setUserPreference(collapsed ? 'expanded' : 'collapsed')}
-            className="flex items-center justify-center p-1.5 w-full text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 rounded-lg"
-            title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-          >
-            {collapsed ? (
-              <FaAngleDoubleRight className="text-sm" />
-            ) : (
-              <FaAngleDoubleLeft className="text-sm" />
-            )}
-          </button>
+          {/* Bottom section with collapse/expand button */}
+          <div className="p-2 w-full">
+            <button
+              onClick={() => setUserPreference(collapsed ? 'expanded' : 'collapsed')}
+              className="flex items-center justify-center p-1.5 w-full text-zinc-600 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-100 rounded-lg"
+              title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+            >
+              {collapsed ? (
+                <FaAngleDoubleRight className="text-sm" />
+              ) : (
+                <FaAngleDoubleLeft className="text-sm" />
+              )}
+            </button>
+          </div>
+        </nav>
+      </div>
+
+      {/*
+        Mobile bottom navigation (below md). Mirrors the mobile pattern used by
+        apps like Twitter/X. Uses z-10 (matching the top NavBar) rather than a
+        higher layer so HeadlessUI dialogs — which render at z-10 via a portal to
+        <body> — correctly appear above it instead of the bar covering the modal.
+        pb-[env(safe-area-inset-bottom)] keeps icons clear of the iOS home indicator.
+      */}
+      <nav
+        aria-label="Primary"
+        className="fixed bottom-0 inset-x-0 z-10 md:hidden border-t border-neutral-300 dark:border-neutral-800 bg-neutral-100 dark:bg-neutral-900 pb-[env(safe-area-inset-bottom)]"
+      >
+        <div className="flex items-center justify-around h-14">
+          {links.map((link) => (
+            <Link
+              key={link.name}
+              href={link.href}
+              title={link.name}
+              aria-label={link.name}
+              aria-current={link.active ? 'page' : undefined}
+              className={clsx(
+                'flex items-center justify-center flex-1 h-full text-xl transition-colors',
+                link.active
+                  ? 'text-zinc-900 dark:text-zinc-100'
+                  : 'text-zinc-500 dark:text-zinc-400'
+              )}
+            >
+              {link.icon}
+            </Link>
+          ))}
+          {showOrgsMenu && <MobileOrgSwitcher />}
         </div>
       </nav>
-    </div>
+    </>
   )
 }
 


### PR DESCRIPTION
## Summary

On narrow screens (<768px) the left `Sidebar` is hidden and replaced with a fixed
bottom navigation bar — similar to Twitter/X — linking to the same team routes.
The layout grid/dividers become `md:`-only so content is full-width on mobile, and
the content area gets mobile-only bottom padding so nothing hides behind the bar.

This continues/rebases #771 by @nimish-ks, resolves its merge conflicts with `main`,
and closes the two open Cursor Bugbot findings on that PR.

## What's included

- **Mobile bottom nav** (`md:hidden`, `fixed bottom-0`) with all current team routes:
  Home, Apps, Integrations, Access Control, Audit Logs, Settings — equal-width tap
  targets and active-state highlighting.
- **Org switching on mobile** — new compact `MobileOrgSwitcher` that reuses the same
  organisations/permissions logic as the desktop `OrgsMenu`, shown only when the user
  belongs to more than one org, opening upward from the bar. *(Fixes Bugbot: "No
  organization switching capability on mobile".)*
- **Modal z-index fix** — the bar is `z-10` (matching the top `NavBar`) instead of
  `z-50`, so HeadlessUI dialogs (`z-10`, portaled to `<body>`) correctly render above
  it rather than the bar covering the modal/backdrop. *(Fixes Bugbot: "Mobile nav
  z-index renders above modal dialogs".)*
- **Accessibility** — each icon link keeps `title`/`aria-label` and gains
  `aria-current="page"` when active.
- **iOS safe area** — `pb-[env(safe-area-inset-bottom)]` keeps icons clear of the
  home indicator.

## Changed files

- `frontend/app/[team]/layout.tsx` — responsive grid (`md:divide-x md:grid-cols-…`) + `pb-14 md:pb-0`
- `frontend/components/layout/Sidebar.tsx` — split desktop (`hidden md:flex`) vs. fixed mobile bar; add `MobileOrgSwitcher`

## Notes for reviewers

- The original branch was ~336 commits behind `main`; this is rebased onto current
  `main`, which had already reduced the top navbar to 48px — those values are preserved.
- Verified locally: `tsc --noEmit` (0 errors), `next lint` (clean), `next build`
  (compiled successfully).

## Screenshots

| | Mobile | Desktop (≥768px) |
|---|---|---|
| Before | _sidebar squeezed on mobile_ | unchanged |
| After | _bottom nav + org switcher_ | unchanged |

<!-- drag device screenshots / DevTools captures here -->

## Test plan

- [ ] Resize below 768px → sidebar disappears, bottom nav appears
- [ ] All bottom-nav links navigate correctly; active state highlights the right icon
- [ ] Resize ≥768px → normal sidebar returns, bottom bar hidden, no layout shift
- [ ] Open a dialog (e.g. Unlock Keyring) on mobile → dialog renders **above** the bar; links are not tappable through the backdrop
- [ ] Multi-org account → org switcher appears and switching works; single-org account → switcher hidden
- [ ] Dark mode parity
- [ ] iOS device → bar clears the home indicator (safe-area)
- [ ] Real device / DevTools device emulation