### PR TITLE
feat: apply API rate limits org-wide via an atomic fixed-window counter

### DIFF
--- a/backend/api/throttling.py
+++ b/backend/api/throttling.py
@@ -1,5 +1,9 @@
+import logging
+
 from rest_framework.throttling import SimpleRateThrottle
 from django.conf import settings
+
+logger = logging.getLogger(__name__)
 
 CLOUD_HOSTED = settings.APP_HOST == "cloud"
 
@@ -7,70 +11,111 @@ CLOUD_HOSTED = settings.APP_HOST == "cloud"
 class PlanBasedRateThrottle(SimpleRateThrottle):
     """
     Limits the rate of API calls based on the Organisation's plan.
+    The limit is shared org-wide: all members, service accounts and
+    service tokens of an organisation draw from a single bucket.
     Uses the pre-fetched organisation data from request.auth to avoid DB lookups.
+
+    Enforcement uses a fixed-window atomic counter (cache add + incr) rather
+    than SimpleRateThrottle's read-modify-write history list, so concurrent
+    workers cannot under-count the shared bucket.
     """
 
     scope = "plan_based"
 
-    def get_cache_key(self, request, view):
-        # Identify the user or service account
-        ident = self.get_ident(request)
+    @staticmethod
+    def get_organisation(request):
+        """Resolve the requesting organisation from the auth context."""
+        if not (request.user.is_authenticated and request.auth):
+            return None
 
-        if request.user.is_authenticated and request.auth:
-            if request.auth.get("org_member"):
-                ident = f"user_{request.auth['org_member'].id}"
-            elif request.auth.get("service_account"):
-                ident = f"sa_{request.auth['service_account'].id}"
-            elif request.auth.get("service_token"):
-                ident = f"st_{request.auth['service_token'].id}"
+        auth = request.auth
+        try:
+            org = auth.get("organisation")
+            if org is not None:
+                return org
+
+            env = auth.get("environment")
+            if env is not None:
+                return env.app.organisation
+
+            app = auth.get("app")
+            if app is not None:
+                return app.organisation
+
+            for principal_key in ("org_member", "service_account"):
+                principal = auth.get(principal_key)
+                if principal is not None:
+                    return principal.organisation
+
+            service_token = auth.get("service_token")
+            if service_token is not None:
+                return service_token.app.organisation
+        except AttributeError:
+            pass
+
+        return None
+
+    def get_cache_key(self, request, view):
+        return self._cache_key(self.get_organisation(request), request)
+
+    def _cache_key(self, org, request):
+        if org is not None:
+            ident = f"org_{org.id}"
         else:
-            ident = f"anon_{ident}"
+            ident = f"anon_{self.get_ident(request)}"
 
         return self.cache_format % {"scope": self.scope, "ident": ident}
 
     def allow_request(self, request, view):
         """
-        Override allow_request to dynamically set the rate based on the request user's plan.
+        Resolve the org's plan rate, then count this request against the
+        org's shared fixed-window bucket atomically.
         """
-        # Default fallback (reads from REST_FRAMEWORK['DEFAULT_THROTTLE_RATES']['plan_based'])
-        new_rate = self.get_rate()
+        org = self.get_organisation(request)
 
-        if request.user.is_authenticated and request.auth:
-            env = request.auth.get("environment")
-            if env:
-                try:
-                    plan = env.app.organisation.plan
-                    new_rate = self.get_rate_for_plan(plan)
-                except AttributeError:
-                    pass
-            else:
-                # App-only mode fallback (e.g. environments CRUD API)
-                app = request.auth.get("app")
-                if app:
-                    try:
-                        plan = app.organisation.plan
-                        new_rate = self.get_rate_for_plan(plan)
-                    except AttributeError:
-                        pass
-                else:
-                    # Org-only mode fallback (e.g. apps CRUD API)
-                    org = request.auth.get("organisation")
-                    if org:
-                        try:
-                            plan = org.plan
-                            new_rate = self.get_rate_for_plan(plan)
-                        except AttributeError:
-                            pass
+        if org is not None:
+            self.rate = self.get_rate_for_plan(org.plan)
+        else:
+            if request.user.is_authenticated and request.auth:
+                logger.warning(
+                    "Could not resolve an organisation for authenticated request to %s; "
+                    "throttling in the per-IP fallback bucket",
+                    request.path,
+                )
+            # Default fallback (reads from REST_FRAMEWORK['DEFAULT_THROTTLE_RATES']['plan_based'])
+            self.rate = self.get_rate()
 
-        # Update the throttle configuration for this specific request
-        self.rate = new_rate
         self.num_requests, self.duration = self.parse_rate(self.rate)
 
-        return super().allow_request(request, view)
+        if self.rate is None:
+            return True
+
+        now = self.timer()
+        window = int(now // self.duration)
+        self._window_reset = (window + 1) * self.duration
+        self.key = f"{self._cache_key(org, request)}_{window}"
+
+        self.cache.add(self.key, 0, self.duration)
+        try:
+            count = self.cache.incr(self.key)
+        except ValueError:
+            # Window key expired between add and incr
+            self.cache.add(self.key, 0, self.duration)
+            count = self.cache.incr(self.key)
+
+        return count <= self.num_requests
+
+    def wait(self):
+        window_reset = getattr(self, "_window_reset", None)
+        if window_reset is None:
+            return None
+        return max(window_reset - self.timer(), 0)
 
     @staticmethod
     def get_rate_for_plan(plan):
         # If self-hosted return the default rate limit. If not set, this will disable throttling
         if not CLOUD_HOSTED:
             return settings.PLAN_RATE_LIMITS["DEFAULT"]
-        return settings.PLAN_RATE_LIMITS.get(plan, settings.PLAN_RATE_LIMITS["DEFAULT"])
+        return settings.PLAN_RATE_LIMITS.get(plan) or settings.PLAN_RATE_LIMITS[
+            "DEFAULT"
+        ]

--- a/backend/tests/api/test_throttling.py
+++ b/backend/tests/api/test_throttling.py
@@ -1,7 +1,77 @@
+import logging
+
 import pytest
 from unittest.mock import Mock, patch
 from rest_framework.test import APIRequestFactory
 from api.throttling import PlanBasedRateThrottle
+
+
+def make_org(org_id="org-1", plan="FR"):
+    return Mock(id=org_id, plan=plan)
+
+
+def _base_auth(**overrides):
+    # Keys PhaseTokenAuthentication always sets on request.auth
+    auth = {
+        "token": "test-token",
+        "auth_type": "User",
+        "org_member": None,
+        "service_token": None,
+        "service_account": None,
+        "service_account_token": None,
+        "environment": None,
+    }
+    auth.update(overrides)
+    return auth
+
+
+# Builders mirroring the auth dict shapes authenticate() actually emits
+def user_env_auth(org):
+    env = Mock(app=Mock(organisation=org))
+    return _base_auth(environment=env, app=env.app, org_member=Mock(organisation=org))
+
+
+def user_app_auth(org):
+    return _base_auth(app=Mock(organisation=org), org_member=Mock(organisation=org))
+
+
+def user_org_auth(org):
+    return _base_auth(
+        org_only=True, organisation=org, org_member=Mock(organisation=org)
+    )
+
+
+def service_token_env_auth(org):
+    env = Mock(app=Mock(organisation=org))
+    return _base_auth(
+        auth_type="Service", environment=env, app=env.app, service_token=Mock(app=env.app)
+    )
+
+
+def service_token_bootstrap_auth(org):
+    app = Mock(organisation=org)
+    return _base_auth(
+        auth_type="Service", app=app, organisation=org, service_token=Mock(app=app)
+    )
+
+
+def service_account_org_auth(org):
+    return _base_auth(
+        auth_type="ServiceAccount",
+        org_only=True,
+        organisation=org,
+        service_account=Mock(organisation=org),
+    )
+
+
+AUTH_SHAPES = [
+    user_env_auth,
+    user_app_auth,
+    user_org_auth,
+    service_token_env_auth,
+    service_token_bootstrap_auth,
+    service_account_org_auth,
+]
 
 
 class TestPlanBasedRateThrottle:
@@ -39,41 +109,58 @@ class TestPlanBasedRateThrottle:
         self.factory = APIRequestFactory()
         self.throttle = PlanBasedRateThrottle()
 
+        # Pin the clock so fixed-window tests can never straddle a boundary
+        self.throttle.timer = lambda: 1_000_000.0
+
         # 4. Assign the fresh LocMemCache to the throttle and clear it
         from django.core.cache import cache
 
         self.throttle.cache = cache
         cache.clear()
 
-    def test_get_cache_key_authenticated_user(self):
-        """Test cache key generation for standard authenticated user"""
+    def build_request(self, auth=None, authenticated=True):
         request = self.factory.get("/")
-        request.user = Mock(is_authenticated=True)
-        request.auth = {"org_member": Mock(id=123)}
+        request.user = Mock(is_authenticated=authenticated)
+        request.auth = auth
+        return request
+
+    @pytest.mark.parametrize("build_auth", AUTH_SHAPES, ids=lambda f: f.__name__)
+    def test_cache_key_is_org_scoped_for_all_auth_shapes(self, build_auth):
+        """Every auth shape authenticate() emits keys the org bucket exactly"""
+        request = self.build_request(build_auth(make_org(org_id="org-123")))
 
         key = self.throttle.get_cache_key(request, None)
-        assert "plan_based" in key
-        assert "user_123" in key
+        assert key == "throttle_plan_based_org_org-123"
 
-    def test_get_cache_key_service_account(self):
-        """Test cache key generation for service account"""
-        request = self.factory.get("/")
-        request.user = Mock(is_authenticated=True)
-        request.auth = {"service_account": Mock(id=456)}
+    def test_cache_key_shared_across_org_principals(self):
+        """All principals of one org draw from a single shared bucket"""
+        org = make_org(org_id="abc-123")
 
-        key = self.throttle.get_cache_key(request, None)
-        assert "plan_based" in key
-        assert "sa_456" in key
+        keys = {
+            self.throttle.get_cache_key(self.build_request(build_auth(org)), None)
+            for build_auth in AUTH_SHAPES
+        }
+        assert keys == {"throttle_plan_based_org_abc-123"}
 
     def test_get_cache_key_anonymous(self):
         """Test cache key generation for anonymous user"""
-        request = self.factory.get("/")
-        request.user = Mock(is_authenticated=False)
-        request.auth = None
+        request = self.build_request(auth=None, authenticated=False)
 
         key = self.throttle.get_cache_key(request, None)
-        assert "plan_based" in key
-        assert "anon" in key
+        assert key.startswith("throttle_plan_based_anon_")
+
+    def test_get_organisation_falls_back_to_principals(self):
+        """Defensive fallbacks for auth shapes authenticate() does not currently emit"""
+        org = make_org()
+        for auth in (
+            _base_auth(org_member=Mock(organisation=org)),
+            _base_auth(service_account=Mock(organisation=org)),
+            _base_auth(
+                auth_type="Service", service_token=Mock(app=Mock(organisation=org))
+            ),
+        ):
+            request = self.build_request(auth)
+            assert PlanBasedRateThrottle.get_organisation(request) is org
 
     @patch("api.throttling.CLOUD_HOSTED", True)
     def test_rate_selection_cloud_hosted_free_plan(self, settings):
@@ -84,15 +171,8 @@ class TestPlanBasedRateThrottle:
             "DEFAULT": "5/min",
         }
 
-        request = self.factory.get("/")
-        request.user = Mock(is_authenticated=True)
+        request = self.build_request(user_env_auth(make_org(plan="FR")))
 
-        # Mock environment structure
-        mock_env = Mock()
-        mock_env.app.organisation.plan = "FR"
-        request.auth = {"environment": mock_env}
-
-        # Mock get_rate to return default (simulating DRF settings)
         with patch.object(PlanBasedRateThrottle, "get_rate", return_value="5/min"):
             self.throttle.allow_request(request, None)
 
@@ -109,29 +189,35 @@ class TestPlanBasedRateThrottle:
             "DEFAULT": "5/min",
         }
 
-        request = self.factory.get("/")
-        request.user = Mock(is_authenticated=True)
-
-        mock_env = Mock()
-        mock_env.app.organisation.plan = "PR"
-        request.auth = {"environment": mock_env}
+        request = self.build_request(user_org_auth(make_org(plan="PR")))
 
         with patch.object(PlanBasedRateThrottle, "get_rate", return_value="5/min"):
             self.throttle.allow_request(request, None)
 
         assert self.throttle.rate == "100/min"
 
+    @patch("api.throttling.CLOUD_HOSTED", True)
+    def test_missing_plan_rate_falls_back_to_default(self, settings):
+        """An unset per-plan rate falls back to DEFAULT instead of disabling throttling"""
+        settings.PLAN_RATE_LIMITS = {
+            "FR": None,
+            "PR": "100/min",
+            "DEFAULT": "7/min",
+        }
+
+        request = self.build_request(user_env_auth(make_org(plan="FR")))
+
+        with patch.object(PlanBasedRateThrottle, "get_rate", return_value="5/min"):
+            self.throttle.allow_request(request, None)
+
+        assert self.throttle.rate == "7/min"
+
     @patch("api.throttling.CLOUD_HOSTED", False)
     def test_rate_selection_self_hosted_uses_default(self, settings):
         """Test that self-hosted mode ignores plan and uses default"""
         settings.PLAN_RATE_LIMITS = {"FR": "10/min", "DEFAULT": "5/min"}
 
-        request = self.factory.get("/")
-        request.user = Mock(is_authenticated=True)
-
-        mock_env = Mock()
-        mock_env.app.organisation.plan = "FR"  # Should be ignored
-        request.auth = {"environment": mock_env}
+        request = self.build_request(user_env_auth(make_org(plan="FR")))
 
         with patch.object(PlanBasedRateThrottle, "get_rate", return_value="5/min"):
             self.throttle.allow_request(request, None)
@@ -143,30 +229,81 @@ class TestPlanBasedRateThrottle:
         """Test that anonymous requests use the default rate"""
         settings.PLAN_RATE_LIMITS = {"DEFAULT": "5/min"}
 
-        request = self.factory.get("/")
-        request.user = Mock(is_authenticated=False)
-        request.auth = None
+        request = self.build_request(auth=None, authenticated=False)
 
         with patch.object(PlanBasedRateThrottle, "get_rate", return_value="5/min"):
             self.throttle.allow_request(request, None)
 
         assert self.throttle.rate == "5/min"
 
-    @patch("api.throttling.CLOUD_HOSTED", False)
-    def test_self_hosted_no_default_disables_throttling(self, settings):
-        """Test that self-hosted mode with no default set disables throttling"""
-        settings.PLAN_RATE_LIMITS = {"DEFAULT": None}
+    @patch("api.throttling.CLOUD_HOSTED", True)
+    def test_unresolvable_auth_falls_back_to_ip_bucket_with_warning(
+        self, settings, caplog
+    ):
+        """Authenticated requests with no resolvable org log a warning and use the IP bucket"""
+        settings.PLAN_RATE_LIMITS = {"DEFAULT": "5/min"}
 
-        request = self.factory.get("/")
-        request.user = Mock(is_authenticated=True)
-        request.auth = {}
+        request = self.build_request(_base_auth())
 
-        # Reset rate to None to force allow_request to call get_rate() again
-        # This ensures we test the logic inside get_rate with the new settings
-        self.throttle.rate = None
-
-        # We do NOT mock get_rate here. We want to verify that the REAL get_rate
-        # returns None when CLOUD_HOSTED is False and DEFAULT is None.
-        allowed = self.throttle.allow_request(request, None)
+        with patch.object(PlanBasedRateThrottle, "get_rate", return_value="5/min"):
+            with caplog.at_level(logging.WARNING, logger="api.throttling"):
+                allowed = self.throttle.allow_request(request, None)
 
         assert allowed is True
+        assert "Could not resolve an organisation" in caplog.text
+        assert "anon_" in self.throttle.key
+
+    @patch("api.throttling.CLOUD_HOSTED", True)
+    def test_org_bucket_shared_enforcement(self, settings):
+        """Different principals in one org consume the same rate limit"""
+        settings.PLAN_RATE_LIMITS = {"FR": "2/min", "DEFAULT": "5/min"}
+
+        org = make_org(org_id="org-1", plan="FR")
+
+        def allow(auth):
+            return self.throttle.allow_request(self.build_request(auth), None)
+
+        assert allow(user_env_auth(org)) is True
+        assert allow(service_token_env_auth(org)) is True
+        # Org bucket exhausted — a third principal is throttled
+        assert allow(user_org_auth(org)) is False
+        # A different org is unaffected
+        assert allow(user_env_auth(make_org(org_id="org-2", plan="FR"))) is True
+
+    @patch("api.throttling.CLOUD_HOSTED", True)
+    def test_throttled_wait_returns_window_remainder(self, settings):
+        """wait() reports the seconds until the fixed window resets"""
+        settings.PLAN_RATE_LIMITS = {"FR": "1/min", "DEFAULT": "5/min"}
+
+        org = make_org(plan="FR")
+
+        assert self.throttle.allow_request(self.build_request(user_env_auth(org)), None) is True
+        assert self.throttle.allow_request(self.build_request(user_env_auth(org)), None) is False
+        # Clock is pinned at 1,000,000s; the current 60s window resets at 1,000,020s
+        assert self.throttle.wait() == 20.0
+
+    @patch("api.throttling.CLOUD_HOSTED", True)
+    def test_window_reset_allows_requests_again(self, settings):
+        """A new fixed window starts a fresh count"""
+        settings.PLAN_RATE_LIMITS = {"FR": "1/min", "DEFAULT": "5/min"}
+
+        org = make_org(plan="FR")
+
+        def allow():
+            return self.throttle.allow_request(self.build_request(user_env_auth(org)), None)
+
+        assert allow() is True
+        assert allow() is False
+
+        self.throttle.timer = lambda: 1_000_020.0
+        assert allow() is True
+
+    def test_no_rate_disables_throttling(self):
+        """A None rate (e.g. self-hosted with RATE_LIMIT_DEFAULT unset) disables throttling"""
+        request = self.build_request(auth={})
+
+        with patch.object(PlanBasedRateThrottle, "get_rate", return_value=None):
+            allowed = self.throttle.allow_request(request, None)
+
+        assert allowed is True
+        assert self.throttle.rate is None


### PR DESCRIPTION
## :mag: Overview

API rate limits are currently enforced per principal: each User (PAT), Service Account, and Service Token gets its own throttle bucket (`user_<id>` / `sa_<id>` / `st_<id>`). Since plan rate limits are conceptually org-scoped, this means an organisation's effective API capacity multiplies with every principal it creates, and the plan-based limit doesn't actually bound what an org can send.

This PR unifies rate limiting to a single shared bucket per organisation: all members, service accounts, and service tokens of an org draw from one limit, resolved from the org's plan.

## :bulb: Proposed Changes

- **Org-wide throttle bucket.** `PlanBasedRateThrottle` now keys the cache on `org_<id>`. A new `get_organisation()` resolves the org from `request.auth` (`organisation` → `environment` → `app` → principal fallbacks), covering every auth shape `PhaseTokenAuthentication` emits. Unauthenticated requests keep the per-IP `anon_` bucket.
- **Atomic fixed-window counter.** Enforcement replaces DRF `SimpleRateThrottle`'s cached timestamp list (a non-atomic read-modify-write that loses updates under concurrency) with `cache.add` + `cache.incr` on a window-suffixed key — atomic `SET NX` / `INCRBY` on Redis. This matters now that one hot key is shared by all of an org's workers. It also drops the per-request cost from shipping an O(limit) pickled list to O(1) integer ops.
- **`wait()` / `retry-after`** now reports the seconds until the current window resets.
- **Rate config hardening.** An unset per-plan env var (e.g. `RATE_LIMIT_PRO`) now falls back to `RATE_LIMIT_DEFAULT` instead of silently disabling throttling for that plan tier.
- **Observability.** An authenticated request whose org cannot be resolved logs a warning before falling back to the per-IP bucket.

## :framed_picture: Screenshots or Demo

N/A — backend-only change. Throttled responses are unchanged in shape:

```
HTTP/2 429
retry-after: 52
```

## :memo: Release Notes

- Phase Cloud API rate limits are now shared across your entire organisation: all Users, Service Accounts, and Service Tokens draw from one plan-based limit (previously enforced per account). If you run many parallel integrations, review your request volume against your plan's limit.
- `429` responses continue to include a `retry-after` header.
- Self-hosted: behavior is unchanged — `RATE_LIMIT_DEFAULT` sets the (now org-wide) limit; if unset, no rate limits are applied.
- Companion docs update: `phasehq/docs` branch `unified-rate-limits`.


### :test_tube: Testing

- `tests/api/test_throttling.py` rewritten: 19 tests, all passing in the dev container.
- Auth fixtures now mirror the exact `request.auth` shapes `PhaseTokenAuthentication.authenticate()` emits (env / app-only / org-only modes × User / Service Token / Service Account), instead of synthetic dicts.
- New coverage: exact org cache-key assertions for all six auth shapes, shared-bucket enforcement across principals, cross-org isolation, DEFAULT fallback for unset plan rates, window reset, `wait()` remainder, fallback warning log, and rate-`None` disabling throttling.
- The throttle clock is pinned in the fixture so fixed-window tests cannot straddle a real minute boundary.
- Known unrelated flake: `tests/api/views/identities/**` can 429 when run back-to-back in a dev container with `RATE_LIMIT_DEFAULT=5/min` (they hit real throttled views against live Redis). Pre-existing on `main`, not introduced here.

### :dart: Reviewer Focus

- `backend/api/throttling.py` — `allow_request()`: the add/incr atomicity, window keying, and the plan-rate resolution path.
- `get_organisation()` — confirm the resolution order against the auth dict shapes built in `backend/api/auth.py` (`authenticate()`), which always sets one of `organisation` / `environment` / `app`; the principal fallbacks are defensive only.

### :heavy_plus_sign: Additional Context

- `auth.py` already resolves the caller org (`_resolve_caller_org`) but only attaches it to `request.auth` in org-only/bootstrap modes. A follow-up could attach it on every request and collapse `get_organisation()` to a single dict read.
- Docs changes (org-wide wording on the public API page, `RATE_LIMIT_DEFAULT` semantics on the self-hosting env vars page) ship separately via `phasehq/docs#unified-rate-limits`.

## :sparkles: How to Test the Changes Locally

1. `docker compose -f dev-docker-compose.yml up -d` (set `RATE_LIMIT_DEFAULT=5/min`).
2. In one organisation, create a PAT and a Service Token.
3. Send 6 requests within a minute to `https://localhost/service/public/v1/secrets/?app_id=<id>&env=development`, alternating between the two tokens.
4. The 6th request returns `429` with a `retry-after` header, regardless of which token sent it — both principals share the org bucket.
5. Repeat with a token from a second organisation: it is unaffected.
6. Run the suite: `docker compose -f dev-docker-compose.yml exec backend pytest tests/api/test_throttling.py -v`

### :green_heart: Did You...

- [x] Ensure linting passes (code style checks)? *(no backend linter configured in CI; style matches surrounding code)*
- [x] Update dependencies and lockfiles (if required) *(not required)*
- [x] Update migrations (if required) *(not required)*
- [x] Regenerate graphql schema and types (if required) *(not required)*
- [x] Verify the app builds locally?
- [ ] Manually test the changes on different browsers/devices? *(N/A — backend-only)*
