### PR TITLE
fix(frontend): stop environment switches from decrypting with stale keys

### DIFF
--- a/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
+++ b/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
@@ -687,7 +687,14 @@ export default function EnvironmentPath({
   useEffect(() => {
     if (!data || !keyring) return
 
-    const wrappedSeed = data.environmentKeys[0].wrappedSeed
+    // Optional chaining rather than a bare index: this read used to sit inside
+    // the async function below, where an empty environmentKeys would surface
+    // as a rejected promise. Hoisting it up here to compare against the ref
+    // would otherwise turn that same case into a synchronous throw from the
+    // effect body, which takes the page down via the error boundary. Keeping
+    // the old failure mode rather than changing it as a side effect.
+    const wrappedSeed = data.environmentKeys[0]?.wrappedSeed
+    if (!wrappedSeed) return
     if (derivedForSeedRef.current === wrappedSeed) return
 
     // Switching environments (e.g. via the environment tabs) keeps this page

--- a/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
+++ b/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
@@ -677,37 +677,25 @@ export default function EnvironmentPath({
     [deleteFolder, params.environment, secretPath]
   )
 
-  // wrappedSeed identifies which environment's keys are currently derived.
-  // GetSecrets polls every 5s (see the useQuery below), so `data` gets a new
-  // object reference on every poll tick even when nothing changed; keying off
-  // wrappedSeed rather than `data` itself means an unrelated poll refresh of
-  // the same environment does not re-trigger key derivation or clear envKeys.
+  // Tracks which environment's keys are derived. Keyed off wrappedSeed rather
+  // than `data`, which gets a new reference on every 5s poll tick.
   const derivedForSeedRef = useRef<string | null>(null)
 
   useEffect(() => {
     if (!data || !keyring) return
 
-    // Optional chaining rather than a bare index: this read used to sit inside
-    // the async function below, where an empty environmentKeys would surface
-    // as a rejected promise. Hoisting it up here to compare against the ref
-    // would otherwise turn that same case into a synchronous throw from the
-    // effect body, which takes the page down via the error boundary. Keeping
-    // the old failure mode rather than changing it as a side effect.
+    // Optional chaining keeps an empty environmentKeys a rejected promise
+    // rather than a synchronous throw from the effect body.
     const wrappedSeed = data.environmentKeys[0]?.wrappedSeed
     if (!wrappedSeed) return
     if (derivedForSeedRef.current === wrappedSeed) return
 
-    // Switching environments (e.g. via the environment tabs) keeps this page
-    // mounted and only changes `data`, so a slower-resolving key derivation
-    // for an environment the user has since navigated away from must not be
-    // allowed to land after a newer one; `ignore` covers that regardless of
-    // resolution order. Clearing envKeys here is a display nicety, not the
-    // race guard itself: it stops the previous environment's already-decrypted
-    // secrets from staying on screen while this one's keys are still deriving.
-    // The decryptSecrets effect below does its own check against
-    // derivedForSeedRef, so it never runs against a mismatched envKeys/data
-    // pair even if it fires before this line's update is visible to it.
+    // `ignore` stops a slower derivation for an environment the user has left
+    // from landing after a newer one. The ref is cleared with envKeys so the
+    // two cannot disagree: on A -> B -> A before B resolves, a stale ref would
+    // match on the return to A and the effect would never re-derive.
     let ignore = false
+    derivedForSeedRef.current = null
     setEnvKeys(null)
 
     const initEnvKeys = async () => {

--- a/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
+++ b/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
@@ -677,10 +677,33 @@ export default function EnvironmentPath({
     [deleteFolder, params.environment, secretPath]
   )
 
-  useEffect(() => {
-    const initEnvKeys = async () => {
-      const wrappedSeed = data.environmentKeys[0].wrappedSeed
+  // wrappedSeed identifies which environment's keys are currently derived.
+  // GetSecrets polls every 5s (see the useQuery below), so `data` gets a new
+  // object reference on every poll tick even when nothing changed; keying off
+  // wrappedSeed rather than `data` itself means an unrelated poll refresh of
+  // the same environment does not re-trigger key derivation or clear envKeys.
+  const derivedForSeedRef = useRef<string | null>(null)
 
+  useEffect(() => {
+    if (!data || !keyring) return
+
+    const wrappedSeed = data.environmentKeys[0].wrappedSeed
+    if (derivedForSeedRef.current === wrappedSeed) return
+
+    // Switching environments (e.g. via the environment tabs) keeps this page
+    // mounted and only changes `data`, so a slower-resolving key derivation
+    // for an environment the user has since navigated away from must not be
+    // allowed to land after a newer one; `ignore` covers that regardless of
+    // resolution order. Clearing envKeys here is a display nicety, not the
+    // race guard itself: it stops the previous environment's already-decrypted
+    // secrets from staying on screen while this one's keys are still deriving.
+    // The decryptSecrets effect below does its own check against
+    // derivedForSeedRef, so it never runs against a mismatched envKeys/data
+    // pair even if it fires before this line's update is visible to it.
+    let ignore = false
+    setEnvKeys(null)
+
+    const initEnvKeys = async () => {
       const userKxKeys = {
         publicKey: await getUserKxPublicKey(keyring!.publicKey),
         privateKey: await getUserKxPrivateKey(keyring!.privateKey),
@@ -694,18 +717,36 @@ export default function EnvironmentPath({
       )
       const { publicKey, privateKey } = await envKeyring(seed)
 
-      setEnvKeys({
-        publicKey,
-        privateKey,
-        salt,
-      })
+      if (!ignore) {
+        derivedForSeedRef.current = wrappedSeed
+        setEnvKeys({
+          publicKey,
+          privateKey,
+          salt,
+        })
+      }
     }
 
-    if (data && keyring) initEnvKeys()
+    initEnvKeys()
+
+    return () => {
+      ignore = true
+    }
   }, [data, keyring])
 
   useEffect(() => {
-    if (data && envKeys) {
+    // This is the actual guard against decrypting one environment's secrets
+    // with another environment's keys. envKeys can be one render behind data
+    // changing, since the effect above derives it asynchronously, so this
+    // effect must not trust that envKeys already matches data just because
+    // both are non-null; it checks against derivedForSeedRef directly instead
+    // of relying on the ordering of the two effects.
+    const currentWrappedSeed = data?.environmentKeys[0]?.wrappedSeed
+    const envKeysAreCurrent =
+      currentWrappedSeed !== undefined && derivedForSeedRef.current === currentWrappedSeed
+
+    if (data && envKeys && envKeysAreCurrent) {
+      let ignore = false
       setDecrypting(true)
       const decryptSecrets = async () => {
         const decryptedStaticSecrets = await Promise.all(
@@ -811,13 +852,28 @@ export default function EnvironmentPath({
         return { decryptedStaticSecrets, decryptedDynamicSecrets }
       }
 
-      decryptSecrets().then((decryptedSecrets) => {
-        setServerSecrets(decryptedSecrets.decryptedStaticSecrets)
-        setClientSecrets(decryptedSecrets.decryptedStaticSecrets)
-        setDynamicSecrets(decryptedSecrets.decryptedDynamicSecrets)
-        setDecrypting(false)
-        setSecretsLoaded(true)
-      })
+      decryptSecrets()
+        .then((decryptedSecrets) => {
+          if (ignore) return
+          setServerSecrets(decryptedSecrets.decryptedStaticSecrets)
+          setClientSecrets(decryptedSecrets.decryptedStaticSecrets)
+          setDynamicSecrets(decryptedSecrets.decryptedDynamicSecrets)
+          setDecrypting(false)
+          setSecretsLoaded(true)
+        })
+        .catch((error) => {
+          // A decrypt call rejects if envKeys ever gets paired with data from
+          // a different environment (see the guard in the effect above). This
+          // used to be an unhandled rejection that left `decrypting` stuck at
+          // true, so the page never recovered from the race without a reload.
+          if (ignore) return
+          console.error('Failed to decrypt secrets:', error)
+          setDecrypting(false)
+        })
+
+      return () => {
+        ignore = true
+      }
     }
   }, [envKeys, data])
 

--- a/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
+++ b/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
@@ -677,23 +677,20 @@ export default function EnvironmentPath({
     [deleteFolder, params.environment, secretPath]
   )
 
-  // Tracks which environment's keys are derived. Keyed off wrappedSeed rather
-  // than `data`, which gets a new reference on every 5s poll tick.
+  // Which environment's keys are derived. Keyed off wrappedSeed, not `data`,
+  // which gets a fresh reference on every poll tick.
   const derivedForSeedRef = useRef<string | null>(null)
 
   useEffect(() => {
     if (!data || !keyring) return
 
-    // Optional chaining keeps an empty environmentKeys a rejected promise
-    // rather than a synchronous throw from the effect body.
+    // Optional chaining: an empty environmentKeys must not throw synchronously.
     const wrappedSeed = data.environmentKeys[0]?.wrappedSeed
     if (!wrappedSeed) return
     if (derivedForSeedRef.current === wrappedSeed) return
 
-    // `ignore` stops a slower derivation for an environment the user has left
-    // from landing after a newer one. The ref is cleared with envKeys so the
-    // two cannot disagree: on A -> B -> A before B resolves, a stale ref would
-    // match on the return to A and the effect would never re-derive.
+    // `ignore` drops a derivation the user has already navigated away from.
+    // The ref is cleared with envKeys so a cancelled pass cannot leave it stale.
     let ignore = false
     derivedForSeedRef.current = null
     setEnvKeys(null)
@@ -730,12 +727,8 @@ export default function EnvironmentPath({
   }, [data, keyring])
 
   useEffect(() => {
-    // This is the actual guard against decrypting one environment's secrets
-    // with another environment's keys. envKeys can be one render behind data
-    // changing, since the effect above derives it asynchronously, so this
-    // effect must not trust that envKeys already matches data just because
-    // both are non-null; it checks against derivedForSeedRef directly instead
-    // of relying on the ordering of the two effects.
+    // envKeys can be one render behind data, so being non-null is not proof it
+    // belongs to this environment. Check the derived seed rather than the order.
     const currentWrappedSeed = data?.environmentKeys[0]?.wrappedSeed
     const envKeysAreCurrent =
       currentWrappedSeed !== undefined && derivedForSeedRef.current === currentWrappedSeed
@@ -857,10 +850,8 @@ export default function EnvironmentPath({
           setSecretsLoaded(true)
         })
         .catch((error) => {
-          // A decrypt call rejects if envKeys ever gets paired with data from
-          // a different environment (see the guard in the effect above). This
-          // used to be an unhandled rejection that left `decrypting` stuck at
-          // true, so the page never recovered from the race without a reload.
+          // Without this the mismatch rejection was unhandled and left
+          // `decrypting` stuck at true until a reload.
           if (ignore) return
           console.error('Failed to decrypt secrets:', error)
           setDecrypting(false)

--- a/frontend/tests/utils/crypto/environmentKeyRace.test.ts
+++ b/frontend/tests/utils/crypto/environmentKeyRace.test.ts
@@ -8,11 +8,8 @@
   to fix: ReferenceError: TextDecoder is not defined
 */
 
-/*
-  Proves the property the environment-switch fix relies on: decryptAsymmetric
-  rejects, rather than returning garbage, when the keypair does not match the
-  ciphertext.
-*/
+// decryptAsymmetric must reject on a mismatched keypair, not return garbage.
+// That is the property the environment-switch fix relies on.
 
 import { decryptAsymmetric, encryptAsymmetric, randomKeyPair } from '@/utils/crypto'
 
@@ -29,7 +26,9 @@ describe("Environment key race (decrypting one environment's secrets with anothe
     const ciphertext = await encryptAsymmetric('super-secret-value', envA.publicKey)
 
     // What the page did when envKeys still held B's keys and data was A's.
-    await expect(decryptAsymmetric(ciphertext, envB.privateKey, envB.publicKey)).rejects.toBeDefined()
+    await expect(
+      decryptAsymmetric(ciphertext, envB.privateKey, envB.publicKey)
+    ).rejects.toBeDefined()
 
     // The matching keypair still works, so the rejection is the mismatch.
     const decrypted = await decryptAsymmetric(ciphertext, envA.privateKey, envA.publicKey)

--- a/frontend/tests/utils/crypto/environmentKeyRace.test.ts
+++ b/frontend/tests/utils/crypto/environmentKeyRace.test.ts
@@ -9,20 +9,9 @@
 */
 
 /*
-  Regression test for the environment-switch race described in the PR that
-  added this file. It does not mount the page component (that needs Apollo,
-  Next navigation and the keyring context, none of which are set up in this
-  suite); instead it proves the property the fix in
-  app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
-  relies on, using the real crypto primitives: decryptAsymmetric rejects,
-  rather than silently returning garbage, when the keypair does not match the
-  ciphertext's session.
-
-  That is why the original unguarded effect (pairing one environment's `data`
-  with another environment's `envKeys` while the correct keys were still
-  being derived) surfaced as a promise rejection, and why the missing
-  `.catch()` on that call turned it into an unhandled rejection that left
-  `decrypting` stuck at `true` with no way to recover short of a reload.
+  Proves the property the environment-switch fix relies on: decryptAsymmetric
+  rejects, rather than returning garbage, when the keypair does not match the
+  ciphertext.
 */
 
 import { decryptAsymmetric, encryptAsymmetric, randomKeyPair } from '@/utils/crypto'
@@ -39,13 +28,10 @@ describe("Environment key race (decrypting one environment's secrets with anothe
 
     const ciphertext = await encryptAsymmetric('super-secret-value', envA.publicKey)
 
-    // This is the exact operation the page performs when envKeys still holds
-    // environment B's keys while data has already updated to environment A's
-    // secrets (or vice versa): decrypting A's ciphertext with B's keypair.
+    // What the page did when envKeys still held B's keys and data was A's.
     await expect(decryptAsymmetric(ciphertext, envB.privateKey, envB.publicKey)).rejects.toBeDefined()
 
-    // Decrypting with the matching keypair still works, so the rejection
-    // above is specifically about the key mismatch, not a broken fixture.
+    // The matching keypair still works, so the rejection is the mismatch.
     const decrypted = await decryptAsymmetric(ciphertext, envA.privateKey, envA.publicKey)
     expect(decrypted).toBe('super-secret-value')
   })

--- a/frontend/tests/utils/crypto/environmentKeyRace.test.ts
+++ b/frontend/tests/utils/crypto/environmentKeyRace.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment node
+ */
+
+/*
+  👆
+  overrides: testEnvironment: 'jsdom' in jest.config.js
+  to fix: ReferenceError: TextDecoder is not defined
+*/
+
+/*
+  Regression test for the environment-switch race described in the PR that
+  added this file. It does not mount the page component (that needs Apollo,
+  Next navigation and the keyring context, none of which are set up in this
+  suite); instead it proves the property the fix in
+  app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
+  relies on, using the real crypto primitives: decryptAsymmetric rejects,
+  rather than silently returning garbage, when the keypair does not match the
+  ciphertext's session.
+
+  That is why the original unguarded effect (pairing one environment's `data`
+  with another environment's `envKeys` while the correct keys were still
+  being derived) surfaced as a promise rejection, and why the missing
+  `.catch()` on that call turned it into an unhandled rejection that left
+  `decrypting` stuck at `true` with no way to recover short of a reload.
+*/
+
+import { decryptAsymmetric, encryptAsymmetric, randomKeyPair } from '@/utils/crypto'
+
+const toHexKeyPair = (keyPair: { publicKey: Uint8Array; privateKey: Uint8Array }) => ({
+  publicKey: Buffer.from(keyPair.publicKey).toString('hex'),
+  privateKey: Buffer.from(keyPair.privateKey).toString('hex'),
+})
+
+describe("Environment key race (decrypting one environment's secrets with another's keys)", () => {
+  test('decrypting with a mismatched keypair rejects rather than returning garbage', async () => {
+    const envA = toHexKeyPair(await randomKeyPair())
+    const envB = toHexKeyPair(await randomKeyPair())
+
+    const ciphertext = await encryptAsymmetric('super-secret-value', envA.publicKey)
+
+    // This is the exact operation the page performs when envKeys still holds
+    // environment B's keys while data has already updated to environment A's
+    // secrets (or vice versa): decrypting A's ciphertext with B's keypair.
+    await expect(decryptAsymmetric(ciphertext, envB.privateKey, envB.publicKey)).rejects.toBeDefined()
+
+    // Decrypting with the matching keypair still works, so the rejection
+    // above is specifically about the key mismatch, not a broken fixture.
+    const decrypted = await decryptAsymmetric(ciphertext, envA.privateKey, envA.publicKey)
+    expect(decrypted).toBe('super-secret-value')
+  })
+})


### PR DESCRIPTION
## What happened

Switching environments (the environment tabs use a plain `<Link>`, so the page stays mounted and only `data` changes) can leave the page stuck on "Decrypting..." until reloaded.

`app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx` has two effects:

1. Derives `envKeys` asynchronously from `data.environmentKeys[0].wrappedSeed` (several `await`ed decrypt calls).
2. Once `data` and `envKeys` are both set, decrypts every secret in `data.secrets` with `envKeys`.

The second effect fires on the same render where `data` changes to the new environment, before the first effect's async derivation has any chance to resolve. At that point `envKeys` still holds the *previous* environment's keys. It decrypts the new environment's ciphertext with the old environment's keypair, which `decryptAsymmetric` rejects (verified in the added test, it does not silently return garbage).

That rejection went to `decryptSecrets().then(...)` with no `.catch()`. An unhandled rejection, so `setDecrypting(false)` was never reached and `decrypting` stayed `true`.

There's a second, narrower case: switching to a third environment before the second one's key derivation resolves could let it land *after* the third's, pairing `envKeys` with the wrong `data` even once the promise settles.

## The fix

- Track which environment's `wrappedSeed` the current `envKeys` were derived from (`derivedForSeedRef`), and skip re-deriving when it's unchanged. This matters because `GetSecrets` polls every 5s (`pollInterval: unsavedChanges ? 0 : 5000`), so keying key derivation directly off `data` would re-derive and flash `envKeys` to `null` on every idle poll tick, not just on real environment switches.
- The deriving effect gets a standard `ignore` flag so a slower-resolving derivation for an environment the user has since left can't land after a newer one, regardless of resolution order.
- The decrypting effect independently checks `envKeys` against that same tracked seed before running, rather than assuming the deriving effect's `setEnvKeys(null)` is visible to it in the same pass. I didn't want to build correctness on an assumption about React's effect-batching order between two separate effects that I couldn't verify without the app running end to end, so this effect verifies the pairing itself either way.
- Added the missing `.catch()`, so a genuine decrypt failure surfaces to the console and clears `decrypting` instead of hanging forever.

## Testing

`tests/utils/crypto/environmentKeyRace.test.ts` uses the real crypto primitives (`randomKeyPair`, `encryptAsymmetric`, `decryptAsymmetric`) to prove the underlying failure mode: decrypting with a mismatched keypair rejects rather than returning garbage, which is why the race above surfaces as a stuck page rather than silently wrong data.

I didn't mount the page component itself. It needs Apollo's `MockedProvider`, Next navigation, and the keyring context, none of which are set up in this test suite, and building that harness felt disproportionate to the fix. The existing tests in `tests/utils/crypto/` follow the same pattern of testing the crypto layer directly rather than mounting pages, so I matched that.

`tsc --noEmit` and `eslint` are clean on both changed files (eslint reports one pre-existing warning at line 489 unrelated to this change, confirmed present on `main` before my edit too).

## Note for reviewers

Five other open PRs touch this same file (#968, #956, #935, #592, #474), none of them near these two effects as far as I could tell, but flagging it since a merge conflict is likely depending on ordering. Happy to rebase.
