### PR TITLE
fix: authenticate and session-bind the GitHub integration OAuth callback

### DIFF
--- a/backend/api/views/auth.py
+++ b/backend/api/views/auth.py
@@ -1,10 +1,15 @@
 import requests
-import json
-import base64
 import os
+import secrets as pysecrets
+from urllib.parse import urlparse, urlencode
+from django.apps import apps
+from django.core.exceptions import ValidationError
 from django.shortcuts import redirect
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.http import require_POST
+from django.views.decorators.csrf import csrf_exempt
 from api.utils.syncing.auth import store_oauth_token
+from api.utils.access.permissions import user_has_permission
 
 from backend.utils.secrets import get_secret
 from api.serializers import (
@@ -25,6 +30,11 @@ from api.throttling import PlanBasedRateThrottle
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework import status
+
+# First configured origin — ALLOWED_ORIGINS may hold a comma-separated list.
+FRONTEND_URL = os.getenv("ALLOWED_ORIGINS", "").split(",")[0].strip()
+
+GITHUB_INTEGRATION_SCOPE = "user,repo,admin:repo_hook,admin:org"
 
 
 @require_POST
@@ -102,33 +112,168 @@ def secrets_tokens(request):
         return JsonResponse({"error": "Invalid token type"}, status=403)
 
 
-def github_integration_callback(request):
-    error = request.GET.get("error")
-    state = request.GET.get("state")
+def _github_callback_redirect_uri():
+    """redirect_uri registered with the GitHub app — must match at authorize and token exchange."""
+    return f"{FRONTEND_URL}/service/oauth/github/callback"
 
-    # Safely decode the state so we always have the original returnUrl
-    state_decoded = base64.b64decode(state).decode("utf-8")
-    state = json.loads(state_decoded)
-    original_url = state.get("returnUrl", "/")
 
-    if error:
-        # User denied the OAuth consent
+def _safe_return_url(candidate):
+    """Only allow same-origin root-relative redirect targets (open-redirect guard)."""
+    if (
+        isinstance(candidate, str)
+        and candidate.startswith("/")
+        and url_has_allowed_host_and_scheme(candidate, allowed_hosts=None)
+    ):
+        return candidate
+    return "/"
+
+
+def _github_param(request, *names):
+    """Read a POST param under any spelling — CamelCaseMiddleWare may snake_case it."""
+    for name in names:
+        value = request.POST.get(name)
+        if value is not None:
+            return value
+    return None
+
+
+@csrf_exempt
+@require_POST
+def github_integration_authorize(request):
+    """Begin the GitHub secret-sync OAuth flow (POST-only, session-bound).
+
+    csrf_exempt matches the app's SameSite-based CSRF posture (graphql/logout);
+    POST-only + SameSite already blocks cross-site initiation. App-wide CSRF
+    tokens are a separate change."""
+    if not request.user.is_authenticated:
+        return redirect(f"{FRONTEND_URL}/login?error=login_required")
+
+    org_id = _github_param(request, "org_id", "orgId")
+    name = _github_param(request, "name") or "GitHub OAuth credentials"
+    return_url = _safe_return_url(_github_param(request, "return_url", "returnUrl"))
+
+    if not org_id:
+        return redirect(f"{FRONTEND_URL}{return_url}?error=missing_org")
+
+    Organisation = apps.get_model("api", "Organisation")
+    try:
+        org = Organisation.objects.get(id=org_id)
+    except (Organisation.DoesNotExist, ValidationError, ValueError):
+        return redirect(f"{FRONTEND_URL}{return_url}?error=org_not_found")
+
+    if not user_has_permission(
+        request.user, "create", "IntegrationCredentials", org
+    ):
+        return redirect(f"{FRONTEND_URL}{return_url}?error=permission_denied")
+
+    # Cloud pins github.com (never send the shared secret to a caller's host).
+    # Self-hosted's GHE host is browser-supplied but session-bound, so not forgeable.
+    is_cloud = settings.APP_HOST == "cloud"
+    is_enterprise = (
+        False
+        if is_cloud
+        else str(_github_param(request, "is_enterprise", "isEnterprise") or "").lower()
+        in ("true", "1")
+    )
+
+    if is_enterprise:
+        host_url = (_github_param(request, "host_url", "hostUrl") or "").strip()
+        api_url = (_github_param(request, "api_url", "apiUrl") or "").strip()
+        parsed_host = urlparse(host_url)
+        if parsed_host.scheme not in ("https", "http") or not parsed_host.netloc:
+            return redirect(f"{FRONTEND_URL}{return_url}?error=invalid_host_url")
+        if not api_url:
+            api_url = f"{host_url.rstrip('/')}/api/v3"
+    else:
+        host_url = "https://github.com"
+        api_url = "https://api.github.com"
+
+    client_id = (
+        os.getenv("GITHUB_ENTERPRISE_INTEGRATION_CLIENT_ID")
+        if is_enterprise
+        else os.getenv("GITHUB_INTEGRATION_CLIENT_ID")
+    )
+    if not client_id:
         return redirect(
-            f"{os.getenv('ALLOWED_ORIGINS')}{original_url}?error=access_denied"
+            f"{FRONTEND_URL}{return_url}?error=integration_not_configured"
         )
+
+    state = pysecrets.token_urlsafe(32)
+    request.session["gh_int_state"] = state
+    request.session["gh_int_org_id"] = str(org.id)
+    request.session["gh_int_host_url"] = host_url
+    request.session["gh_int_api_url"] = api_url
+    request.session["gh_int_is_enterprise"] = is_enterprise
+    request.session["gh_int_name"] = name
+    request.session["gh_int_return_url"] = return_url
+    request.session.save()
+
+    params = {
+        "client_id": client_id,
+        "redirect_uri": _github_callback_redirect_uri(),
+        "scope": GITHUB_INTEGRATION_SCOPE,
+        "state": state,
+        "prompt": "consent",
+    }
+    authorize_url = f"{host_url}/login/oauth/authorize"
+    return redirect(f"{authorize_url}?{urlencode(params)}")
+
+
+def github_integration_callback(request):
+    """Complete the OAuth flow — trusted params come from the session set in
+    authorize (gated by the state nonce), never from the request."""
+    state = request.GET.get("state")
+    expected_state = request.session.get("gh_int_state")
+
+    # Reject anything not tied to a session we started (blocks unauth callers).
+    if not state or not expected_state or state != expected_state:
+        return redirect(f"{FRONTEND_URL}/?error=invalid_state")
+
+    # One-time use: consume the flow state regardless of outcome.
+    org_id = request.session.get("gh_int_org_id")
+    host_url = request.session.get("gh_int_host_url", "https://github.com")
+    api_url = request.session.get("gh_int_api_url", "https://api.github.com")
+    is_enterprise = request.session.get("gh_int_is_enterprise", False)
+    name = request.session.get("gh_int_name")
+    return_url = _safe_return_url(request.session.get("gh_int_return_url", "/"))
+    for key in (
+        "gh_int_state",
+        "gh_int_org_id",
+        "gh_int_host_url",
+        "gh_int_api_url",
+        "gh_int_is_enterprise",
+        "gh_int_name",
+        "gh_int_return_url",
+    ):
+        request.session.pop(key, None)
+
+    # Re-verify the caller still holds the permission the flow was started with.
+    if not request.user.is_authenticated:
+        return redirect(f"{FRONTEND_URL}/login?error=login_required")
+
+    Organisation = apps.get_model("api", "Organisation")
+    try:
+        org = Organisation.objects.get(id=org_id)
+    except (Organisation.DoesNotExist, ValidationError, ValueError):
+        return redirect(f"{FRONTEND_URL}{return_url}?error=org_not_found")
+
+    if not user_has_permission(
+        request.user, "create", "IntegrationCredentials", org
+    ):
+        return redirect(f"{FRONTEND_URL}{return_url}?error=permission_denied")
+
+    if request.GET.get("error"):
+        # User denied the OAuth consent
+        return redirect(f"{FRONTEND_URL}{return_url}?error=access_denied")
 
     code = request.GET.get("code")
     if not code:
-        # Something went wrong (missing code)
-        return redirect(
-            f"{os.getenv('ALLOWED_ORIGINS')}{original_url}?error=missing_code"
-        )
+        return redirect(f"{FRONTEND_URL}{return_url}?error=missing_code")
 
-    is_enterprise = bool(state.get("isEnterprise", False))
-    host_url = state.get("hostUrl", "https://github.com")
-    api_url = state.get("apiUrl", "https://github.com")
-    org_id = state.get("orgId")
-    name = state.get("name")
+    # Defense in depth: scheme sanity check on the session-provided host.
+    parsed_host = urlparse(host_url)
+    if parsed_host.scheme not in ("https", "http") or not parsed_host.netloc:
+        return redirect(f"{FRONTEND_URL}{return_url}?error=invalid_host_url")
 
     client_id = (
         os.getenv("GITHUB_ENTERPRISE_INTEGRATION_CLIENT_ID")
@@ -141,7 +286,7 @@ def github_integration_callback(request):
         else get_secret("GITHUB_INTEGRATION_CLIENT_SECRET")
     )
 
-    # Exchange code for token
+    # Exchange code for token; allow_redirects=False stops the host bouncing the secret onward.
     response = requests.post(
         f"{host_url}/login/oauth/access_token",
         headers={"Accept": "application/json"},
@@ -149,17 +294,16 @@ def github_integration_callback(request):
             "client_id": client_id,
             "client_secret": client_secret,
             "code": code,
-            "redirect_uri": f"{os.getenv('ALLOWED_ORIGINS')}/service/oauth/github/callback",
+            "redirect_uri": _github_callback_redirect_uri(),
         },
+        allow_redirects=False,
     )
 
     access_token = response.json().get("access_token")
     if not access_token:
-        return redirect(
-            f"{os.getenv('ALLOWED_ORIGINS')}{original_url}?error=token_exchange_failed"
-        )
+        return redirect(f"{FRONTEND_URL}{return_url}?error=token_exchange_failed")
 
-    store_oauth_token("github", name, access_token, host_url, api_url, org_id)
+    store_oauth_token("github", name, access_token, host_url, api_url, str(org.id))
 
     # Redirect back to Next.js app
-    return redirect(f"{os.getenv('ALLOWED_ORIGINS')}{original_url}")
+    return redirect(f"{FRONTEND_URL}{return_url}")

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -34,6 +34,7 @@ from api.views.teams import (
 from api.views.auth import (
     logout_view,
     health_check,
+    github_integration_authorize,
     github_integration_callback,
     secrets_tokens,
     root_endpoint,
@@ -82,6 +83,7 @@ urlpatterns = [
     # GraphQL API
     path("graphql/", csrf_exempt(PrivateGraphQLView.as_view(graphiql=True))),
     # OAuth integrations
+    path("oauth/github/authorize", github_integration_authorize),
     path("oauth/github/callback", github_integration_callback),
     # Secrets management
     path("secrets/", E2EESecretsView.as_view()),

--- a/backend/tests/api/views/test_github_callback.py
+++ b/backend/tests/api/views/test_github_callback.py
@@ -1,0 +1,461 @@
+"""Security tests for the GitHub secret-sync OAuth flow (GHSA-68r4-53vq-4fqm):
+CSRF/auth-gated authorize, session-bound host, callback state nonce."""
+
+import uuid
+from importlib import import_module
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from django.conf import settings as dj_settings
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
+
+
+class _OrgDoesNotExist(Exception):
+    pass
+
+
+def _user(authenticated=True):
+    user = Mock()
+    user.userId = uuid.uuid4()
+    user.id = user.userId
+    user.is_authenticated = authenticated
+    return user
+
+
+def _org(org_id=None):
+    org = Mock()
+    org.id = org_id or uuid.uuid4()
+    return org
+
+
+def _attach_session(request, initial=None):
+    engine = import_module(dj_settings.SESSION_ENGINE)
+    request.session = engine.SessionStore()
+    for key, value in (initial or {}).items():
+        request.session[key] = value
+    return request
+
+
+def _org_model(org=None, missing=False):
+    """A stand-in for apps.get_model("api", "Organisation")."""
+    model = MagicMock()
+    model.DoesNotExist = _OrgDoesNotExist
+    if missing:
+        model.objects.get.side_effect = _OrgDoesNotExist()
+    else:
+        model.objects.get.return_value = org
+    return model
+
+
+def _patch_apps(org_model):
+    """Patch the `apps` registry so get_model returns our stub."""
+    mock_apps = MagicMock()
+    mock_apps.get_model.return_value = org_model
+    return patch("api.views.auth.apps", mock_apps)
+
+
+# ────────────────────────────────────────────────────────────────────
+#  return-url sanitisation (open-redirect guard)
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestSafeReturnUrl:
+    @pytest.mark.parametrize(
+        "candidate,expected",
+        [
+            ("/apps", "/apps"),
+            ("/team/settings?tab=1", "/team/settings?tab=1"),
+            ("/", "/"),
+            ("//evil.example.com", "/"),  # scheme-relative
+            ("///evil.example.com", "/"),
+            ("https://evil.example.com", "/"),  # absolute
+            ("http://evil.example.com/x", "/"),
+            ("/\\evil.example.com", "/"),  # backslash normalised to //
+            ("/\t/evil.example.com", "/"),  # control char
+            ("javascript:alert(1)", "/"),  # not root-relative
+            ("apps", "/"),  # not root-relative
+            ("", "/"),
+            (None, "/"),
+        ],
+    )
+    def test_safe_return_url(self, candidate, expected):
+        from api.views.auth import _safe_return_url
+
+        assert _safe_return_url(candidate) == expected
+
+
+# ────────────────────────────────────────────────────────────────────
+#  authorize
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestGithubIntegrationAuthorize:
+    def _post(self, **params):
+        # authorize is POST-only; params arrive as form data.
+        factory = RequestFactory()
+        request = factory.post("/oauth/github/authorize", params)
+        return _attach_session(request)
+
+    def test_rejects_get(self):
+        # @require_POST → 405; closes the cross-site GET CSRF vector.
+        from api.views.auth import github_integration_authorize
+
+        factory = RequestFactory()
+        request = _attach_session(factory.get("/oauth/github/authorize"))
+        request.user = _user()
+
+        response = github_integration_authorize(request)
+        assert response.status_code == 405
+
+    def test_requires_authentication(self):
+        from api.views.auth import github_integration_authorize
+
+        request = self._post(orgId=str(uuid.uuid4()))
+        request.user = AnonymousUser()
+
+        response = github_integration_authorize(request)
+
+        assert response.status_code == 302
+        assert "login_required" in response.url
+        assert "gh_int_state" not in request.session
+
+    def test_denied_without_permission(self, monkeypatch):
+        from api.views import auth as auth_views
+
+        org = _org()
+        request = self._post(orgId=str(org.id), returnUrl="/apps")
+        request.user = _user()
+
+        with _patch_apps(_org_model(org)), patch.object(
+            auth_views, "user_has_permission", return_value=False
+        ):
+            response = auth_views.github_integration_authorize(request)
+
+        assert response.status_code == 302
+        assert "permission_denied" in response.url
+        assert "gh_int_state" not in request.session
+
+    def test_unknown_org_is_rejected(self, monkeypatch):
+        from api.views import auth as auth_views
+
+        request = self._post(orgId=str(uuid.uuid4()))
+        request.user = _user()
+
+        with _patch_apps(_org_model(missing=True)), patch.object(
+            auth_views, "user_has_permission", return_value=True
+        ):
+            response = auth_views.github_integration_authorize(request)
+
+        assert response.status_code == 302
+        assert "org_not_found" in response.url
+        assert "gh_int_state" not in request.session
+
+    def test_cloud_ignores_attacker_host_and_pins_github(self, settings, monkeypatch):
+        settings.APP_HOST = "cloud"
+        monkeypatch.setenv("GITHUB_INTEGRATION_CLIENT_ID", "cid-123")
+        from api.views import auth as auth_views
+
+        org = _org()
+        # Attacker-style params: try to force an evil host + enterprise mode.
+        request = self._post(
+            orgId=str(org.id),
+            hostUrl="https://evil.example.com",
+            apiUrl="https://evil.example.com",
+            isEnterprise="true",
+            name="GitHub Actions",
+        )
+        request.user = _user()
+
+        with _patch_apps(_org_model(org)), patch.object(
+            auth_views, "user_has_permission", return_value=True
+        ):
+            response = auth_views.github_integration_authorize(request)
+
+        assert response.status_code == 302
+        # Redirect must target real GitHub, not the attacker host.
+        assert response.url.startswith("https://github.com/login/oauth/authorize")
+        assert "evil.example.com" not in response.url
+        # Session is pinned to github.com, enterprise coerced off.
+        assert request.session["gh_int_host_url"] == "https://github.com"
+        assert request.session["gh_int_api_url"] == "https://api.github.com"
+        assert request.session["gh_int_is_enterprise"] is False
+        assert request.session["gh_int_org_id"] == str(org.id)
+        assert request.session["gh_int_state"]
+        assert f"state={request.session['gh_int_state']}" in response.url
+
+    def test_self_hosted_enterprise_accepts_browser_host(self, settings, monkeypatch):
+        # Operator-supplied GHE host is honoured and stored for the callback,
+        # which reads it from the session (see test_happy_path_uses_session_not_query).
+        settings.APP_HOST = "self"
+        monkeypatch.setenv("GITHUB_ENTERPRISE_INTEGRATION_CLIENT_ID", "ent-cid")
+        from api.views import auth as auth_views
+
+        org = _org()
+        request = self._post(
+            orgId=str(org.id),
+            hostUrl="https://ghe.internal.corp",
+            apiUrl="https://ghe.internal.corp/api/v3",
+            isEnterprise="true",
+        )
+        request.user = _user()
+
+        with _patch_apps(_org_model(org)), patch.object(
+            auth_views, "user_has_permission", return_value=True
+        ):
+            response = auth_views.github_integration_authorize(request)
+
+        assert response.status_code == 302
+        assert response.url.startswith(
+            "https://ghe.internal.corp/login/oauth/authorize"
+        )
+        assert request.session["gh_int_host_url"] == "https://ghe.internal.corp"
+        assert request.session["gh_int_api_url"] == "https://ghe.internal.corp/api/v3"
+        assert request.session["gh_int_is_enterprise"] is True
+
+    def test_self_hosted_enterprise_api_url_derived_when_omitted(
+        self, settings, monkeypatch
+    ):
+        settings.APP_HOST = "self"
+        monkeypatch.setenv("GITHUB_ENTERPRISE_INTEGRATION_CLIENT_ID", "ent-cid")
+        from api.views import auth as auth_views
+
+        org = _org()
+        request = self._post(
+            orgId=str(org.id),
+            hostUrl="https://ghe.internal.corp",
+            isEnterprise="true",
+        )
+        request.user = _user()
+
+        with _patch_apps(_org_model(org)), patch.object(
+            auth_views, "user_has_permission", return_value=True
+        ):
+            response = auth_views.github_integration_authorize(request)
+
+        assert response.status_code == 302
+        assert request.session["gh_int_api_url"] == "https://ghe.internal.corp/api/v3"
+
+    def test_self_hosted_enterprise_rejects_bad_scheme(self, settings, monkeypatch):
+        settings.APP_HOST = "self"
+        monkeypatch.setenv("GITHUB_ENTERPRISE_INTEGRATION_CLIENT_ID", "ent-cid")
+        from api.views import auth as auth_views
+
+        org = _org()
+        request = self._post(
+            orgId=str(org.id),
+            hostUrl="javascript:alert(1)",
+            isEnterprise="true",
+            returnUrl="/apps",
+        )
+        request.user = _user()
+
+        with _patch_apps(_org_model(org)), patch.object(
+            auth_views, "user_has_permission", return_value=True
+        ):
+            response = auth_views.github_integration_authorize(request)
+
+        assert response.status_code == 302
+        assert "invalid_host_url" in response.url
+        assert "gh_int_state" not in request.session
+
+    def test_return_url_must_be_relative(self, settings, monkeypatch):
+        settings.APP_HOST = "cloud"
+        monkeypatch.setenv("GITHUB_INTEGRATION_CLIENT_ID", "cid-123")
+        from api.views import auth as auth_views
+
+        org = _org()
+        request = self._post(orgId=str(org.id), returnUrl="//evil.example.com/x")
+        request.user = _user()
+
+        with _patch_apps(_org_model(org)), patch.object(
+            auth_views, "user_has_permission", return_value=True
+        ):
+            response = auth_views.github_integration_authorize(request)
+
+        # Open-redirect target is dropped back to "/".
+        assert request.session["gh_int_return_url"] == "/"
+
+
+# ────────────────────────────────────────────────────────────────────
+#  callback
+# ────────────────────────────────────────────────────────────────────
+
+
+class TestGithubIntegrationCallback:
+    def _session_for(self, org_id, host_url="https://github.com", state="good-state"):
+        return {
+            "gh_int_state": state,
+            "gh_int_org_id": str(org_id),
+            "gh_int_host_url": host_url,
+            "gh_int_api_url": "https://api.github.com",
+            "gh_int_is_enterprise": False,
+            "gh_int_name": "GitHub Actions",
+            "gh_int_return_url": "/apps",
+        }
+
+    def _callback(self, query, session):
+        factory = RequestFactory()
+        request = factory.get("/oauth/github/callback", query)
+        _attach_session(request, session)
+        return request
+
+    def test_rejects_request_without_session_state(self):
+        from api.views import auth as auth_views
+
+        request = self._callback(
+            {"code": "x", "state": "anything"}, session={}
+        )
+        request.user = _user()
+
+        with patch.object(auth_views, "requests") as mock_requests, patch.object(
+            auth_views, "store_oauth_token"
+        ) as mock_store, patch.object(
+            auth_views, "get_secret", return_value="SUPER-SECRET"
+        ):
+            response = auth_views.github_integration_callback(request)
+
+        assert response.status_code == 302
+        assert "invalid_state" in response.url
+        # The client secret must never be sent, and nothing gets stored.
+        mock_requests.post.assert_not_called()
+        mock_store.assert_not_called()
+
+    def test_rejects_forged_state(self):
+        from api.views import auth as auth_views
+
+        org = _org()
+        session = self._session_for(org.id, state="server-nonce")
+        request = self._callback(
+            {"code": "x", "state": "attacker-nonce"}, session=session
+        )
+        request.user = _user()
+
+        with patch.object(auth_views, "requests") as mock_requests, patch.object(
+            auth_views, "store_oauth_token"
+        ) as mock_store, patch.object(
+            auth_views, "get_secret", return_value="SUPER-SECRET"
+        ):
+            response = auth_views.github_integration_callback(request)
+
+        assert "invalid_state" in response.url
+        mock_requests.post.assert_not_called()
+        mock_store.assert_not_called()
+
+    def test_happy_path_uses_session_not_query(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_INTEGRATION_CLIENT_ID", "cid-123")
+        from api.views import auth as auth_views
+
+        org = _org()
+        session = self._session_for(org.id)
+        # Attacker appends their host to the callback query — it must be ignored.
+        request = self._callback(
+            {
+                "code": "real-code",
+                "state": "good-state",
+                "hostUrl": "https://evil.example.com",
+                "orgId": str(uuid.uuid4()),
+            },
+            session=session,
+        )
+        request.user = _user()
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"access_token": "gho_abc"}
+
+        with _patch_apps(_org_model(org)), patch.object(
+            auth_views, "user_has_permission", return_value=True
+        ), patch.object(
+            auth_views.requests, "post", return_value=mock_response
+        ) as mock_post, patch.object(
+            auth_views, "store_oauth_token"
+        ) as mock_store, patch.object(
+            auth_views, "get_secret", return_value="SUPER-SECRET"
+        ):
+            response = auth_views.github_integration_callback(request)
+
+        # Token exchange goes to the SESSION host (github.com), not the attacker.
+        post_url = mock_post.call_args.args[0]
+        assert post_url == "https://github.com/login/oauth/access_token"
+        assert mock_post.call_args.kwargs["data"]["client_secret"] == "SUPER-SECRET"
+
+        # Credential is stored for the SESSION org, not the attacker's query org.
+        stored_args = mock_store.call_args.args
+        assert stored_args[0] == "github"
+        assert stored_args[5] == str(org.id)
+
+        assert response.status_code == 302
+        assert response.url == f"{auth_views.FRONTEND_URL}/apps"
+        # State is consumed (one-time use).
+        assert "gh_int_state" not in request.session
+
+    def test_revoked_permission_blocks_exchange(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_INTEGRATION_CLIENT_ID", "cid-123")
+        from api.views import auth as auth_views
+
+        org = _org()
+        session = self._session_for(org.id)
+        request = self._callback(
+            {"code": "real-code", "state": "good-state"}, session=session
+        )
+        request.user = _user()
+
+        with _patch_apps(_org_model(org)), patch.object(
+            auth_views, "user_has_permission", return_value=False
+        ), patch.object(
+            auth_views.requests, "post"
+        ) as mock_post, patch.object(
+            auth_views, "store_oauth_token"
+        ) as mock_store, patch.object(
+            auth_views, "get_secret", return_value="SUPER-SECRET"
+        ):
+            response = auth_views.github_integration_callback(request)
+
+        assert "permission_denied" in response.url
+        mock_post.assert_not_called()
+        mock_store.assert_not_called()
+
+    def test_unauthenticated_callback_blocked(self):
+        from api.views import auth as auth_views
+
+        org = _org()
+        session = self._session_for(org.id)
+        request = self._callback(
+            {"code": "real-code", "state": "good-state"}, session=session
+        )
+        request.user = AnonymousUser()
+
+        with patch.object(auth_views, "requests") as mock_requests, patch.object(
+            auth_views, "store_oauth_token"
+        ) as mock_store, patch.object(
+            auth_views, "get_secret", return_value="SUPER-SECRET"
+        ):
+            response = auth_views.github_integration_callback(request)
+
+        assert "login_required" in response.url
+        mock_requests.post.assert_not_called()
+        mock_store.assert_not_called()
+
+    def test_missing_code_after_valid_state(self, monkeypatch):
+        monkeypatch.setenv("GITHUB_INTEGRATION_CLIENT_ID", "cid-123")
+        from api.views import auth as auth_views
+
+        org = _org()
+        session = self._session_for(org.id)
+        request = self._callback({"state": "good-state"}, session=session)
+        request.user = _user()
+
+        with _patch_apps(_org_model(org)), patch.object(
+            auth_views, "user_has_permission", return_value=True
+        ), patch.object(
+            auth_views.requests, "post"
+        ) as mock_post, patch.object(
+            auth_views, "store_oauth_token"
+        ) as mock_store, patch.object(
+            auth_views, "get_secret", return_value="SUPER-SECRET"
+        ):
+            response = auth_views.github_integration_callback(request)
+
+        assert "missing_code" in response.url
+        mock_post.assert_not_called()
+        mock_store.assert_not_called()

--- a/frontend/components/syncing/GitHub/SetupGhAuth.tsx
+++ b/frontend/components/syncing/GitHub/SetupGhAuth.tsx
@@ -36,24 +36,33 @@ export const SetupGhAuth = () => {
     e.preventDefault()
     setIsPending(true)
 
+    // Real form POST (not fetch) so the backend's 302 to GitHub drives a
+    // top-level navigation. POST-only blocks cross-site initiation.
     const hostname = `${window.location.protocol}//${window.location.host}`
-    const redirectUri = `${hostname}/service/oauth/github/callback`
-    const scope = 'user,repo,admin:repo_hook,admin:org'
 
-    const statePayload = {
-      returnUrl: path,
+    const fields: Record<string, string> = {
       orgId: organisation!.id,
-      hostUrl,
-      apiUrl,
-      isEnterprise,
+      returnUrl: path ?? '/',
       name,
+      isEnterprise: String(isEnterprise),
+    }
+    if (isEnterprise) {
+      fields.hostUrl = hostUrl
+      fields.apiUrl = apiUrl
     }
 
-    const state = btoa(JSON.stringify(statePayload))
-
-    const authUrl = `${hostUrl}/login/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&scope=${scope}&state=${state}&prompt=consent`
-
-    window.open(authUrl, '_self')
+    const form = document.createElement('form')
+    form.method = 'POST'
+    form.action = `${hostname}/service/oauth/github/authorize`
+    for (const [key, value] of Object.entries(fields)) {
+      const input = document.createElement('input')
+      input.type = 'hidden'
+      input.name = key
+      input.value = value
+      form.appendChild(input)
+    }
+    document.body.appendChild(form)
+    form.submit()
   }
 
   useEffect(() => {


### PR DESCRIPTION
## :mag: Overview

Patches the GitHub secret-sync integration OAuth callback with various security hardening.

Full details are covered in a separate security advisory.

## :bulb: Proposed Changes

- **New authenticated `github_integration_authorize` endpoint.** It requires a logged-in user, checks the caller's `IntegrationCredentials: create` permission on the target org, generates a random `state` nonce, and binds the org / host / name / return URL to the server session before redirecting to GitHub.
- **Hardened `github_integration_callback`.** It validates the `state` against the session nonce, reads all sensitive parameters **from the session (never the request)**, consumes them (one-time use), and re-checks authentication + permission before exchanging the code. This is what closes the unauthenticated code path.
- **Host policy.** On cloud the OAuth host is pinned to `github.com`; on self-hosted, admin-configured GitHub Enterprise Server URLs (incl. internal hosts) continue to work unchanged.
- **Frontend.** `SetupGhAuth.tsx` now hands off to the backend authorize endpoint instead of building the OAuth `state` client-side.
- Post-flow redirects are constrained to same-origin relative paths.

## :framed_picture: Screenshots or Demo

N/A — no visible UI change; only the flow's initiation target and redirect handling change.

### :test_tube: Testing

- Added `backend/tests/api/views/test_github_callback.py` (13 tests): unauthenticated rejection, missing/forged `state`, permission enforcement (authorize + callback), cloud host-pinning + `isEnterprise` coercion, self-hosted internal GHE allowed, bad-scheme rejection, session-sourced (not query-sourced) host/org, one-time-use state, and the open-redirect guard.
- `tests/api/views/` passes (247), `python manage.py check` clean, frontend `tsc --noEmit` and `eslint` clean on the changed file.
- **Gap:** the end-to-end OAuth round-trip against a live GitHub app has not been exercised in a browser yet.

### :dart: Reviewer Focus

Start in `backend/api/views/auth.py`: the new `github_integration_authorize` and the rewritten `github_integration_callback` — specifically that every trusted value comes from `request.session` after the nonce check, and the cloud vs. self-hosted host policy. Then `frontend/components/syncing/GitHub/SetupGhAuth.tsx` for the initiation change.

### :heavy_plus_sign: Additional Context

Supersedes #806, which added `validate_url_is_safe` only — insufficient here (doesn't stop exfiltration to a public host, leaves the endpoint unauthenticated, and would reject legitimate internal GHE). Full security advisory published separately.

## :sparkles: How to Test the Changes Locally

1. Configure the GitHub integration OAuth env vars and start the dev stack (`docker compose -f dev-docker-compose.yml up -d`).
2. As a user with `IntegrationCredentials: create`, connect a GitHub credential from an app's syncing/integrations screen — the flow should complete and store the credential.
3. Negative check: an unauthenticated `GET /service/oauth/github/callback?code=x&state=y` should redirect to `?error=invalid_state` and perform no token exchange.

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
- [x] Update dependencies and lockfiles (if required) — N/A
- [x] Update migrations (if required) — N/A (no model changes)
- [x] Regenerate graphql schema and types (if required) — N/A (no schema changes)
- [x] Verify the app builds locally? — `django check` + frontend `tsc` clean
- [ ] Manually test the changes on different browsers/devices? — pending live OAuth round-trip
