### PR TITLE
refactor(frontend): harden log decryption against unhandled rejections

### DIFF
--- a/frontend/components/logs/SecretLogs.tsx
+++ b/frontend/components/logs/SecretLogs.tsx
@@ -239,15 +239,38 @@ export default function SecretLogs(props: { app: string }) {
 
         const envKeyPair = envKeys.find((envKey) => envKey.envId === event.environment.id)
 
-        const { publicKey, privateKey } = envKeyPair!.keys
+        // A log entry can reference an environment that no longer has a
+        // matching entry here, e.g. audit history retained for an
+        // environment the viewer has since lost access to or that was
+        // deleted. That is a real, expected case rather than a bug, so
+        // this must not be a non-null assertion: dereferencing undefined
+        // would throw inside this async function with nothing to catch
+        // it, an unhandled rejection.
+        if (!envKeyPair) {
+          console.error(
+            `No environment key available to decrypt log for environment ${event.environment.id}; leaving this entry undecrypted.`
+          )
+          return
+        }
 
-        // Decrypt event fields
-        decryptedEvent!.key = await decryptAsymmetric(event!.key, privateKey, publicKey)
+        const { publicKey, privateKey } = envKeyPair.keys
 
-        setDecryptedEvent(decryptedEvent)
+        try {
+          // Decrypt event fields
+          decryptedEvent!.key = await decryptAsymmetric(event!.key, privateKey, publicKey)
+
+          setDecryptedEvent(decryptedEvent)
+        } catch (error) {
+          console.error(`Failed to decrypt log for environment ${event.environment.id}:`, error)
+        }
       }
 
       if (log && envKeys.length > 0) decryptSecretEvent()
+      // envKeys is intentionally not a dependency: it is state on the
+      // enclosing SecretLogs component, so a change to it already re-renders
+      // this row with a fresh LogRow closure (LogRow is defined inside
+      // SecretLogs), which resets this effect regardless of its deps.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [log])
 
     const relativeTimeStamp = () => {


### PR DESCRIPTION
## What happened

`components/logs/SecretLogs.tsx`, in the `LogRow` sub-component:

```tsx
const envKeyPair = envKeys.find((envKey) => envKey.envId === event.environment.id)
const { publicKey, privateKey } = envKeyPair!.keys
```

`envKeyPair` can be `undefined`: `Array.prototype.find` returns that whenever no entry matches. This isn't hypothetical here, a log entry can reference an environment that no longer has a corresponding key locally, e.g. audit history retained for an environment that's since been deleted, or one the current viewer has lost access to.

The `!` silences TypeScript but not the runtime. Dereferencing `undefined!.keys` throws, and it throws inside an async function (`decryptSecretEvent`) that's called with no `.catch()` and no surrounding `try`/`catch`:

```tsx
if (log && envKeys.length > 0) decryptSecretEvent()
```

That's an unhandled promise rejection, the same shape as the bug fixed in #970 (different trigger, same underlying pattern: an async decrypt call with nowhere for its rejection to go).

## The fix

- Replace the assertion with an explicit `if (!envKeyPair)` guard that logs and returns, rather than crashing the row.
- Wrap the decrypt call itself in `try`/`catch`, so a genuine decrypt failure for one log entry (corrupted ciphertext, key rotation mid-flight, whatever) doesn't hit the same unhandled-rejection shape either.

## A dead end I want to be upfront about

I initially also added `envKeys` to this effect's dependency array, since it's read inside but wasn't listed, and I couldn't immediately see why that was safe. Running `eslint` surfaced its own answer:

> React Hook useEffect has an unnecessary dependency: 'envKeys'. Outer scope values like 'envKeys' aren't valid dependencies because mutating them doesn't re-render the component

`LogRow` is defined inside `SecretLogs`'s render body, so when `envKeys` (the parent's state) updates, `SecretLogs` re-renders, which recreates `LogRow` as a fresh closure and resets this effect regardless of its dependency array. So a stale `envKeys` snapshot from before it finished loading doesn't get stuck, this effect gets another chance once the parent re-renders. I'd suspected the opposite (that a row could stay stuck showing its skeleton forever if key derivation resolved after this effect's one shot), and eslint's own reasoning is what told me that wasn't right. I've left a comment plus the disable directive so this doesn't get "corrected" back into a lint warning later without the context.

I'm flagging this in case I'm still missing something about how the two components interact. I did not change this behaviour, only documented it, since I could not find a case where it's actually wrong once I understood why eslint was silent on it.

## Testing

`tsc --noEmit` and `eslint components/logs/SecretLogs.tsx` are both clean on the changed file. I didn't add a test for this one: the fix is a straightforward null-guard plus a try/catch, and reproducing the `envKeys` lookup miss faithfully would need mocking the same GraphQL/Apollo/keyring context stack as the page component, which felt disproportionate for a change this size, same reasoning as the test scope note in #970.
