### PR TITLE
fix(api): resolve every secret before writing any of them in PublicSecretsView.put

### DIFF
--- a/backend/api/views/secrets.py
+++ b/backend/api/views/secrets.py
@@ -1104,32 +1104,55 @@ class PublicSecretsView(APIView):
                     (secret["override"]["value"]), env_pubkey
                 )
 
+        # Resolve and validate every secret before writing any of them, the same
+        # ordering E2EESecretsView.put uses. Nothing below this loop returns
+        # early, so a late missing, soft-deleted, rotating or unseal-attempting
+        # id cannot leave an earlier update committed. There is no transaction
+        # here and an early return commits rather than rolls back, so this
+        # ordering is what provides the atomicity.
+        secret_objects = []
+        for secret in secrets:
+            try:
+                secret_obj = Secret.objects.get(
+                    id=secret["id"], environment=env, deleted_at__isnull=True
+                )
+            except (Secret.DoesNotExist, ValueError):
+                return JsonResponse(
+                    {"error": f"Secret not found: {secret['id']}"},
+                    status=404,
+                )
+
+            if secret_obj.rotating_secret_id is not None:
+                return JsonResponse(
+                    {
+                        "error": (
+                            "Rotating secrets are managed by the Phase rotation "
+                            "engine and cannot be updated via this endpoint."
+                        )
+                    },
+                    status=400,
+                )
+
+            # Enforce seal permanence
+            if (
+                secret_obj.type == "sealed"
+                and secret.get("type") is not None
+                and secret.get("type") != "sealed"
+            ):
+                return JsonResponse(
+                    {
+                        "error": "Sealed secrets cannot be unsealed. Delete and recreate the secret instead."
+                    },
+                    status=400,
+                )
+
+            secret_objects.append(secret_obj)
+
         updated_secrets = []
 
         # Defer per-secret sync triggering (trigger_sync=False); trigger once below.
         try:
-            for secret in secrets:
-
-                try:
-                    secret_obj = Secret.objects.get(
-                        id=secret["id"], environment=env, deleted_at__isnull=True
-                    )
-                except (Secret.DoesNotExist, ValueError):
-                    return JsonResponse(
-                        {"error": f"Secret not found: {secret['id']}"},
-                        status=404,
-                    )
-
-                if secret_obj.rotating_secret_id is not None:
-                    return JsonResponse(
-                        {
-                            "error": (
-                                "Rotating secrets are managed by the Phase rotation "
-                                "engine and cannot be updated via this endpoint."
-                            )
-                        },
-                        status=400,
-                    )
+            for secret, secret_obj in zip(secrets, secret_objects):
 
                 if "key" not in secret:
                     secret["key"] = secret_obj.key
@@ -1144,13 +1167,6 @@ class PublicSecretsView(APIView):
                     secret["comment"] = encrypt_asymmetric(secret["comment"], env_pubkey)
                 else:
                     secret["comment"] = secret_obj.comment
-
-                # Enforce seal permanence
-                if secret_obj.type == "sealed" and secret.get("type") is not None and secret.get("type") != "sealed":
-                    return JsonResponse(
-                        {"error": "Sealed secrets cannot be unsealed. Delete and recreate the secret instead."},
-                        status=400,
-                    )
 
                 secret_data = {
                     "environment": env,

--- a/backend/tests/api/views/test_secrets_api.py
+++ b/backend/tests/api/views/test_secrets_api.py
@@ -267,6 +267,96 @@ class TestPublicSecretsPutRecordsOverridelessUpdates:
         assert secret_obj in mock_audit.call_args.args[0]
 
 
+class TestPublicSecretsPutRejectsBatchBeforeWriting:
+    """Regression: a bulk PUT must not commit earlier secrets before it
+    discovers a later one it has to reject. E2EESecretsView.put resolves every
+    secret first for exactly this reason; PublicSecretsView.put saved as it
+    iterated, and there is no transaction in this view, so an early return
+    committed rather than rolled back."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, settings):
+        self.view = PublicSecretsView.as_view()
+        self.org = _make_org()
+        self.app = _make_app(org=self.org, sse_enabled=True)
+        self.env = _make_env(app=self.app)
+
+    def _secret(self, sid, rotating=None, stype="secret"):
+        obj = Mock()
+        obj.id = sid
+        obj.rotating_secret_id = rotating
+        obj.type = stype
+        obj.version = 1
+        obj.key = "ph:v1:k"
+        obj.key_digest = "digest"
+        obj.comment = "ph:v1:c"
+        obj.value = "ph:v1:v"
+        obj.save = Mock()
+        return obj
+
+    @patch("api.views.secrets.log_secret_events_bulk")
+    @patch("api.views.secrets.encrypt_asymmetric", return_value="ph:v1:enc")
+    @patch("api.views.secrets.get_environment_keys", return_value=(b"pub", b"priv"))
+    @patch("api.views.secrets.PlanBasedRateThrottle.allow_request", return_value=True)
+    @patch("api.views.secrets.IsIPAllowed.has_permission", return_value=True)
+    def test_rotating_secret_second_in_batch_writes_nothing(
+        self, _ip, _throttle, _keys, _enc, mock_audit
+    ):
+        first = self._secret(str(uuid.uuid4()))
+        rotating = self._secret(str(uuid.uuid4()), rotating=uuid.uuid4())
+
+        with patch(
+            "api.views.secrets.Secret.objects.get",
+            side_effect=[first, rotating],
+        ):
+            request = _build_put_request(
+                self.env,
+                {"secrets": [{"id": first.id, "value": "v2"}, {"id": rotating.id}]},
+            )
+            response = self.view(request)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Rotating secrets" in json.loads(response.content)["error"]
+        first.save.assert_not_called()
+        rotating.save.assert_not_called()
+        self.env.save.assert_not_called()
+        mock_audit.assert_not_called()
+
+    @patch("api.views.secrets.log_secret_events_bulk")
+    @patch("api.views.secrets.encrypt_asymmetric", return_value="ph:v1:enc")
+    @patch("api.views.secrets.get_environment_keys", return_value=(b"pub", b"priv"))
+    @patch("api.views.secrets.PlanBasedRateThrottle.allow_request", return_value=True)
+    @patch("api.views.secrets.IsIPAllowed.has_permission", return_value=True)
+    def test_unseal_attempt_second_in_batch_writes_nothing(
+        self, _ip, _throttle, _keys, _enc, mock_audit
+    ):
+        first = self._secret(str(uuid.uuid4()))
+        sealed = self._secret(str(uuid.uuid4()), stype="sealed")
+
+        with patch(
+            "api.views.secrets.Secret.objects.get",
+            side_effect=[first, sealed],
+        ):
+            request = _build_put_request(
+                self.env,
+                {
+                    "secrets": [
+                        {"id": first.id, "value": "v2"},
+                        {"id": sealed.id, "type": "secret"},
+                    ]
+                },
+            )
+            response = self.view(request)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "cannot be unsealed" in json.loads(response.content)["error"]
+        first.save.assert_not_called()
+        sealed.save.assert_not_called()
+        self.env.save.assert_not_called()
+        mock_audit.assert_not_called()
+
+
+
 # ══════════════════════════════════════════════════════════════
 # Legacy E2EESecretsView mutations — body IDs stay inside auth env
 # ══════════════════════════════════════════════════════════════


### PR DESCRIPTION
Follow-up to c192966, which fixed this for the other view.

## The problem

`E2EESecretsView.put` resolves every secret into `secret_objects` before writing any of them, and the comment says exactly why:

> `# late foreign, missing, or rotating ID would leave an earlier update committed.`

`PublicSecretsView.put` still saved as it iterated. It calls `secret_obj.save(trigger_sync=False)` inside the loop, and three separate early returns can fire on a later entry:

- a missing or soft-deleted id, 404
- a rotating secret, 400
- an attempt to unseal a sealed secret, 400

So `PUT /v1/secrets` with `[{good}, {rotating}]` answers 400 and **the first secret is already written**, with nothing telling the caller which part of the batch applied.

Nothing rolls it back. There is no `transaction.atomic` anywhere in `secrets.py`, and the surrounding `try` has only a `finally`, no `except`. An early `return` inside an atomic block would commit anyway, so ordering is the only thing that can make this batch atomic, which is what c192966 established for the E2EE view.

## The change

The lookup, the rotating-secret check and the seal-permanence check move into a preflight loop, and the write loop zips over the already-resolved objects. Same shape and same ordering as `E2EESecretsView.put`.

No behaviour change for a batch that passes validation: same queries, same saves, same order, same response.

## Verification

Two tests, mirroring the existing `test_rotating_secret_is_rejected_before_any_update` for the E2EE view:

- second entry is a rotating secret, and
- second entry attempts to unseal a sealed secret

Each asserts the 400, then `first.save.assert_not_called()`, `env.save.assert_not_called()` and no audit event.

I checked they fail for the right reason rather than passing by accident. With the view change stashed, both fail on exactly that line and not on the status code, because the endpoint already returned 400 correctly before this change:

```
        assert response.status_code == status.HTTP_400_BAD_REQUEST     ✓
        assert "Rotating secrets" in ...["error"]                      ✓
>       first.save.assert_not_called()                                 ✗
```

That is the whole bug: the right answer, after the wrong write.

Full backend suite with the fix: **1505 passed**.

## Not included

The `_resolve_secret_tags` error path at the end of the write loop can still return early after earlier saves. It needs an organisation lookup per secret and could be hoisted too, but it changes when tags are resolved relative to encryption, so it is a separate decision rather than something to fold in here.
