### PR TITLE
fix: post-mobile-UI regressions and Firefox paint artifacts

### DIFF
--- a/frontend/components/auth/UnlockKeyringDialog.tsx
+++ b/frontend/components/auth/UnlockKeyringDialog.tsx
@@ -122,6 +122,11 @@ export default function UnlockKeyringDialog(props: { organisation: OrganisationT
 
     reset()
 
+    // The dialog stays mounted across org switches, so this flag must be
+    // re-derived per org: without a cached key below, a stale `true` from the
+    // previous org would show the auto-unlock spinner with no decrypt running.
+    setDevicePasswordExists(false)
+
     const isPasswordUser = user.authMethod === 'password'
 
     // Preferred: cached deviceKey. Password users have a single per-user

--- a/frontend/components/auth/UnlockKeyringDialog.tsx
+++ b/frontend/components/auth/UnlockKeyringDialog.tsx
@@ -301,7 +301,7 @@ export default function UnlockKeyringDialog(props: { organisation: OrganisationT
                             </div>
                           </div>
 
-                          <div className="flex justify-end">
+                          <div className="flex items-start justify-end">
                             <Button type="button" variant="outline" onClick={() => handleSignout()}>
                               <div className="flex items-center gap-1 text-xs">
                                 <FaSignOutAlt /> Log out

--- a/frontend/components/dashboard/GetStarted.tsx
+++ b/frontend/components/dashboard/GetStarted.tsx
@@ -40,7 +40,9 @@ const TaskPanel = (props: {
     <Disclosure
       as="div"
       defaultOpen={defaultOpen}
-      className="ring-1 ring-inset ring-neutral-500/40 rounded-md p-px flex flex-col divide-y divide-neutral-500/30 w-full text-xs"
+      // real border, not ring-inset: an inset box-shadow spanning the card is the
+      // classic WebRender tile-seam trigger on thin edges (visually identical)
+      className="border border-neutral-500/40 rounded-md overflow-hidden flex flex-col divide-y divide-neutral-500/30 w-full text-xs"
     >
       {({ open }) => (
         <>
@@ -71,22 +73,14 @@ const TaskPanel = (props: {
                   )}
                 />
               </div>
-              <div
-                className={clsx(
-                  'h-0.5 w-full bg-neutral-300 dark:bg-neutral-600 text-xs',
-                  !open && 'rounded-b-md'
-                )}
-              >
+              {/* Deliberately minimal paint — two solid rects, no radius/clip/shadow/
+                  transform on the bar itself (the card root's overflow-hidden rounds it).
+                  Fancier variants (scaleX fill, rounded inset ring) mis-rasterized in
+                  Firefox as a partially thinner bar. */}
+              <div className="h-0.5 w-full bg-neutral-300 dark:bg-neutral-600">
                 <div
-                  className={clsx(
-                    'h-0.5 w-full ml-0 transition-all ease float-left',
-                    progressBarColor,
-                    !open && 'rounded-b-md'
-                  )}
-                  style={{
-                    transform: `scaleX(${progress})`,
-                    transformOrigin: '0%',
-                  }}
+                  className={clsx('h-full transition-all ease', progressBarColor)}
+                  style={{ width: progress }}
                 ></div>
               </div>
             </div>

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -232,7 +232,8 @@ const Sidebar = () => {
             <div>
               <PlanLabel plan={activeOrganisation?.plan!} />
             </div>
-            <span className="block w-full truncate font-semibold tracking-wider text-base">
+            {/* text-left: the full-width span sits inside a <button>, which centers text by default */}
+            <span className="block w-full truncate text-left font-semibold tracking-wider text-base">
               {activeOrganisation?.name}
             </span>
           </div>


### PR DESCRIPTION
## :mag: Overview

Follow-up fixes for issues found while testing after the mobile responsiveness release. Two are regressions from recently merged PRs, one is a long-standing auth UX bug surfaced by multi-org testing, and one is a Firefox-specific rendering artifact:

- #968 changed the Log out button's wrapper in the unlock keyring dialog to `flex justify-end`, which stretches the button to the full height of its row on `sm+`.
- #969 made the org name in the sidebar switcher a full-width `block w-full truncate` span. The span sits inside a Headless UI `Menu.Button`, and buttons default to `text-align: center` — so the org name rendered centered instead of left-aligned.
- Switching organisations to one with no locally cached device key left the unlock keyring dialog on an infinite "Initializing account keys..." spinner, requiring a hard refresh to reach the password prompt. Pre-existing; primarily affects SSO users (device keys are cached per-membership).
- The "Getting started" guide's progress bars rendered with part of the bar thinner than the rest in Firefox on Linux (fine in Chromium).

## :bulb: Proposed Changes

- **`UnlockKeyringDialog`** — added `items-start` to the Log out button wrapper so the button keeps its standard height instead of stretching with the flex row (382a8472).
- **`Sidebar`** — added `text-left` to the org-name span in the switcher label, matching what #969 already did for the dropdown entries (382a8472).
- **`UnlockKeyringDialog`** — the dialog stays mounted across org switches (App Router keeps the `[team]` layout subtree alive across dynamic-param changes), so the `devicePasswordExists` flag survived from the previous org. The auto-unlock effect only ever *set* the flag when it found a cached key and never cleared it, so an org with nothing cached rendered the spinner branch with no decrypt attempt running. The effect now resets the flag at the top of each run and lets the cache-hit branches re-assert it; React 18 batches the reset + re-set into one render, so orgs that do auto-unlock show no flash (9dfbed3e).
- **`GetStarted`** — flattened the task-card paint path to eliminate the primitives Firefox rasterized incorrectly (be2e5269):
  - progress fill is a plain child with `width: {progress}` instead of a `float-left` + `transform: scaleX(...)` layer
  - card border is a real `border` instead of `ring-1 ring-inset` (an inset box-shadow)
  - rounding/clipping happens once via `overflow-hidden` on the card root; the track and fill are plain unrounded rects

No backend, schema, or dependency changes.

## :framed_picture: Screenshots or Demo

<img width="1643" height="1323" alt="image" src="https://github.com/user-attachments/assets/cbc9e41c-a506-405e-bbb2-fc09e7cb6f0b" />

## :memo: Release Notes

- Fixed the unlock dialog showing an endless spinner when switching to an organisation whose keys aren't cached on the device — it now correctly prompts for your sudo password.
- Fixed the oversized Log out button in the unlock dialog.
- Fixed the organisation name appearing centered in the sidebar switcher.
- Fixed "Getting started" progress bars rendering incorrectly in Firefox.

No breaking changes or migrations.

## :question: Open Questions

- The Firefox bar artifact was resolved by removing the fragile paint primitives (inset shadow, transformed fill layer, per-element rounded clip on a 2px box) rather than by pinpointing the exact WebRender internal at fault. The isolated markup rendered correctly in headless Firefox/Chromium at multiple DPRs, so the artifact only reproduces on real GPU compositing paths. If we ever want the old visuals back verbatim, this likely warrants an upstream bugzilla report first.

### :test_pipeline: Testing

- `tsc --noEmit` clean against the existing baseline.
- Unlock flow: manually walked all paths — password user with valid/stale cached key, SSO user with valid/stale per-membership key, legacy stored-password migration (success + failure), and org switch into an org with nothing cached (the bug scenario). Failure paths (stale key → recovery redirect / prompt fallback) are unchanged.
- Progress bars: rendered at 100% and partial progress in Chromium and Firefox headless; manually verified in Firefox on Linux (previously broken environment).
- Gap: no automated tests — these are visual/client-state fixes; the unlock-dialog state machine has no test harness today.

### :dart: Reviewer Focus

- `frontend/components/auth/UnlockKeyringDialog.tsx` — the one-line reset in the auto-unlock effect is auth-adjacent; review the effect's early-return guard and the cache-hit branches to confirm the flag can't be cleared while a decrypt is legitimately pending.
- `frontend/components/dashboard/GetStarted.tsx` — confirm the card root's new `overflow-hidden` doesn't clip anything you'd expect to escape (the CLI copy buttons are positioned within their own blocks, so they're safe).

### :heavy_plus_sign: Additional Context

- Regression sources: #968 (Log out button), #969 (org name centering).
- The seam artifact was content-anchored (moved with the card when scrolling) and Chromium-clean, which ruled out compositor tiling and pointed at element-level paint primitives.

## :sparkles: How to Test the Changes Locally

1. `docker compose -f dev-docker-compose.yml up -d` and log in.
2. **Unlock dialog spinner:** be a member of two orgs; unlock org A with "Remember password" enabled, then clear the second org's cached key (or use an SSO account whose second org was never unlocked on this device) and switch to org B via the sidebar. You should get the sudo password prompt immediately — previously an endless spinner.
3. **Log out button:** lock the keyring (fresh session), check the unlock dialog at a `sm+` viewport — the Log out button should be normal height, top-aligned.
4. **Org switcher:** with 2+ orgs, check the sidebar org label is left-aligned, expanded and after switching.
5. **Progress bars:** open the org home "Getting started" guide in Firefox on Linux; collapse/expand each task card — the 2px bar should be uniform thickness edge to edge.

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
- [x] Update dependencies and lockfiles (if required) — n/a
- [x] Update migrations (if required) — n/a
- [x] Regenerate graphql schema and types (if required) — n/a
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices?
