### PR TITLE
fix(frontend): stop one undecryptable secret blanking the environment page

### DIFF
--- a/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
+++ b/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
@@ -687,7 +687,14 @@ export default function EnvironmentPath({
   useEffect(() => {
     if (!data || !keyring) return
 
-    const wrappedSeed = data.environmentKeys[0].wrappedSeed
+    // Optional chaining rather than a bare index: this read used to sit inside
+    // the async function below, where an empty environmentKeys would surface
+    // as a rejected promise. Hoisting it up here to compare against the ref
+    // would otherwise turn that same case into a synchronous throw from the
+    // effect body, which takes the page down via the error boundary. Keeping
+    // the old failure mode rather than changing it as a side effect.
+    const wrappedSeed = data.environmentKeys[0]?.wrappedSeed
+    if (!wrappedSeed) return
     if (derivedForSeedRef.current === wrappedSeed) return
 
     // Switching environments (e.g. via the environment tabs) keeps this page

--- a/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
+++ b/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
@@ -677,37 +677,25 @@ export default function EnvironmentPath({
     [deleteFolder, params.environment, secretPath]
   )
 
-  // wrappedSeed identifies which environment's keys are currently derived.
-  // GetSecrets polls every 5s (see the useQuery below), so `data` gets a new
-  // object reference on every poll tick even when nothing changed; keying off
-  // wrappedSeed rather than `data` itself means an unrelated poll refresh of
-  // the same environment does not re-trigger key derivation or clear envKeys.
+  // Tracks which environment's keys are derived. Keyed off wrappedSeed rather
+  // than `data`, which gets a new reference on every 5s poll tick.
   const derivedForSeedRef = useRef<string | null>(null)
 
   useEffect(() => {
     if (!data || !keyring) return
 
-    // Optional chaining rather than a bare index: this read used to sit inside
-    // the async function below, where an empty environmentKeys would surface
-    // as a rejected promise. Hoisting it up here to compare against the ref
-    // would otherwise turn that same case into a synchronous throw from the
-    // effect body, which takes the page down via the error boundary. Keeping
-    // the old failure mode rather than changing it as a side effect.
+    // Optional chaining keeps an empty environmentKeys a rejected promise
+    // rather than a synchronous throw from the effect body.
     const wrappedSeed = data.environmentKeys[0]?.wrappedSeed
     if (!wrappedSeed) return
     if (derivedForSeedRef.current === wrappedSeed) return
 
-    // Switching environments (e.g. via the environment tabs) keeps this page
-    // mounted and only changes `data`, so a slower-resolving key derivation
-    // for an environment the user has since navigated away from must not be
-    // allowed to land after a newer one; `ignore` covers that regardless of
-    // resolution order. Clearing envKeys here is a display nicety, not the
-    // race guard itself: it stops the previous environment's already-decrypted
-    // secrets from staying on screen while this one's keys are still deriving.
-    // The decryptSecrets effect below does its own check against
-    // derivedForSeedRef, so it never runs against a mismatched envKeys/data
-    // pair even if it fires before this line's update is visible to it.
+    // `ignore` stops a slower derivation for an environment the user has left
+    // from landing after a newer one. The ref is cleared with envKeys so the
+    // two cannot disagree: on A -> B -> A before B resolves, a stale ref would
+    // match on the return to A and the effect would never re-derive.
     let ignore = false
+    derivedForSeedRef.current = null
     setEnvKeys(null)
 
     const initEnvKeys = async () => {

--- a/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
+++ b/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
@@ -677,10 +677,33 @@ export default function EnvironmentPath({
     [deleteFolder, params.environment, secretPath]
   )
 
-  useEffect(() => {
-    const initEnvKeys = async () => {
-      const wrappedSeed = data.environmentKeys[0].wrappedSeed
+  // wrappedSeed identifies which environment's keys are currently derived.
+  // GetSecrets polls every 5s (see the useQuery below), so `data` gets a new
+  // object reference on every poll tick even when nothing changed; keying off
+  // wrappedSeed rather than `data` itself means an unrelated poll refresh of
+  // the same environment does not re-trigger key derivation or clear envKeys.
+  const derivedForSeedRef = useRef<string | null>(null)
 
+  useEffect(() => {
+    if (!data || !keyring) return
+
+    const wrappedSeed = data.environmentKeys[0].wrappedSeed
+    if (derivedForSeedRef.current === wrappedSeed) return
+
+    // Switching environments (e.g. via the environment tabs) keeps this page
+    // mounted and only changes `data`, so a slower-resolving key derivation
+    // for an environment the user has since navigated away from must not be
+    // allowed to land after a newer one; `ignore` covers that regardless of
+    // resolution order. Clearing envKeys here is a display nicety, not the
+    // race guard itself: it stops the previous environment's already-decrypted
+    // secrets from staying on screen while this one's keys are still deriving.
+    // The decryptSecrets effect below does its own check against
+    // derivedForSeedRef, so it never runs against a mismatched envKeys/data
+    // pair even if it fires before this line's update is visible to it.
+    let ignore = false
+    setEnvKeys(null)
+
+    const initEnvKeys = async () => {
       const userKxKeys = {
         publicKey: await getUserKxPublicKey(keyring!.publicKey),
         privateKey: await getUserKxPrivateKey(keyring!.privateKey),
@@ -694,18 +717,36 @@ export default function EnvironmentPath({
       )
       const { publicKey, privateKey } = await envKeyring(seed)
 
-      setEnvKeys({
-        publicKey,
-        privateKey,
-        salt,
-      })
+      if (!ignore) {
+        derivedForSeedRef.current = wrappedSeed
+        setEnvKeys({
+          publicKey,
+          privateKey,
+          salt,
+        })
+      }
     }
 
-    if (data && keyring) initEnvKeys()
+    initEnvKeys()
+
+    return () => {
+      ignore = true
+    }
   }, [data, keyring])
 
   useEffect(() => {
-    if (data && envKeys) {
+    // This is the actual guard against decrypting one environment's secrets
+    // with another environment's keys. envKeys can be one render behind data
+    // changing, since the effect above derives it asynchronously, so this
+    // effect must not trust that envKeys already matches data just because
+    // both are non-null; it checks against derivedForSeedRef directly instead
+    // of relying on the ordering of the two effects.
+    const currentWrappedSeed = data?.environmentKeys[0]?.wrappedSeed
+    const envKeysAreCurrent =
+      currentWrappedSeed !== undefined && derivedForSeedRef.current === currentWrappedSeed
+
+    if (data && envKeys && envKeysAreCurrent) {
+      let ignore = false
       setDecrypting(true)
       const decryptSecrets = async () => {
         const decryptedStaticSecrets = await Promise.all(
@@ -811,13 +852,28 @@ export default function EnvironmentPath({
         return { decryptedStaticSecrets, decryptedDynamicSecrets }
       }
 
-      decryptSecrets().then((decryptedSecrets) => {
-        setServerSecrets(decryptedSecrets.decryptedStaticSecrets)
-        setClientSecrets(decryptedSecrets.decryptedStaticSecrets)
-        setDynamicSecrets(decryptedSecrets.decryptedDynamicSecrets)
-        setDecrypting(false)
-        setSecretsLoaded(true)
-      })
+      decryptSecrets()
+        .then((decryptedSecrets) => {
+          if (ignore) return
+          setServerSecrets(decryptedSecrets.decryptedStaticSecrets)
+          setClientSecrets(decryptedSecrets.decryptedStaticSecrets)
+          setDynamicSecrets(decryptedSecrets.decryptedDynamicSecrets)
+          setDecrypting(false)
+          setSecretsLoaded(true)
+        })
+        .catch((error) => {
+          // A decrypt call rejects if envKeys ever gets paired with data from
+          // a different environment (see the guard in the effect above). This
+          // used to be an unhandled rejection that left `decrypting` stuck at
+          // true, so the page never recovered from the race without a reload.
+          if (ignore) return
+          console.error('Failed to decrypt secrets:', error)
+          setDecrypting(false)
+        })
+
+      return () => {
+        ignore = true
+      }
     }
   }, [envKeys, data])
 

--- a/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
+++ b/frontend/app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
@@ -744,7 +744,7 @@ export default function EnvironmentPath({
       let ignore = false
       setDecrypting(true)
       const decryptSecrets = async () => {
-        const decryptedStaticSecrets = await Promise.all(
+        const staticResults = await Promise.allSettled(
           data.secrets.map(async (secret: SecretType) => {
             const decryptedSecret = structuredClone(secret)
 
@@ -822,8 +822,21 @@ export default function EnvironmentPath({
           })
         )
 
+        // A single row with unreadable ciphertext must not take the whole
+        // environment down. Keep what decrypted and report the rest.
+        const decryptedStaticSecrets = staticResults
+          .filter(
+            (r): r is PromiseFulfilledResult<SecretType> => r.status === 'fulfilled'
+          )
+          .map((r) => r.value)
+
+        staticResults.forEach((r, index) => {
+          if (r.status === 'rejected')
+            console.error(`Failed to decrypt secret ${data.secrets[index]?.id}:`, r.reason)
+        })
+
         //Decrypt dynamic secrets keyMap.keyName
-        const decryptedDynamicSecrets = await Promise.all(
+        const dynamicResults = await Promise.allSettled(
           (data.dynamicSecrets ?? []).map(async (secret: DynamicSecretType) => {
             const decryptedSecret = structuredClone(secret)
             if (decryptedSecret.keyMap && Array.isArray(decryptedSecret.keyMap)) {
@@ -844,7 +857,17 @@ export default function EnvironmentPath({
           })
         )
 
-        return { decryptedStaticSecrets, decryptedDynamicSecrets }
+        const decryptedDynamicSecrets = dynamicResults
+          .filter(
+            (r): r is PromiseFulfilledResult<DynamicSecretType> => r.status === 'fulfilled'
+          )
+          .map((r) => r.value)
+
+        const undecryptableCount =
+          staticResults.filter((r) => r.status === 'rejected').length +
+          dynamicResults.filter((r) => r.status === 'rejected').length
+
+        return { decryptedStaticSecrets, decryptedDynamicSecrets, undecryptableCount }
       }
 
       decryptSecrets()
@@ -855,6 +878,11 @@ export default function EnvironmentPath({
           setDynamicSecrets(decryptedSecrets.decryptedDynamicSecrets)
           setDecrypting(false)
           setSecretsLoaded(true)
+          if (decryptedSecrets.undecryptableCount > 0)
+            toast.error(
+              `${decryptedSecrets.undecryptableCount} secret(s) could not be decrypted and are not shown. See the browser console for details.`,
+              { autoClose: false }
+            )
         })
         .catch((error) => {
           // A decrypt call rejects if envKeys ever gets paired with data from

--- a/frontend/tests/utils/crypto/environmentKeyRace.test.ts
+++ b/frontend/tests/utils/crypto/environmentKeyRace.test.ts
@@ -9,20 +9,9 @@
 */
 
 /*
-  Regression test for the environment-switch race described in the PR that
-  added this file. It does not mount the page component (that needs Apollo,
-  Next navigation and the keyring context, none of which are set up in this
-  suite); instead it proves the property the fix in
-  app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
-  relies on, using the real crypto primitives: decryptAsymmetric rejects,
-  rather than silently returning garbage, when the keypair does not match the
-  ciphertext's session.
-
-  That is why the original unguarded effect (pairing one environment's `data`
-  with another environment's `envKeys` while the correct keys were still
-  being derived) surfaced as a promise rejection, and why the missing
-  `.catch()` on that call turned it into an unhandled rejection that left
-  `decrypting` stuck at `true` with no way to recover short of a reload.
+  Proves the property the environment-switch fix relies on: decryptAsymmetric
+  rejects, rather than returning garbage, when the keypair does not match the
+  ciphertext.
 */
 
 import { decryptAsymmetric, encryptAsymmetric, randomKeyPair } from '@/utils/crypto'
@@ -39,13 +28,10 @@ describe("Environment key race (decrypting one environment's secrets with anothe
 
     const ciphertext = await encryptAsymmetric('super-secret-value', envA.publicKey)
 
-    // This is the exact operation the page performs when envKeys still holds
-    // environment B's keys while data has already updated to environment A's
-    // secrets (or vice versa): decrypting A's ciphertext with B's keypair.
+    // What the page did when envKeys still held B's keys and data was A's.
     await expect(decryptAsymmetric(ciphertext, envB.privateKey, envB.publicKey)).rejects.toBeDefined()
 
-    // Decrypting with the matching keypair still works, so the rejection
-    // above is specifically about the key mismatch, not a broken fixture.
+    // The matching keypair still works, so the rejection is the mismatch.
     const decrypted = await decryptAsymmetric(ciphertext, envA.privateKey, envA.publicKey)
     expect(decrypted).toBe('super-secret-value')
   })

--- a/frontend/tests/utils/crypto/environmentKeyRace.test.ts
+++ b/frontend/tests/utils/crypto/environmentKeyRace.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment node
+ */
+
+/*
+  👆
+  overrides: testEnvironment: 'jsdom' in jest.config.js
+  to fix: ReferenceError: TextDecoder is not defined
+*/
+
+/*
+  Regression test for the environment-switch race described in the PR that
+  added this file. It does not mount the page component (that needs Apollo,
+  Next navigation and the keyring context, none of which are set up in this
+  suite); instead it proves the property the fix in
+  app/[team]/apps/[app]/environments/[environment]/[[...path]]/page.tsx
+  relies on, using the real crypto primitives: decryptAsymmetric rejects,
+  rather than silently returning garbage, when the keypair does not match the
+  ciphertext's session.
+
+  That is why the original unguarded effect (pairing one environment's `data`
+  with another environment's `envKeys` while the correct keys were still
+  being derived) surfaced as a promise rejection, and why the missing
+  `.catch()` on that call turned it into an unhandled rejection that left
+  `decrypting` stuck at `true` with no way to recover short of a reload.
+*/
+
+import { decryptAsymmetric, encryptAsymmetric, randomKeyPair } from '@/utils/crypto'
+
+const toHexKeyPair = (keyPair: { publicKey: Uint8Array; privateKey: Uint8Array }) => ({
+  publicKey: Buffer.from(keyPair.publicKey).toString('hex'),
+  privateKey: Buffer.from(keyPair.privateKey).toString('hex'),
+})
+
+describe("Environment key race (decrypting one environment's secrets with another's keys)", () => {
+  test('decrypting with a mismatched keypair rejects rather than returning garbage', async () => {
+    const envA = toHexKeyPair(await randomKeyPair())
+    const envB = toHexKeyPair(await randomKeyPair())
+
+    const ciphertext = await encryptAsymmetric('super-secret-value', envA.publicKey)
+
+    // This is the exact operation the page performs when envKeys still holds
+    // environment B's keys while data has already updated to environment A's
+    // secrets (or vice versa): decrypting A's ciphertext with B's keypair.
+    await expect(decryptAsymmetric(ciphertext, envB.privateKey, envB.publicKey)).rejects.toBeDefined()
+
+    // Decrypting with the matching keypair still works, so the rejection
+    // above is specifically about the key mismatch, not a broken fixture.
+    const decrypted = await decryptAsymmetric(ciphertext, envA.privateKey, envA.publicKey)
+    expect(decrypted).toBe('super-secret-value')
+  })
+})

--- a/frontend/tests/utils/crypto/undecryptableSecret.test.ts
+++ b/frontend/tests/utils/crypto/undecryptableSecret.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment node
+ */
+
+/*
+  Regression test for #948: one secret with unreadable ciphertext used to
+  reject the whole Promise.all batch, so the environment page never loaded
+  for any user. Promise.allSettled keeps the readable rows.
+*/
+
+import { decryptAsymmetric, encryptAsymmetric, randomKeyPair } from '@/utils/crypto'
+
+const toHexKeyPair = (keyPair: { publicKey: Uint8Array; privateKey: Uint8Array }) => ({
+  publicKey: Buffer.from(keyPair.publicKey).toString('hex'),
+  privateKey: Buffer.from(keyPair.privateKey).toString('hex'),
+})
+
+describe('Undecryptable secret in a batch', () => {
+  test('a corrupt row rejects on its own without taking the batch down', async () => {
+    const env = toHexKeyPair(await randomKeyPair())
+
+    const good = await encryptAsymmetric('readable-value', env.publicKey)
+
+    // The reported corruption: the ciphertext was truncated at write time,
+    // leaving the base64 segment with length % 4 === 1, which sodium rejects.
+    const corrupt = good.slice(0, good.length - (good.length % 4) - 3)
+
+    await expect(
+      decryptAsymmetric(corrupt, env.privateKey, env.publicKey)
+    ).rejects.toBeDefined()
+
+    // Promise.all is what the page used to do: one rejection loses everything.
+    await expect(
+      Promise.all([
+        decryptAsymmetric(good, env.privateKey, env.publicKey),
+        decryptAsymmetric(corrupt, env.privateKey, env.publicKey),
+        decryptAsymmetric(good, env.privateKey, env.publicKey),
+      ])
+    ).rejects.toBeDefined()
+
+    // allSettled keeps the rows that decrypted and isolates the one that did not.
+    const results = await Promise.allSettled([
+      decryptAsymmetric(good, env.privateKey, env.publicKey),
+      decryptAsymmetric(corrupt, env.privateKey, env.publicKey),
+      decryptAsymmetric(good, env.privateKey, env.publicKey),
+    ])
+
+    const fulfilled = results.filter((r) => r.status === 'fulfilled')
+    const rejected = results.filter((r) => r.status === 'rejected')
+
+    expect(fulfilled).toHaveLength(2)
+    expect(rejected).toHaveLength(1)
+    expect((fulfilled[0] as PromiseFulfilledResult<string>).value).toBe('readable-value')
+  })
+})


### PR DESCRIPTION
Fixes #948.

> **Stacked on #970.** This branch is cut from `fix/environment-switch-key-race`, so the diff here includes that PR's three commits. Only the last commit belongs to this one. Merge #970 first and I will rebase, or say the word and I will re-cut this against `main` instead.

## The problem

`decryptSecrets` runs every secret through a single `Promise.all`. One row whose ciphertext cannot be decoded rejects the whole batch, so `setServerSecrets` / `setSecretsLoaded` never run and every member of that app sits on skeleton loaders indefinitely.

The reporter's instance hit this with a value truncated to 16384 characters at write time, months before anyone noticed. The truncation left the base64 segment at `length % 4 === 1`, which `sodium.from_base64` rejects with `invalid input`.

#970 added a `.catch` on this chain, which stopped the unhandled rejection and released `decrypting`. It does not fix this issue: `setSecretsLoaded(true)` is still never reached, so the skeletons stay. The two changes are complementary, which is the other reason this is stacked rather than standalone.

## The change

`Promise.allSettled` for both the static and dynamic passes, then:

- render every row that decrypted, so the page loads with N-1 secrets instead of nothing
- `console.error` per failed row, including the secret id, so the bad row is identifiable
- one non-dismissing toast with the count

The count matters because of the failure mode described in the issue: the CLI already skips undecodable rows silently, `phase secrets list` showed N-1 with no warning, and that silence is what hid the problem for months. Dropping the rows without saying so would reproduce that in the console.

## What I did not decide

How a failed row should *look* is a design call, so I left it out. A greyed row with an "undecryptable" marker in place of dropping it entirely would be better than a toast, and I will add it if you say what it should look like.

## Verification

New test at `frontend/tests/utils/crypto/undecryptableSecret.test.ts` reproduces the reported corruption (truncating a real ciphertext to `length % 4 === 1`) and asserts both halves: `Promise.all` over the same three rows rejects, `Promise.allSettled` returns 2 fulfilled and 1 rejected with the readable value intact.

`tsc --noEmit` clean. Full suite 19 files / 387 tests passing.
