### PR TITLE
fix: protect service account credential boundaries

### DIFF
--- a/backend/api/views/service_accounts.py
+++ b/backend/api/views/service_accounts.py
@@ -406,6 +406,13 @@ class PublicServiceAccountsView(APIView):
             account = request.auth["service_account"]
             is_sa = True
 
+        # Creating an SA also mints its one-shot initial credential. Legacy
+        # and otherwise unsupported principals must not bypass either check.
+        if request.method == "POST" and account is None:
+            raise PermissionDenied(
+                "This token type cannot create service accounts."
+            )
+
         if account is not None:
             org = self._get_org(request)
             if not user_has_permission(
@@ -413,6 +420,17 @@ class PublicServiceAccountsView(APIView):
             ):
                 raise PermissionDenied(
                     f"You don't have permission to {action} service accounts."
+                )
+            if request.method == "POST" and not user_has_permission(
+                account,
+                "create",
+                "ServiceAccountTokens",
+                org,
+                False,
+                is_sa,
+            ):
+                raise PermissionDenied(
+                    "You don't have permission to create service account tokens."
                 )
 
     def get(self, request, *args, **kwargs):

--- a/backend/api/views/service_accounts.py
+++ b/backend/api/views/service_accounts.py
@@ -406,8 +406,7 @@ class PublicServiceAccountsView(APIView):
             account = request.auth["service_account"]
             is_sa = True
 
-        # Creating an SA also mints its one-shot initial credential. Legacy
-        # and otherwise unsupported principals must not bypass either check.
+        # Creating an SA also mints its one-shot initial credential.
         if request.method == "POST" and account is None:
             raise PermissionDenied(
                 "This token type cannot create service accounts."

--- a/backend/backend/graphene/types.py
+++ b/backend/backend/graphene/types.py
@@ -375,7 +375,18 @@ class ServiceAccountTokenType(DjangoObjectType):
 
     class Meta:
         model = ServiceAccountToken
-        fields = "__all__"
+        fields = (
+            "id",
+            "service_account",
+            "name",
+            "created_by",
+            "created_by_service_account",
+            "created_at",
+            "updated_at",
+            "deleted_at",
+            "expires_at",
+            "last_used_at",
+        )
 
     def resolve_last_used(self, info):
         # Direct bump from auth is authoritative — every authenticated

--- a/backend/backend/graphene/types.py
+++ b/backend/backend/graphene/types.py
@@ -965,10 +965,7 @@ class ServiceAccountType(DjangoObjectType):
         return ServiceAccountHandler.objects.filter(service_account=self)
 
     def resolve_tokens(self, info):
-        # Gate raw token / wrapped_key_share / identity_key — exposed
-        # via fields="__all__" on ServiceAccountTokenType. Without this
-        # check, any user with Teams.read can harvest team-owned SA
-        # credentials cross-team.
+        # Resolving the SA (e.g. via Teams.read) must not imply listing its token metadata.
         from api.utils.access.permissions import _check_sa_permission
         try:
             _check_sa_permission(

--- a/backend/tests/api/test_service_account_token_exposure.py
+++ b/backend/tests/api/test_service_account_token_exposure.py
@@ -18,6 +18,25 @@ from unittest.mock import MagicMock, patch
 from graphql import GraphQLError
 
 
+def test_service_account_token_graphql_type_exposes_metadata_only():
+    """The GraphQL token type must never publish credential material."""
+    from backend.graphene.types import ServiceAccountTokenType
+
+    assert set(ServiceAccountTokenType._meta.fields) == {
+        "id",
+        "service_account",
+        "name",
+        "created_by",
+        "created_by_service_account",
+        "created_at",
+        "updated_at",
+        "deleted_at",
+        "expires_at",
+        "last_used_at",
+        "last_used",
+    }
+
+
 def _info(user):
     info = MagicMock()
     info.context.user = user

--- a/backend/tests/api/views/test_service_accounts_api.py
+++ b/backend/tests/api/views/test_service_accounts_api.py
@@ -266,6 +266,60 @@ class TestServiceAccountsCreate:
         assert "id" in initial
         assert "token" in initial
         assert "bearer_token" in initial
+        checked_permissions = {
+            (call.args[1], call.args[2]) for call in _perm.call_args_list
+        }
+        assert checked_permissions == {
+            ("create", "ServiceAccounts"),
+            ("create", "ServiceAccountTokens"),
+        }
+
+    @patch("api.views.service_accounts.ServiceAccountToken")
+    @patch("api.views.service_accounts.ServiceAccount")
+    @patch("api.views.service_accounts.user_has_permission")
+    @patch("api.views.service_accounts.PlanBasedRateThrottle.allow_request", return_value=True)
+    @patch("api.views.service_accounts.IsIPAllowed.has_permission", return_value=True)
+    def test_create_requires_token_create_permission(
+        self, _ip, _throttle, mock_permission, mock_sa_model, mock_sat_model
+    ):
+        mock_permission.side_effect = (
+            lambda _account, _action, resource, *_args: resource
+            == "ServiceAccounts"
+        )
+
+        request = _build_list_request(
+            "post",
+            "/public/v1/service-accounts/",
+            self.org,
+            data={"name": "new-sa", "role_id": str(self.role.id)},
+        )
+        response = self.view(request)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        mock_sa_model.objects.create.assert_not_called()
+        mock_sat_model.objects.create.assert_not_called()
+
+    @patch("api.views.service_accounts.ServiceAccountToken")
+    @patch("api.views.service_accounts.ServiceAccount")
+    @patch("api.views.service_accounts.user_has_permission", return_value=True)
+    @patch("api.views.service_accounts.PlanBasedRateThrottle.allow_request", return_value=True)
+    @patch("api.views.service_accounts.IsIPAllowed.has_permission", return_value=True)
+    def test_create_rejects_legacy_service_principal(
+        self, _ip, _throttle, mock_permission, mock_sa_model, mock_sat_model
+    ):
+        request = _build_list_request(
+            "post",
+            "/public/v1/service-accounts/",
+            self.org,
+            data={"name": "new-sa", "role_id": str(self.role.id)},
+            auth_type="Service",
+        )
+        response = self.view(request)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        mock_permission.assert_not_called()
+        mock_sa_model.objects.create.assert_not_called()
+        mock_sat_model.objects.create.assert_not_called()
 
     @patch("api.views.service_accounts.user_has_permission", return_value=True)
     @patch("api.views.service_accounts.PlanBasedRateThrottle.allow_request", return_value=True)

--- a/frontend/apollo/graphql.ts
+++ b/frontend/apollo/graphql.ts
@@ -3740,15 +3740,11 @@ export type ServiceAccountTokenType = {
   deletedAt?: Maybe<Scalars['DateTime']['output']>;
   expiresAt?: Maybe<Scalars['DateTime']['output']>;
   id: Scalars['String']['output'];
-  identityKey: Scalars['String']['output'];
   lastUsed?: Maybe<Scalars['DateTime']['output']>;
   lastUsedAt?: Maybe<Scalars['DateTime']['output']>;
   name: Scalars['String']['output'];
-  secreteventSet: Array<SecretEventType>;
   serviceAccount: ServiceAccountType;
-  token: Scalars['String']['output'];
   updatedAt: Scalars['DateTime']['output'];
-  wrappedKeyShare: Scalars['String']['output'];
 };
 
 export type ServiceAccountType = {

--- a/frontend/apollo/schema.graphql
+++ b/frontend/apollo/schema.graphql
@@ -409,9 +409,6 @@ type ServiceAccountTokenType {
   id: String!
   serviceAccount: ServiceAccountType!
   name: String!
-  identityKey: String!
-  token: String!
-  wrappedKeyShare: String!
   createdBy: OrganisationMemberType
   createdByServiceAccount: ServiceAccountType
   createdAt: DateTime
@@ -419,7 +416,6 @@ type ServiceAccountTokenType {
   deletedAt: DateTime
   expiresAt: DateTime
   lastUsedAt: DateTime
-  secreteventSet: [SecretEventType!]!
   lastUsed: DateTime
 }
 


### PR DESCRIPTION
- Limit service-account token reads to metadata.
- Require token-create permission before issuing initial credentials.
- Add regression coverage and regenerate GraphQL types.