### PR TITLE
fix: validate env and principal bindings in SSE init, env creation, and SA handler flows

### DIFF
--- a/backend/backend/graphene/mutations/environment.py
+++ b/backend/backend/graphene/mutations/environment.py
@@ -191,6 +191,55 @@ class CreateEnvironmentMutation(graphene.Mutation):
             else:
                 index = 0
 
+        org_owner = OrganisationMember.objects.get(
+            organisation=app.organisation,
+            role__is_default=True,
+            role__managed_key=OWNER_ROLE_KEY,
+            deleted_at=None,
+        )
+
+        request_member = OrganisationMember.objects.get(
+            user=info.context.user,
+            organisation=app.organisation,
+            deleted_at=None,
+        )
+
+        # Admin keys grant env access — global-access members and the creator only.
+        admin_keys = list(admin_keys or [])
+        admin_member_ids = [
+            str(key.user_id)
+            for key in admin_keys
+            if getattr(key, "user_id", None) is not None
+        ]
+        if len(admin_member_ids) != len(admin_keys):
+            raise GraphQLError("Admin key principal is required")
+        if len(set(admin_member_ids)) != len(admin_member_ids):
+            raise GraphQLError("Duplicate admin key principals are not allowed")
+        if str(org_owner.id) in admin_member_ids:
+            raise GraphQLError(
+                "The Owner's environment key is created automatically"
+            )
+
+        admin_members = {
+            str(member.id): member
+            for member in OrganisationMember.objects.filter(
+                id__in=admin_member_ids,
+                organisation=app.organisation,
+                deleted_at=None,
+            ).select_related("role")
+        }
+        if set(admin_members) != set(admin_member_ids):
+            raise GraphQLError(
+                "Some admin key principals are not members of this organisation"
+            )
+        for member in admin_members.values():
+            if str(member.id) == str(request_member.id):
+                continue
+            if not role_has_global_access(member.role):
+                raise GraphQLError(
+                    "Admin keys can only be created for members with global access"
+                )
+
         with transaction.atomic():
             environment = Environment.objects.create(
                 app=app,
@@ -200,13 +249,6 @@ class CreateEnvironmentMutation(graphene.Mutation):
                 identity_key=environment_data.identity_key,
                 wrapped_seed=environment_data.wrapped_seed,
                 wrapped_salt=environment_data.wrapped_salt,
-            )
-
-            org_owner = OrganisationMember.objects.get(
-                organisation=environment.app.organisation,
-                role__is_default=True,
-                role__managed_key=OWNER_ROLE_KEY,
-                deleted_at=None,
             )
 
             # Add the org owner to the environment
@@ -226,7 +268,7 @@ class CreateEnvironmentMutation(graphene.Mutation):
             for key in admin_keys:
                 admin_key = EnvironmentKey.objects.create(
                     environment=environment,
-                    user_id=key.user_id,
+                    user=admin_members[str(key.user_id)],
                     wrapped_seed=key.wrapped_seed,
                     wrapped_salt=key.wrapped_salt,
                     identity_key=key.identity_key,

--- a/backend/backend/graphene/mutations/service_accounts.py
+++ b/backend/backend/graphene/mutations/service_accounts.py
@@ -36,6 +36,31 @@ class ServiceAccountHandlerInput(graphene.InputObjectType):
     wrapped_recovery = graphene.String(required=True)
 
 
+def _validate_handler_members(org, handlers):
+    """Handler principals must be active members of the SA's organisation."""
+    if None in {getattr(handler, "member_id", None) for handler in handlers}:
+        raise GraphQLError("Handler member ID is required")
+
+    handler_pairs = [
+        (str(getattr(handler, "service_account_id", None)), str(handler.member_id))
+        for handler in handlers
+    ]
+    if len(handler_pairs) != len(set(handler_pairs)):
+        raise GraphQLError("Duplicate handlers are not allowed")
+
+    member_ids = {str(handler.member_id) for handler in handlers}
+    valid_member_ids = {
+        str(member_id)
+        for member_id in OrganisationMember.objects.filter(
+            id__in=member_ids,
+            organisation=org,
+            deleted_at=None,
+        ).values_list("id", flat=True)
+    }
+    if member_ids != valid_member_ids:
+        raise GraphQLError("Some handlers are not members of this organisation")
+
+
 class CreateServiceAccountMutation(graphene.Mutation):
     class Arguments:
         name = graphene.String()
@@ -100,6 +125,8 @@ class CreateServiceAccountMutation(graphene.Mutation):
 
         if handlers is None or len(handlers) == 0:
             raise GraphQLError("At least one service account handler must be provided")
+
+        _validate_handler_members(org, handlers)
 
         role = Role.objects.get(id=role_id, organisation=org)
 
@@ -340,14 +367,23 @@ class UpdateServiceAccountHandlersMutation(graphene.Mutation):
 
         # Pre-flight: org-level perms aren't sufficient for team-owned
         # SAs — fail before the bulk delete below if any are off-limits.
-        sa_ids = set(h.service_account_id for h in handlers)
-        target_sas = ServiceAccount.objects.filter(
-            id__in=sa_ids,
-            organisation=org,
-            deleted_at__isnull=True,
-        ).select_related("team")
-        for sa in target_sas:
+        sa_ids = set(str(h.service_account_id) for h in handlers)
+        target_sas = {
+            str(sa.id): sa
+            for sa in ServiceAccount.objects.filter(
+                id__in=sa_ids,
+                organisation=org,
+                deleted_at__isnull=True,
+            ).select_related("team")
+        }
+        if set(target_sas) != sa_ids:
+            raise GraphQLError(
+                "Some service accounts do not belong to this organisation"
+            )
+        for sa in target_sas.values():
             _check_sa_permission(user, sa, "update", "ServiceAccounts")
+
+        _validate_handler_members(org, handlers)
 
         # Scope the delete to listed SAs so we don't wipe handlers for
         # team-owned SAs the caller can't see.
@@ -358,9 +394,7 @@ class UpdateServiceAccountHandlersMutation(graphene.Mutation):
         ).delete()
 
         for handler in handlers:
-            service_account = ServiceAccount.objects.get(
-                id=handler.service_account_id, deleted_at__isnull=True
-            )
+            service_account = target_sas[str(handler.service_account_id)]
 
             if not ServiceAccountHandler.objects.filter(
                 service_account=service_account, user_id=handler.member_id

--- a/backend/backend/graphene/mutations/syncing.py
+++ b/backend/backend/graphene/mutations/syncing.py
@@ -6,6 +6,7 @@ from api.utils.syncing.azure.key_vault import validate_vault_uri
 
 from api.utils.syncing.render.main import RenderResourceType
 import graphene
+from django.db import transaction
 from graphql import GraphQLError
 from api.utils.access.permissions import (
     user_can_access_app,
@@ -48,46 +49,78 @@ class InitEnvSync(graphene.Mutation):
         if not user_can_access_app(user.userId, app.id):
             raise GraphQLError("You don't have access to this app")
 
-        for env in Environment.objects.filter(app=app):
-            if not user_can_access_environment(info.context.user.userId, env.id):
+        if not user_has_permission(
+            user, "update", "EncryptionMode", app.organisation, True, app=app
+        ):
+            raise GraphQLError(
+                "You don't have permission to change the encryption mode of this App"
+            )
+
+        app_environments = {
+            str(env.id): env for env in Environment.objects.filter(app=app)
+        }
+        if not app_environments:
+            raise GraphQLError("This App has no environments")
+
+        for env in app_environments.values():
+            if not user_can_access_environment(user.userId, env.id):
                 raise GraphQLError(
                     "You cannot enable SSE as you don't have access to all environments in this App"
                 )
 
-        else:
+        env_keys = list(env_keys or [])
+        requested_env_ids = [str(key.env_id) for key in env_keys]
+        if len(requested_env_ids) != len(set(requested_env_ids)):
+            raise GraphQLError("Duplicate environment IDs are not allowed")
+        if not set(requested_env_ids) <= set(app_environments):
+            raise GraphQLError("Some environment IDs do not belong to this app")
+        if set(requested_env_ids) != set(app_environments):
+            raise GraphQLError(
+                "Server keys must be supplied for every environment of this App"
+            )
+
+        with transaction.atomic():
             was_enabled = app.sse_enabled
             app.sse_enabled = True
             app.save()
-            # set new server env keys
-            for key in env_keys:
-                ServerEnvironmentKey.objects.create(
-                    environment_id=key.env_id,
-                    wrapped_seed=key.wrapped_seed,
-                    wrapped_salt=key.wrapped_salt,
-                    identity_key=key.identity_key,
-                )
 
-            # Only audit the actual transition, not idempotent re-enables.
-            if not was_enabled:
-                actor_type, actor_id, actor_metadata = get_actor_info_from_graphql(
-                    info, organisation=app.organisation
-                )
-                ip_address, user_agent = get_resolver_request_meta(info.context)
-                log_audit_event(
-                    organisation=app.organisation,
-                    event_type="U",
-                    resource_type="app",
-                    resource_id=app.id,
-                    actor_type=actor_type,
-                    actor_id=actor_id,
-                    actor_metadata=actor_metadata,
-                    resource_metadata={"name": app.name},
-                    old_values={"sse_enabled": False},
-                    new_values={"sse_enabled": True},
-                    description=f"Enabled server-side encryption on app '{app.name}'",
-                    ip_address=ip_address,
-                    user_agent=user_agent,
-                )
+            for key in env_keys:
+                environment = app_environments[str(key.env_id)]
+                # filter().first() instead of update_or_create: legacy dupes
+                # from the old unconditional create() would trip
+                # MultipleObjectsReturned.
+                server_key = ServerEnvironmentKey.objects.filter(
+                    environment=environment
+                ).first()
+                if server_key is None:
+                    server_key = ServerEnvironmentKey(environment=environment)
+                server_key.wrapped_seed = key.wrapped_seed
+                server_key.wrapped_salt = key.wrapped_salt
+                server_key.identity_key = key.identity_key
+                server_key.deleted_at = None
+                server_key.save()
+
+        # Only audit the actual transition, not idempotent re-enables.
+        if not was_enabled:
+            actor_type, actor_id, actor_metadata = get_actor_info_from_graphql(
+                info, organisation=app.organisation
+            )
+            ip_address, user_agent = get_resolver_request_meta(info.context)
+            log_audit_event(
+                organisation=app.organisation,
+                event_type="U",
+                resource_type="app",
+                resource_id=app.id,
+                actor_type=actor_type,
+                actor_id=actor_id,
+                actor_metadata=actor_metadata,
+                resource_metadata={"name": app.name},
+                old_values={"sse_enabled": False},
+                new_values={"sse_enabled": True},
+                description=f"Enabled server-side encryption on app '{app.name}'",
+                ip_address=ip_address,
+                user_agent=user_agent,
+            )
 
         return InitEnvSync(app=app)
 

--- a/backend/tests/api/mutations/test_update_service_account_handlers.py
+++ b/backend/tests/api/mutations/test_update_service_account_handlers.py
@@ -81,6 +81,7 @@ def test_pre_flight_check_blocks_inaccessible_team_sa(
     MockHandler.objects.create.assert_not_called()
 
 
+@patch("backend.graphene.mutations.service_accounts.OrganisationMember")
 @patch("backend.graphene.mutations.service_accounts.ServiceAccountHandler")
 @patch("backend.graphene.mutations.service_accounts.ServiceAccount")
 @patch("backend.graphene.mutations.service_accounts._check_sa_permission", return_value=None)
@@ -94,6 +95,7 @@ def test_pre_flight_passes_when_all_sas_accessible(
     _mock_check_sa,
     MockSA,
     MockHandler,
+    MockMember,
 ):
     """Regression: when every SA in the payload passes the per-SA
     permission check, the mutation proceeds to delete handlers and
@@ -107,8 +109,7 @@ def test_pre_flight_passes_when_all_sas_accessible(
 
     sa = MagicMock(id="sa-1")
     MockSA.objects.filter.return_value.select_related.return_value = [sa]
-    # `ServiceAccount.objects.get(...)` for the per-handler create loop
-    MockSA.objects.get.return_value = sa
+    MockMember.objects.filter.return_value.values_list.return_value = ["m1"]
     # No existing handler for this (sa, member) pair.
     MockHandler.objects.filter.return_value.exists.return_value = False
 
@@ -122,6 +123,9 @@ def test_pre_flight_passes_when_all_sas_accessible(
         handlers=[_make_handler_input("sa-1")],
     )
 
-    # Bulk delete fired; new handler created.
+    # Bulk delete fired; new handler created from the preflighted SA —
+    # never via an unscoped re-fetch.
     MockHandler.objects.filter.return_value.delete.assert_called()
     MockHandler.objects.create.assert_called_once()
+    assert MockHandler.objects.create.call_args.kwargs["service_account"] is sa
+    MockSA.objects.get.assert_not_called()

--- a/backend/tests/graphene/mutations/test_env_key_provisioning_bindings.py
+++ b/backend/tests/graphene/mutations/test_env_key_provisioning_bindings.py
@@ -1,0 +1,550 @@
+"""Env and principal binding regressions for SSE init, environment
+creation, and service-account handler provisioning."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from graphql import GraphQLError
+
+
+def _make_info(user_id="actor-1"):
+    info = MagicMock()
+    info.context.user.userId = user_id
+    return info
+
+
+def _make_env_key(env_id):
+    return SimpleNamespace(
+        env_id=env_id,
+        identity_key=f"ik-{env_id}",
+        wrapped_seed=f"seed-{env_id}",
+        wrapped_salt=f"salt-{env_id}",
+    )
+
+
+# ════════════════════════════════════════════════════════════════════
+# InitEnvSync — server keys must cover exactly the app's own envs
+# ════════════════════════════════════════════════════════════════════
+
+
+def _patch_init_env_sync(monkeypatch, app_envs, permission=True):
+    from backend.graphene.mutations import syncing as mutations
+
+    app = MagicMock(id="app-1", name="App One", sse_enabled=False)
+    app.organisation = MagicMock(id="org-1")
+
+    mock_app_model = MagicMock()
+    mock_app_model.objects.get.return_value = app
+    monkeypatch.setattr(mutations, "App", mock_app_model)
+
+    mock_env_model = MagicMock()
+    mock_env_model.objects.filter.return_value = app_envs
+    monkeypatch.setattr(mutations, "Environment", mock_env_model)
+
+    mock_sek_model = MagicMock()
+    monkeypatch.setattr(mutations, "ServerEnvironmentKey", mock_sek_model)
+
+    monkeypatch.setattr(mutations, "transaction", MagicMock())
+    monkeypatch.setattr(mutations, "user_can_access_app", MagicMock(return_value=True))
+    monkeypatch.setattr(
+        mutations, "user_can_access_environment", MagicMock(return_value=True)
+    )
+    monkeypatch.setattr(
+        mutations, "user_has_permission", MagicMock(return_value=permission)
+    )
+    monkeypatch.setattr(
+        mutations,
+        "get_actor_info_from_graphql",
+        MagicMock(return_value=("user", "actor-1", {})),
+    )
+    monkeypatch.setattr(
+        mutations,
+        "get_resolver_request_meta",
+        MagicMock(return_value=("127.0.0.1", "pytest")),
+    )
+    monkeypatch.setattr(mutations, "log_audit_event", MagicMock())
+
+    return mutations, app, mock_sek_model
+
+
+def test_init_env_sync_rejects_foreign_env_id_before_any_write(monkeypatch):
+    env = MagicMock(id="env-1")
+    mutations, app, sek_model = _patch_init_env_sync(monkeypatch, [env])
+
+    with pytest.raises(GraphQLError, match="do not belong to this app"):
+        mutations.InitEnvSync.mutate(
+            None,
+            _make_info(),
+            app_id="app-1",
+            env_keys=[_make_env_key("env-1"), _make_env_key("foreign-env")],
+        )
+
+    sek_model.objects.filter.assert_not_called()
+    sek_model.assert_not_called()
+    app.save.assert_not_called()
+
+
+def test_init_env_sync_rejects_duplicate_env_ids(monkeypatch):
+    env = MagicMock(id="env-1")
+    mutations, app, sek_model = _patch_init_env_sync(monkeypatch, [env])
+
+    with pytest.raises(GraphQLError, match="Duplicate environment IDs"):
+        mutations.InitEnvSync.mutate(
+            None,
+            _make_info(),
+            app_id="app-1",
+            env_keys=[_make_env_key("env-1"), _make_env_key("env-1")],
+        )
+
+    sek_model.objects.filter.assert_not_called()
+    sek_model.assert_not_called()
+    app.save.assert_not_called()
+
+
+def test_init_env_sync_rejects_incomplete_coverage(monkeypatch):
+    envs = [MagicMock(id="env-1"), MagicMock(id="env-2")]
+    mutations, app, sek_model = _patch_init_env_sync(monkeypatch, envs)
+
+    with pytest.raises(GraphQLError, match="every environment"):
+        mutations.InitEnvSync.mutate(
+            None, _make_info(), app_id="app-1", env_keys=[_make_env_key("env-1")]
+        )
+
+    sek_model.objects.filter.assert_not_called()
+    sek_model.assert_not_called()
+    app.save.assert_not_called()
+
+
+def test_init_env_sync_requires_encryption_mode_permission(monkeypatch):
+    env = MagicMock(id="env-1")
+    mutations, app, sek_model = _patch_init_env_sync(
+        monkeypatch, [env], permission=False
+    )
+
+    with pytest.raises(GraphQLError, match="encryption mode"):
+        mutations.InitEnvSync.mutate(
+            None, _make_info(), app_id="app-1", env_keys=[_make_env_key("env-1")]
+        )
+
+    permission_call = mutations.user_has_permission.call_args
+    assert permission_call.args[1:] == ("update", "EncryptionMode", app.organisation, True)
+    assert permission_call.kwargs == {"app": app}
+    sek_model.objects.filter.assert_not_called()
+    sek_model.assert_not_called()
+    app.save.assert_not_called()
+
+
+def test_init_env_sync_rejects_app_with_no_environments(monkeypatch):
+    mutations, app, sek_model = _patch_init_env_sync(monkeypatch, [])
+
+    with pytest.raises(GraphQLError, match="no environments"):
+        mutations.InitEnvSync.mutate(
+            None, _make_info(), app_id="app-1", env_keys=[]
+        )
+
+    app.save.assert_not_called()
+
+
+def test_init_env_sync_upserts_validated_envs(monkeypatch):
+    env_one = MagicMock(id="env-1")
+    env_two = MagicMock(id="env-2")
+    mutations, app, sek_model = _patch_init_env_sync(monkeypatch, [env_one, env_two])
+    existing_key = MagicMock()
+    fresh_key = MagicMock()
+    sek_model.objects.filter.return_value.first.side_effect = [existing_key, None]
+    sek_model.return_value = fresh_key
+
+    mutations.InitEnvSync.mutate(
+        None,
+        _make_info(),
+        app_id="app-1",
+        env_keys=[_make_env_key("env-1"), _make_env_key("env-2")],
+    )
+
+    assert app.sse_enabled is True
+    app.save.assert_called_once()
+    mutations.Environment.objects.filter.assert_called_once_with(app=app)
+    filtered_envs = [
+        call.kwargs["environment"]
+        for call in sek_model.objects.filter.call_args_list
+    ]
+    assert filtered_envs == [env_one, env_two]
+    # env-1 had an existing row: it is updated in place, never duplicated.
+    assert existing_key.wrapped_seed == "seed-env-1"
+    assert existing_key.deleted_at is None
+    existing_key.save.assert_called_once()
+    # env-2 had none: a fresh row is created for the validated environment.
+    sek_model.assert_called_once_with(environment=env_two)
+    assert fresh_key.wrapped_seed == "seed-env-2"
+    fresh_key.save.assert_called_once()
+    mutations.log_audit_event.assert_called_once()
+
+
+# ════════════════════════════════════════════════════════════════════
+# CreateEnvironmentMutation — admin keys only for global-access members
+# ════════════════════════════════════════════════════════════════════
+
+
+def _make_admin_key(user_id):
+    return SimpleNamespace(
+        user_id=user_id,
+        identity_key="ik",
+        wrapped_seed="seed",
+        wrapped_salt="salt",
+    )
+
+
+def _patch_create_environment(monkeypatch, admin_members, global_access=True):
+    from backend.graphene.mutations import environment as mutations
+
+    app = MagicMock(id="app-1", name="App One")
+    app.organisation = MagicMock(id="org-1")
+
+    mock_app_model = MagicMock()
+    mock_app_model.objects.get.return_value = app
+    monkeypatch.setattr(mutations, "App", mock_app_model)
+
+    mock_env_model = MagicMock()
+    mock_env_model.objects.filter.return_value.exists.return_value = False
+    monkeypatch.setattr(mutations, "Environment", mock_env_model)
+
+    owner = MagicMock(id="owner-1")
+    creator = MagicMock(id="creator-1")
+    mock_member_model = MagicMock()
+    # The owner fetch filters by managed_key; the requester fetch by user.
+    mock_member_model.objects.get.side_effect = lambda **kwargs: (
+        owner if "role__managed_key" in kwargs else creator
+    )
+    mock_member_model.objects.filter.return_value.select_related.return_value = (
+        admin_members
+    )
+    monkeypatch.setattr(mutations, "OrganisationMember", mock_member_model)
+
+    mock_key_model = MagicMock()
+    monkeypatch.setattr(mutations, "EnvironmentKey", mock_key_model)
+    monkeypatch.setattr(mutations, "EnvironmentKeyGrant", MagicMock())
+    monkeypatch.setattr(mutations, "ServerEnvironmentKey", MagicMock())
+    monkeypatch.setattr(mutations, "transaction", MagicMock())
+    monkeypatch.setattr(mutations, "user_can_access_app", MagicMock(return_value=True))
+    monkeypatch.setattr(mutations, "user_has_permission", MagicMock(return_value=True))
+    monkeypatch.setattr(
+        mutations, "role_has_global_access", MagicMock(return_value=global_access)
+    )
+    monkeypatch.setattr(mutations, "can_use_custom_envs", MagicMock(return_value=True))
+    monkeypatch.setattr(mutations, "can_add_environment", MagicMock(return_value=True))
+    monkeypatch.setattr(
+        mutations,
+        "get_actor_info_from_graphql",
+        MagicMock(return_value=("user", "actor-1", {})),
+    )
+    monkeypatch.setattr(
+        mutations,
+        "get_resolver_request_meta",
+        MagicMock(return_value=("127.0.0.1", "pytest")),
+    )
+    monkeypatch.setattr(mutations, "log_audit_event", MagicMock())
+
+    environment_data = SimpleNamespace(
+        app_id="app-1",
+        name="Development",
+        env_type="dev",
+        identity_key="env-ik",
+        wrapped_seed="env-seed",
+        wrapped_salt="env-salt",
+    )
+
+    return (
+        mutations,
+        environment_data,
+        owner,
+        creator,
+        mock_env_model,
+        mock_key_model,
+        mock_member_model,
+    )
+
+
+def test_create_environment_rejects_non_org_admin_key_principal(monkeypatch):
+    mutations, environment_data, _, _, env_model, key_model, member_model = (
+        _patch_create_environment(monkeypatch, admin_members=[])
+    )
+
+    with pytest.raises(GraphQLError, match="not members of this organisation"):
+        mutations.CreateEnvironmentMutation.mutate(
+            None,
+            _make_info(),
+            environment_data=environment_data,
+            admin_keys=[_make_admin_key("foreign-member")],
+        )
+
+    env_model.objects.create.assert_not_called()
+    key_model.objects.create.assert_not_called()
+
+
+def test_create_environment_rejects_non_global_admin_key_principal(monkeypatch):
+    member = MagicMock(id="member-1")
+    mutations, environment_data, _, _, env_model, key_model, _ = (
+        _patch_create_environment(
+            monkeypatch, admin_members=[member], global_access=False
+        )
+    )
+
+    with pytest.raises(GraphQLError, match="global access"):
+        mutations.CreateEnvironmentMutation.mutate(
+            None,
+            _make_info(),
+            environment_data=environment_data,
+            admin_keys=[_make_admin_key("member-1")],
+        )
+
+    env_model.objects.create.assert_not_called()
+    key_model.objects.create.assert_not_called()
+
+
+def test_create_environment_rejects_owner_in_admin_keys(monkeypatch):
+    mutations, environment_data, owner, _, env_model, key_model, _ = (
+        _patch_create_environment(monkeypatch, admin_members=[])
+    )
+
+    with pytest.raises(GraphQLError, match="created automatically"):
+        mutations.CreateEnvironmentMutation.mutate(
+            None,
+            _make_info(),
+            environment_data=environment_data,
+            admin_keys=[_make_admin_key(str(owner.id))],
+        )
+
+    env_model.objects.create.assert_not_called()
+
+
+def test_create_environment_rejects_missing_or_duplicate_principals(monkeypatch):
+    mutations, environment_data, _, _, env_model, _, _ = _patch_create_environment(
+        monkeypatch, admin_members=[]
+    )
+
+    with pytest.raises(GraphQLError, match="principal is required"):
+        mutations.CreateEnvironmentMutation.mutate(
+            None,
+            _make_info(),
+            environment_data=environment_data,
+            admin_keys=[_make_admin_key(None)],
+        )
+
+    with pytest.raises(GraphQLError, match="Duplicate admin key principals"):
+        mutations.CreateEnvironmentMutation.mutate(
+            None,
+            _make_info(),
+            environment_data=environment_data,
+            admin_keys=[_make_admin_key("member-1"), _make_admin_key("member-1")],
+        )
+
+    env_model.objects.create.assert_not_called()
+
+
+def test_create_environment_writes_keys_for_validated_members(monkeypatch):
+    admin = MagicMock(id="member-1")
+    mutations, environment_data, owner, _, env_model, key_model, member_model = (
+        _patch_create_environment(monkeypatch, admin_members=[admin])
+    )
+    new_env = MagicMock()
+    env_model.objects.create.return_value = new_env
+
+    mutations.CreateEnvironmentMutation.mutate(
+        None,
+        _make_info(),
+        environment_data=environment_data,
+        admin_keys=[_make_admin_key("member-1")],
+    )
+
+    admin_filter = member_model.objects.filter.call_args.kwargs
+    assert admin_filter["organisation"] is env_model.objects.create.call_args.kwargs["app"].organisation
+    assert admin_filter["deleted_at"] is None
+    key_users = [
+        call.kwargs["user"] for call in key_model.objects.create.call_args_list
+    ]
+    assert key_users == [owner, admin]
+    for call in key_model.objects.create.call_args_list:
+        assert call.kwargs["environment"] is new_env
+
+
+def test_create_environment_allows_creators_own_key_without_global_access(monkeypatch):
+    creator_member = MagicMock(id="creator-1")
+    mutations, environment_data, owner, creator, env_model, key_model, _ = (
+        _patch_create_environment(
+            monkeypatch, admin_members=[creator_member], global_access=False
+        )
+    )
+    new_env = MagicMock()
+    env_model.objects.create.return_value = new_env
+
+    mutations.CreateEnvironmentMutation.mutate(
+        None,
+        _make_info(),
+        environment_data=environment_data,
+        admin_keys=[_make_admin_key("creator-1")],
+    )
+
+    mutations.role_has_global_access.assert_not_called()
+    key_users = [
+        call.kwargs["user"] for call in key_model.objects.create.call_args_list
+    ]
+    assert key_users == [owner, creator_member]
+
+
+# ════════════════════════════════════════════════════════════════════
+# Service account handler provisioning — org-bound SAs and members
+# ════════════════════════════════════════════════════════════════════
+
+
+def _make_handler(service_account_id, member_id):
+    return SimpleNamespace(
+        service_account_id=service_account_id,
+        member_id=member_id,
+        wrapped_keyring="wk",
+        wrapped_recovery="wr",
+    )
+
+
+def _patch_update_handlers(monkeypatch, org_sas, org_member_ids):
+    from backend.graphene.mutations import service_accounts as mutations
+
+    org = MagicMock(id="org-1")
+    mock_org_model = MagicMock()
+    mock_org_model.objects.get.return_value = org
+    monkeypatch.setattr(mutations, "Organisation", mock_org_model)
+
+    mock_sa_model = MagicMock()
+    mock_sa_model.objects.filter.return_value.select_related.return_value = org_sas
+    monkeypatch.setattr(mutations, "ServiceAccount", mock_sa_model)
+
+    mock_member_model = MagicMock()
+    mock_member_model.objects.filter.return_value.values_list.return_value = (
+        org_member_ids
+    )
+    monkeypatch.setattr(mutations, "OrganisationMember", mock_member_model)
+
+    mock_handler_model = MagicMock()
+    mock_handler_model.objects.filter.return_value.exists.return_value = False
+    monkeypatch.setattr(mutations, "ServiceAccountHandler", mock_handler_model)
+
+    monkeypatch.setattr(mutations, "user_is_org_member", MagicMock(return_value=True))
+    monkeypatch.setattr(mutations, "user_has_permission", MagicMock(return_value=True))
+    monkeypatch.setattr(mutations, "_check_sa_permission", MagicMock())
+
+    return mutations, mock_sa_model, mock_handler_model
+
+
+def test_update_handlers_rejects_foreign_service_account_before_delete(monkeypatch):
+    mutations, sa_model, handler_model = _patch_update_handlers(
+        monkeypatch, org_sas=[], org_member_ids=["member-1"]
+    )
+
+    with pytest.raises(GraphQLError, match="do not belong to this organisation"):
+        mutations.UpdateServiceAccountHandlersMutation.mutate(
+            None,
+            _make_info(),
+            organisation_id="org-1",
+            handlers=[_make_handler("foreign-sa", "member-1")],
+        )
+
+    handler_model.objects.filter.assert_not_called()
+    handler_model.objects.create.assert_not_called()
+    mutations._check_sa_permission.assert_not_called()
+
+
+def test_update_handlers_rejects_foreign_member_before_delete(monkeypatch):
+    sa = MagicMock(id="sa-1")
+    mutations, sa_model, handler_model = _patch_update_handlers(
+        monkeypatch, org_sas=[sa], org_member_ids=[]
+    )
+
+    with pytest.raises(GraphQLError, match="not members of this organisation"):
+        mutations.UpdateServiceAccountHandlersMutation.mutate(
+            None,
+            _make_info(),
+            organisation_id="org-1",
+            handlers=[_make_handler("sa-1", "foreign-member")],
+        )
+
+    handler_model.objects.filter.assert_not_called()
+    handler_model.objects.create.assert_not_called()
+
+
+def test_update_handlers_uses_preflighted_service_accounts(monkeypatch):
+    sa = MagicMock(id="sa-1")
+    mutations, sa_model, handler_model = _patch_update_handlers(
+        monkeypatch, org_sas=[sa], org_member_ids=["member-1"]
+    )
+
+    mutations.UpdateServiceAccountHandlersMutation.mutate(
+        None,
+        _make_info(),
+        organisation_id="org-1",
+        handlers=[_make_handler("sa-1", "member-1")],
+    )
+
+    sa_model.objects.get.assert_not_called()
+    sa_filter = sa_model.objects.filter.call_args.kwargs
+    assert sa_filter["organisation"] is mutations.Organisation.objects.get.return_value
+    assert sa_filter["deleted_at__isnull"] is True
+    member_filter = mutations.OrganisationMember.objects.filter.call_args.kwargs
+    assert member_filter["organisation"] is mutations.Organisation.objects.get.return_value
+    assert member_filter["deleted_at"] is None
+    create_kwargs = handler_model.objects.create.call_args.kwargs
+    assert create_kwargs["service_account"] is sa
+    assert create_kwargs["user_id"] == "member-1"
+
+
+def test_update_handlers_rejects_duplicate_handler_pairs(monkeypatch):
+    sa = MagicMock(id="sa-1")
+    mutations, sa_model, handler_model = _patch_update_handlers(
+        monkeypatch, org_sas=[sa], org_member_ids=["member-1"]
+    )
+
+    with pytest.raises(GraphQLError, match="Duplicate handlers"):
+        mutations.UpdateServiceAccountHandlersMutation.mutate(
+            None,
+            _make_info(),
+            organisation_id="org-1",
+            handlers=[
+                _make_handler("sa-1", "member-1"),
+                _make_handler("sa-1", "member-1"),
+            ],
+        )
+
+    handler_model.objects.filter.assert_not_called()
+    handler_model.objects.create.assert_not_called()
+
+
+def test_create_service_account_rejects_foreign_handler_member(monkeypatch):
+    from backend.graphene.mutations import service_accounts as mutations
+
+    org = MagicMock(id="org-1")
+    mock_org_model = MagicMock()
+    mock_org_model.objects.get.return_value = org
+    monkeypatch.setattr(mutations, "Organisation", mock_org_model)
+
+    mock_member_model = MagicMock()
+    mock_member_model.objects.filter.return_value.values_list.return_value = []
+    monkeypatch.setattr(mutations, "OrganisationMember", mock_member_model)
+
+    mock_role_model = MagicMock()
+    monkeypatch.setattr(mutations, "Role", mock_role_model)
+    mock_sa_model = MagicMock()
+    monkeypatch.setattr(mutations, "ServiceAccount", mock_sa_model)
+    monkeypatch.setattr(mutations, "user_has_permission", MagicMock(return_value=True))
+
+    with pytest.raises(GraphQLError, match="not members of this organisation"):
+        mutations.CreateServiceAccountMutation.mutate(
+            None,
+            _make_info(),
+            name="automation",
+            organisation_id="org-1",
+            role_id="role-1",
+            handlers=[_make_handler(None, "foreign-member")],
+            identity_key="ik",
+        )
+
+    mock_role_model.objects.get.assert_not_called()
+    mock_sa_model.objects.create.assert_not_called()


### PR DESCRIPTION
- Require encryption-mode permission and validate environment bindings when initialising server-side encryption.
- Restrict environment admin keys at creation to validated organisation principals.
- Validate service account and member bindings in handler provisioning flows.
- Add regression coverage for all three paths.