### PR TITLE
fix(frontend): Next.js 16 review follow-ups for sync dialogs

### DIFF
--- a/frontend/components/syncing/Cloudflare/CreateCloudflarePagesSync.tsx
+++ b/frontend/components/syncing/Cloudflare/CreateCloudflarePagesSync.tsx
@@ -187,7 +187,7 @@ export const CreateCloudflarePagesSync = (props: { appId: string; closeModal: ()
                             className="w-full"
                             onChange={(event) => setQuery(event.target.value)}
                             required
-                            displayValue={(project: CloudFlarePagesType) => project?.name!}
+                            displayValue={(project: CloudFlarePagesType | null) => project?.name ?? ''}
                           />
                           <div className="absolute inset-y-0 right-2 flex items-center">
                             <Combobox.Button>

--- a/frontend/components/syncing/Cloudflare/CreateCloudflareWorkersSync.tsx
+++ b/frontend/components/syncing/Cloudflare/CreateCloudflareWorkersSync.tsx
@@ -179,7 +179,7 @@ export const CreateCloudflareWorkersSync = (props: { appId: string; closeModal: 
                             className="w-full"
                             onChange={(event) => setQuery(event.target.value)}
                             required
-                            displayValue={(worker: CloudflareWorkerType) => worker?.name!}
+                            displayValue={(worker: CloudflareWorkerType | null) => worker?.name ?? ''}
                           />
                           <div className="absolute inset-y-0 right-2 flex items-center">
                             <Combobox.Button>

--- a/frontend/components/syncing/Railway/CreateRailwaySync.tsx
+++ b/frontend/components/syncing/Railway/CreateRailwaySync.tsx
@@ -71,6 +71,15 @@ export const CreateRailwaySync = (props: { appId: string; closeModal: () => void
     }
   }, [appEnvsData])
 
+  // Environment and service options belong to the selected project, so clear them on change
+  const handleProjectChange = (project: RailwayProjectType | null) => {
+    setRailwayProject(project)
+    setRailwayEnvironment(null)
+    setRailwayService(null)
+    setProjectQuery('')
+    setServiceQuery('')
+  }
+
   const handleSubmit = async (e: { preventDefault: () => void }) => {
     e.preventDefault()
 
@@ -196,7 +205,7 @@ export const CreateRailwaySync = (props: { appId: string; closeModal: () => void
 
             <div className="grid grid-cols-2 gap-8">
               <div className="relative col-span-2">
-                <Combobox as="div" value={railwayProject} onChange={setRailwayProject}>
+                <Combobox as="div" value={railwayProject} onChange={handleProjectChange}>
                   {({ open }) => (
                     <>
                       <div className="space-y-2">
@@ -210,7 +219,7 @@ export const CreateRailwaySync = (props: { appId: string; closeModal: () => void
                             className="w-full"
                             onChange={(event) => setProjectQuery(event.target.value)}
                             required
-                            displayValue={(project: RailwayProjectType) => project?.name!}
+                            displayValue={(project: RailwayProjectType | null) => project?.name ?? ''}
                           />
                           <div className="absolute inset-y-0 right-2 flex items-center">
                             <Combobox.Button>
@@ -314,7 +323,7 @@ export const CreateRailwaySync = (props: { appId: string; closeModal: () => void
                             <Combobox.Input
                               className="w-full"
                               onChange={(event) => setServiceQuery(event.target.value)}
-                              displayValue={(service: RailwayServiceType) => service?.name!}
+                              displayValue={(service: RailwayServiceType | null) => service?.name ?? ''}
                             />
                             <div className="absolute inset-y-0 right-2 flex items-center">
                               <Combobox.Button>

--- a/frontend/components/syncing/Render/CreateRenderSync.tsx
+++ b/frontend/components/syncing/Render/CreateRenderSync.tsx
@@ -239,7 +239,15 @@ export const CreateRenderSync = ({
             </div>
 
             <div>
-              <Tab.Group selectedIndex={tabIndex} onChange={(index) => setTabIndex(index)}>
+              <Tab.Group
+                selectedIndex={tabIndex}
+                onChange={(index) => {
+                  setTabIndex(index)
+                  // Submit prefers the service — clear the hidden tab's selection
+                  if (index === 0) setRenderEnvgroup(null)
+                  else setRenderService(null)
+                }}
+              >
                 <Tab.List className="flex gap-2 w-full border-b border-neutral-500/20 mb-4">
                   {tabs.map((tab) => (
                     <Tab as={Fragment} key={tab.name}>
@@ -275,7 +283,7 @@ export const CreateRenderSync = ({
                                   className="w-full"
                                   onChange={(event) => setServiceQuery(event.target.value)}
                                   required
-                                  displayValue={(service: RenderServiceType) => service?.name!}
+                                  displayValue={(service: RenderServiceType | null) => service?.name ?? ''}
                                 />
                                 <div className="absolute inset-y-0 right-2 flex items-center">
                                   <Combobox.Button>
@@ -346,7 +354,7 @@ export const CreateRenderSync = ({
                                   className="w-full"
                                   onChange={(event) => setEnvgroupQuery(event.target.value)}
                                   required
-                                  displayValue={(envgroup: RenderEnvGroupType) => envgroup?.name!}
+                                  displayValue={(envgroup: RenderEnvGroupType | null) => envgroup?.name ?? ''}
                                 />
                                 <div className="absolute inset-y-0 right-2 flex items-center">
                                   <Combobox.Button>

--- a/frontend/components/syncing/Vercel/CreateVercelSync.tsx
+++ b/frontend/components/syncing/Vercel/CreateVercelSync.tsx
@@ -92,7 +92,8 @@ export const CreateVercelSync = (props: { appId: string; closeModal: () => void 
 
   const handleProjectChange = (project: VercelProjectType | null) => {
     setVercelProject(project)
-    setVercelEnvironment(null)
+    // Preselect production to match the sync mutation's default environment
+    setVercelEnvironment(project?.environments?.find((env) => env?.slug === 'production') ?? null)
     setProjectQuery('')
     setEnvQuery('')
   }
@@ -266,7 +267,7 @@ export const CreateVercelSync = (props: { appId: string; closeModal: () => void 
                           <Combobox.Input
                             className="w-full"
                             onChange={(event) => setTeamQuery(event.target.value)}
-                            displayValue={(team: VercelTeamProjectsType) => team?.teamName!}
+                            displayValue={(team: VercelTeamProjectsType | null) => team?.teamName ?? ''}
                             required
                           />
                           <div className="absolute inset-y-0 right-2 flex items-center">
@@ -330,7 +331,7 @@ export const CreateVercelSync = (props: { appId: string; closeModal: () => void 
                             <Combobox.Input
                               className="w-full"
                               onChange={(event) => setProjectQuery(event.target.value)}
-                              displayValue={(project: VercelProjectType) => project?.name!}
+                              displayValue={(project: VercelProjectType | null) => project?.name ?? ''}
                               required
                             />
                             <div className="absolute inset-y-0 right-2 flex items-center">
@@ -397,7 +398,7 @@ export const CreateVercelSync = (props: { appId: string; closeModal: () => void 
                           <Combobox.Input
                             className="w-full"
                             onChange={(event) => setEnvQuery(event.target.value)}
-                            displayValue={(env: VercelEnvironmentType) => env?.name!}
+                            displayValue={(env: VercelEnvironmentType | null) => env?.name ?? ''}
                             required
                           />
                           <div className="absolute inset-y-0 right-2 flex items-center">


### PR DESCRIPTION
Stacked on #998. Follow-ups from the Headless UI v2 review of the Next.js 16 upgrade.

## Changes

- **Vercel: restore "production by default"**. #998 made the environment selection mandatory, dropping the old flow where submitting without touching the env picker synced to production (the backend mutation defaults `environment="production"`). Selecting a project now preselects its `production` environment, so the default flow works again — but the choice is visible in the UI instead of implicit, and the required-env validation from #998 stays as a net.
- **Railway: clear dependent selections when the project changes**. Environment and service options derive from the selected project, but changing projects kept the previous project's environment/service in state — validation passed and the mutation could send a project/environment mismatch. Same class of bug #998 fixed for the GitHub and Vercel dialogs.
- **Render: clear the hidden tab's selection on tab switch**. Submit prefers `renderService` when both a service and an environment group are selected, so picking a service, switching tabs, and picking an env group silently synced the service. Mirrors the GitHub Actions repo/org tab behavior from #998.
- **Null-honest `displayValue` signatures** across the Vercel/Railway/Render/Cloudflare pickers: `(x: T) => x?.name!` → `(x: T | null) => x?.name ?? ''`. No behavior change — in Headless UI v2 every combobox is nullable and `displayValue` is invoked with `null`, so the non-null assertions were lies.

## Validation

- `tsc --noEmit` clean and 385/385 jest tests pass (run in the dev container)
