### PR TITLE
fix: disable chromium ligature rendering on input fields

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -137,6 +137,9 @@ a {
   input,
   textarea {
     @apply px-2 py-1.5 text-sm focus:outline-none;
+    /* calt off while editing: Chromium's incremental shaping drops JetBrains Mono's
+       slash/underscore ligature glyphs mid-typing, e.g. "http://a" paints as "http: /a" */
+    font-feature-settings: 'calt' 0;
   }
 
   input:not(.custom) {

--- a/frontend/components/common/MaskedTextarea.tsx
+++ b/frontend/components/common/MaskedTextarea.tsx
@@ -60,6 +60,9 @@ export const MaskedTextarea = forwardRef<HTMLTextAreaElement, MaskedTextareaProp
     const sharedClasses = clsx(
       className,
       'resize-none',
+      // Match the textarea's calt-off shaping (globals.css) so the highlight overlay
+      // renders the exact same glyphs it covers
+      "[font-feature-settings:'calt'_0]",
       rows === 1 ? 'whitespace-nowrap' : 'whitespace-pre-wrap break-all'
     )
 

--- a/frontend/components/common/MaskedTextarea.tsx
+++ b/frontend/components/common/MaskedTextarea.tsx
@@ -60,8 +60,6 @@ export const MaskedTextarea = forwardRef<HTMLTextAreaElement, MaskedTextareaProp
     const sharedClasses = clsx(
       className,
       'resize-none',
-      // Match the textarea's calt-off shaping (globals.css) so the highlight overlay
-      // renders the exact same glyphs it covers
       "[font-feature-settings:'calt'_0]",
       rows === 1 ? 'whitespace-nowrap' : 'whitespace-pre-wrap break-all'
     )
@@ -86,7 +84,8 @@ export const MaskedTextarea = forwardRef<HTMLTextAreaElement, MaskedTextareaProp
           'overflow-auto scrollbar-hide focus:outline-none',
           isRevealed ? 'text-security-none' : 'text-security-disc',
           disabled && 'opacity-60 cursor-not-allowed',
-          hasHighlight && '!text-transparent caret-zinc-900 dark:caret-zinc-100 !bg-transparent relative'
+          hasHighlight &&
+            '!text-transparent caret-zinc-900 dark:caret-zinc-100 !bg-transparent relative'
         )}
       />
     )


### PR DESCRIPTION
## :mag: Overview

In the single-env and cross-env secret editors, values that contain `//` render incorrectly while you type in Chromium-based browsers. Example: type `http://a` and the value field shows `http: /a`. The stored value is correct. If you copy the value and paste it elsewhere, the text is correct. Firefox is not affected.

The value fields use the JetBrains Mono font. This font has contextual ligatures (`calt`) for character pairs such as `//` and `__`. For `//`, the font replaces the first slash with a blank spacer glyph. It replaces the second slash with a wide glyph that draws both slashes.

Chromium caches text shaping and reuses a stale prefix while you type ([harfbuzz#1463](https://github.com/harfbuzz/harfbuzz/issues/1463)). After the keystroke, Chromium keeps the blank spacer but draws a plain single slash. The result is a gap and one slash: `http: /a`. Firefox reshapes the full text on each keystroke, so the ligature renders correctly there.

## :bulb: Proposed Changes

- Add `font-feature-settings: 'calt' 0` to the base `input, textarea` rule in `globals.css`. This disables the ligature substitution in all editable fields.
- Add the same rule to the shared classes in `MaskedTextarea.tsx`. The reference-highlight overlay then shows the same glyphs as the textarea below it.

The fix is scoped to editable fields. Read-only surfaces (code blocks, history, diffs, CLI snippets) keep ligatures. Those surfaces reshape the full text on each render, so the bug cannot occur there. Key inputs are also covered: JetBrains Mono has the same substitution for `__`, so keys such as `MY__VAR` had the same problem.

## :framed_picture: Screenshots or Demo

| Before | After |
| --- | --- |
| Type `http://a` → the field shows `http: /a` | The field shows `http://a` |

## :memo: Release Notes

- Fixed: secret values and keys that contain `//` or `__` now render correctly while you type in Chromium-based browsers.

## :question: Open Questions

- The editors now show `//` as two separate slashes. Read-only views, such as the history dialog, still show the fused ligature pair. We can extend the rule to those views if we want identical rendering everywhere.


### :heavy_plus_sign: Additional Context

- The Google Fonts build of JetBrains Mono has no `liga` feature. All of its ligatures live in `calt`. Thus `'calt' 0` disables all of them.
- CodeMirror and VS Code disable font ligatures in editable text by default, for the same reason: ligatures do not show what you typed.


## :sparkles: How to Test the Changes Locally

1. Start the dev environment: `docker compose -f dev-docker-compose.yml up -d`.
2. Open `https://localhost` in a Chromium-based browser.
3. Open an app and go to a secrets editor.
4. Reveal a secret value. Type `http://a` in the value field.
5. Make sure that the field shows `http://a`.
6. Type `A__B` in a key field. Make sure that the field shows two underscores.

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)?
- [ ] Update dependencies and lockfiles (if required) — not required
- [ ] Update migrations (if required) — not required
- [ ] Regenerate graphql schema and types (if required) — not required
- [x] Verify the app builds locally?
- [x] Manually test the changes on different browsers/devices? — verified on Chromium; Firefox was never affected
