### PR TITLE
chore(frontend): build production bundles with Turbopack

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "packageManager": "yarn@1.22.22",
   "scripts": {
     "dev": "NODE_ENV=development next dev",
-    "build": "next build --webpack",
+    "build": "next build",
     "start": "next start",
     "test": "jest",
     "lint": "eslint .",


### PR DESCRIPTION
Stacked on #998. Drops the `--webpack` flag from the build script so production builds use Turbopack, matching dev (Turbopack since #998). This removes the dev/prod bundler drift.

The `webpack()` block in `next.config.js` is deliberately retained as a fallback — restoring `--webpack` remains a one-flag revert with working `.gql` loading.

## Validation (local, staging compose built from source)

- `next build` reports `Next.js 16.3.4 (Turbopack)`, compiled in 15.3s, no errors; no "webpack config ignored" warning
- `output: standalone` traced correctly; release image builds at 251MB
- Full staging stack runtime smoke via nginx:
  - `/` → 307 `/login` (proxy registered and running in the production bundle)
  - deep link → 307 with correct encoded `callbackUrl`
  - `/login` 200 with correct title; Turbopack JS chunks serve
  - `/api/health` 200 (Pages-router API routes intact)
- Authenticated browser click-through against real dev data (keyring unlock incl. libsodium WASM, secrets pages exercising the `.gql` Turbopack loader rules, sync dialogs)
