### PR TITLE
fix(frontend): allow dashes and underscores in folder names

### DIFF
--- a/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
+++ b/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
@@ -1003,8 +1003,10 @@ export default function EnvironmentPath({
     const [name, setName] = useState<string>('')
     const inputRef = useRef(null)
 
-    // Regular expression to match only alphanumeric characters
-    const regex = /^[a-zA-Z0-9]*$/
+    // Folder names may contain letters, numbers, dashes and underscores.
+    // The API applies no character restriction, so this only excludes the
+    // separators that would change the meaning of a path.
+    const folderNamePattern = /^[a-zA-Z0-9_-]*$/
 
     const closeModal = () => {
       setFolderMenuIsOpen(false)
@@ -1020,11 +1022,8 @@ export default function EnvironmentPath({
     }
 
     const handleUpdateName = (newName: string) => {
-      // Regular expression to match only alphanumeric characters
-      const regex = /^[a-zA-Z0-9]*$/
-
       // Check if the new value matches the regular expression
-      if (regex.test(newName) || newName === '') {
+      if (folderNamePattern.test(newName) || newName === '') {
         // Update the state if the value is alphanumeric or empty (to allow clearing the input)
         setName(newName)
       }


### PR DESCRIPTION
Fixes #988.

## The problem

`NewFolderMenu` filters keystrokes through `/^[a-zA-Z0-9]*$/`, so `-` and `_` cannot be typed into the folder name field. The character is dropped with no error and no hint.

Nothing else in the stack applies that rule. `normalize_path_string` does no character validation, and `create_environment_folder_structure` calls `get_or_create(name=segment, ...)` with whatever segment it is given, so `phase secrets create KEY --path /user-service` creates the folder that the dialog refuses to name. The console then renders, expands and syncs that folder normally. The UI is showing valid state its own primary control cannot produce.

## The change

Widen the pattern to `/^[a-zA-Z0-9_-]*$/`, and delete the shadowed duplicate declared inside `handleUpdateName` (the outer one at the top of the component was dead).

This is the same change as #364, which @nimish-ks opened in September 2024 and closed unmerged in December 2025 with no comment or review. Since it was the maintainer's own branch and nothing was said against it, I have read that as stale-cleanup rather than a rejection. If the alphanumeric-only rule is in fact deliberate, close this and I will send the alternative instead: keep the restriction but show validation text, so the character can be typed and visibly rejected rather than swallowed.

## Scope

One file, five lines. I deliberately did not widen this any further:

- Other excluded characters (spaces, `.`, `/`) are still dropped silently. `/` genuinely must not be accepted here since it would change the path structure, but the silent-swallow behaviour for the rest is the second half of #988 and is a separate UI decision.
- The API still applies no validation at all, so the two layers continue to disagree in the permissive direction. Worth deciding separately, and not something to change quietly given folders already exist in production with arbitrary names.

## Verification

`tsc --noEmit` clean, `jest` 17 suites / 385 tests passing locally.
